### PR TITLE
New field Spatie\MediaLibrary

### DIFF
--- a/resources/views/fields/shared/thumbnail.blade.php
+++ b/resources/views/fields/shared/thumbnail.blade.php
@@ -1,1 +1,1 @@
-<img class="h-10 w-10 rounded-full" src="{{ Storage::url($value) }}" />
+<div class="h-10 w-10"><img class="h-10 w-10 rounded-full" src="{{ Storage::url($value) }}" /></div>

--- a/resources/views/fields/shared/thumbnail.blade.php
+++ b/resources/views/fields/shared/thumbnail.blade.php
@@ -1,1 +1,1 @@
-<div class="h-10 w-10"><img class="h-10 w-10 rounded-full" src="{{ Storage::url($value) }}" /></div>
+<div class="h-10 w-10"><img class="h-10 w-10 rounded-full" src="{{ $value }}" /></div>

--- a/resources/views/fields/spatie/media-library-thumbnail.blade.php
+++ b/resources/views/fields/spatie/media-library-thumbnail.blade.php
@@ -1,0 +1,3 @@
+<div  class="h-10 w-10">
+    <img class="h-10 w-10 rounded-full" src="{{ $value }}" alt=""/>
+</div>

--- a/resources/views/fields/spatie/media-library.blade.php
+++ b/resources/views/fields/spatie/media-library.blade.php
@@ -1,0 +1,42 @@
+<div>
+    @if($field->formViewValue($item))
+        @if($field->isMultiple())
+            <div>
+                <div  class="grid md:grid-cols-2 sm:grid-cols-1 lg:grid-cols-3 m-5 mb-10">
+                    @foreach($field->formViewValue($item) as $index => $file)
+                        <div x-data="{}" x-ref="hidden_parent_{{ $field->id() }}"  class="relative bg-white p-3 m-2 border-1 border-dashed border-gray-100 shadow-md rounded-lg overflow-hidden">
+                            <input x-ref="hidden_{{ $field->id() }}" type="hidden" name="hidden_{{ $field->name() }}" value="{{ $file }}" />
+
+                            <img @click.stop="$dispatch('img-modal', {imgModalSrc: '{{ $file }}' })"
+                                 class="w-full object-cover object-center rounded"
+                                 src="{{ $file }}"
+                            />
+
+                            @if($field->isRemovable())
+                                <div class="p-4 absolute top-0 right-0">
+                                    <div class="text-center">
+                                        <a href="#" @click="$refs.hidden_parent_{{ $field->id() }}.remove();" class="px-4 py-2 bg-red-500 shadow-lg border rounded-lg text-white uppercase font-semibold tracking-wider focus:outline-none focus:shadow-outline hover:bg-red-400 active:bg-red-400">
+                                            {{ trans('moonshine::ui.delete') }}
+                                        </a>
+                                    </div>
+                                </div>
+                            @endif
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @else
+            <div x-data="{}" class="max-w-sm rounded overflow-hidden shadow-lg my-2">
+                <img @click.stop="$dispatch('img-modal', {imgModal: true, imgModalSrc: '{{ $field->formViewValue($item) }}' })"
+                     class="w-full"
+                     src="{{ $field->formViewValue($item) }}"
+                />
+            </div>
+        @endif
+    @endif
+
+    @include("moonshine::fields.input", [
+        "field" => $field,
+        "item" => $item
+    ])
+</div>

--- a/src/Fields/Image.php
+++ b/src/Fields/Image.php
@@ -35,7 +35,7 @@ class Image extends Field implements Fileable
         }
 
         return view('moonshine::fields.shared.thumbnail', [
-            'value' => $item->{$this->field()},
+            'value' => $item->{$this->field()} ? Storage::url($item->{$this->field()}) : '' ,
         ]);
     }
 }

--- a/src/Fields/Image.php
+++ b/src/Fields/Image.php
@@ -35,7 +35,7 @@ class Image extends Field implements Fileable
         }
 
         return view('moonshine::fields.shared.thumbnail', [
-            'value' => $item->{$this->field()} ? Storage::url($item->{$this->field()}) : '' ,
+            'value' => Storage::url($item->{$this->field()}) ,
         ]);
     }
 }

--- a/src/Fields/Spatie/MediaLibrary.php
+++ b/src/Fields/Spatie/MediaLibrary.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Leeto\MoonShine\Fields\Spatie;
+
+use Illuminate\Database\Eloquent\Model;
+use Leeto\MoonShine\Fields\Field;
+use Leeto\MoonShine\Traits\Fields\CanBeMultiple;
+
+class MediaLibrary extends Field
+{
+    use CanBeMultiple;
+
+    public static string $view = 'moonshine::fields.spatie.media-library';
+
+    public static string $type = 'file';
+
+    public function save(Model $item): Model
+    {
+        return $item;
+    }
+
+    public function afterSave(Model $item): void
+    {
+        if ($this->requestValue()) {
+            if ($this->isMultiple()) {
+                $item->clearMediaCollection($this->field());
+                foreach ($this->requestValue() as $file) {
+                    $item->addMedia($file)
+                        ->preservingOriginal()
+                        ->toMediaCollection($this->field());
+                }
+
+            } else {
+                if ($media = $item->getFirstMedia($this->field())) {
+                    $media->delete();
+                }
+                $item->addMedia($this->requestValue())
+                    ->preservingOriginal()
+                    ->toMediaCollection($this->field());
+            }
+        }
+    }
+
+    public function indexViewValue(Model $item, bool $container = true): mixed
+    {
+
+        if ($this->isMultiple()) {
+            $values = $item->getMedia($this->field())
+                ->map(fn($value) => "'" . $value->getUrl() . "'")->implode(',');
+
+            return view('moonshine::shared.carousel', [
+                'values' => $values,
+            ]);
+        }
+
+        return view('moonshine::fields.spatie.media-library-thumbnail', [
+            'value' => $item->getFirstMediaUrl($this->field()),
+        ]);
+    }
+
+    public function formViewValue(Model $item): mixed
+    {
+        if ($this->isMultiple()) {
+            return $item->getMedia($this->field())
+                ->map(fn($value) => $value->getUrl())->toArray();
+        }
+        return $item->getFirstMediaUrl($this->field());
+    }
+}


### PR DESCRIPTION
Новое поле Spatie\MediaLibrary

Для работы с https://github.com/spatie/laravel-medialibrary

Поле почти клон поля Image, только изображения сохраняются не в ту же модель, а в подключенную MediaCollection (https://spatie.be/docs/laravel-medialibrary/v10/working-with-media-collections/defining-media-collections)

Синтаксис: 
MediaLibrary::make('Логотип', 'my-collection') - где 'my-collection' это название зарегистрированной коллекции: 

public function registerMediaCollections(): void
{
    $this->addMediaCollection('my-collection')
     ...
}

По умолчанию, используется коллекция из одного файла, но можно использовать ->multiple() для добавления нескольких файлов в коллекцию (в данном случае, все старые файлы будут удалены и добавлены все новые)
