### PR TITLE
Fix BelongsTo ->nullable()

### DIFF
--- a/src/Fields/BelongsTo.php
+++ b/src/Fields/BelongsTo.php
@@ -25,6 +25,12 @@ class BelongsTo extends Field implements HasRelationship, BelongsToRelation
     public function save(Model $item): Model
     {
         if ($this->requestValue() === false) {
+            
+            if ($this->nullable) {
+                return $item->{$this->relation()}()
+                    ->dissociate();
+            }
+            
             return $item;
         }
 

--- a/src/Fields/BelongsTo.php
+++ b/src/Fields/BelongsTo.php
@@ -26,7 +26,7 @@ class BelongsTo extends Field implements HasRelationship, BelongsToRelation
     {
         if ($this->requestValue() === false) {
             
-            if ($this->nullable) {
+            if ($this->isNullable()) {
                 return $item->{$this->relation()}()
                     ->dissociate();
             }


### PR DESCRIPTION
По умолчанию, select возвращает FALSE, а не NULL
Если поле установлено как ->nullable(), и в select выбрано пустое значение то никакого обновления модели не происходит - просто возвращается модель. НО, если установленно nullable(), то по идее можно же заполненное значение сбросить в null)))

Как заметил:
БелонгсТу у записи выбран, но при редактировании, если ставил что надо обнулить значение - ничего не происходило)