### PR TITLE
Add type string for second parameter

### DIFF
--- a/src/Fields/BelongsToMany.php
+++ b/src/Fields/BelongsToMany.php
@@ -114,7 +114,7 @@ class BelongsToMany extends Field implements HasRelationship, HasPivot, HasField
         return $this->treeHtml();
     }
 
-    private function makeTree(array $performedData, int $parent_id = 0, int $offset = 0): void
+    private function makeTree(array $performedData, int|string $parent_id = 0, int $offset = 0): void
     {
         if (isset($performedData[$parent_id])) {
             foreach ($performedData[$parent_id] as $item) {


### PR DESCRIPTION
При использовании метода _tree()_ для поля BelongsToMany, возвращается ошибка: **Argument #2 ($parent_id) must be of type int, string given**, если передать $parent_id типа string.