### PR TITLE
Update badge.blade.php

### DIFF
--- a/resources/views/shared/badge.blade.php
+++ b/resources/views/shared/badge.blade.php
@@ -1,3 +1,3 @@
-<span class="inline-block rounded-full text-white bg-{{ $color }} px-2 py-1 text-xs font-bold mr-3">
+<span class="inline-block rounded-full text-white bg-{{ $color }} px-2 py-1 text-xs font-bold mr-3 text-center">
     {!! $value !!}
 </span>


### PR DESCRIPTION
Выровнял текст по центру

Иногда, чтобы вся таблица влезла на страницу, можно отключить `white-space: nowrap` для колонок, и тогда текст в бейджах съезжает влево, но в бейджах текст всегда должен быть по центру))) Подправил слегка стили
