### PR TITLE
bugfix Правка редиректа без префикса админки

### DIFF
--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -35,11 +35,13 @@ class Authenticate
      */
     protected function except(Request $request): bool
     {
+         $prefix = config('moonshine.route.prefix') ? config('moonshine.route.prefix') . '/' : '';
+
         return $request->is([
-            config('moonshine.route.prefix').'/login',
-            config('moonshine.route.prefix').'/authenticate',
-            config('moonshine.route.prefix').'/logout',
-            config('moonshine.route.prefix').'/socialite/*',
+            "{$prefix}login",
+            "{$prefix}authenticate",
+            "{$prefix}logout",
+            "{$prefix}socialite/*",
         ]);
     }
 }

--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -35,7 +35,7 @@ class Authenticate
      */
     protected function except(Request $request): bool
     {
-         $prefix = config('moonshine.route.prefix') ? config('moonshine.route.prefix') . '/' : '';
+         $prefix = config('moonshine.route.prefix') ? config('moonshine.route.prefix').'/' : '';
 
         return $request->is([
             "{$prefix}login",


### PR DESCRIPTION
Проблема в некорректном сравнении адреса запроса из request с массивом адресов без указания префикса админки в настройках системы. Если не задать в настройках moonshine префикса для админки, получаем бесконечный редирект на страницу /login из-за того, что из request получаем 'login' и сравниваем с указанным в маппинге '/login'.