### PR TITLE
Fix trix dark buttons

### DIFF
--- a/public/css/trix/trix.css
+++ b/public/css/trix/trix.css
@@ -68,6 +68,10 @@ trix-toolbar .trix-button {
     background: transparent;
 }
 
+.dark trix-toolbar .trix-button {
+    background-color: rgba(255, 255, 255, 0.75);
+}
+
 trix-toolbar .trix-button:not(:first-child) {
     border-left: 1px solid #ccc;
 }


### PR DESCRIPTION
В темной теме, в панели кнопок wysiwyg оказывается темные иконки на темно-синем фоне - нечитаемо, немного пофиксил фон