### PR TITLE
Feature/show Детальная страница для элемента модели

### DIFF
--- a/resources/views/base/index/shared/item_actions.blade.php
+++ b/resources/views/base/index/shared/item_actions.blade.php
@@ -9,7 +9,7 @@
     @endif
 @endforeach
 
-@if($resource->can('show', $item) && in_array('show', $resource->getActiveActions()))
+@if($resource->can('show', $item) && in_array('show', $resource->getActiveActions()) && !isset($show))
     <a href="{{ $resource->route("show", $item->getKey()) }}" class="text-purple inline-block">
         @include("moonshine::shared.icons.show", ["size" => 6, "class" => "mr-2", "color" => "purple"])
     </a>

--- a/resources/views/base/index/shared/item_actions.blade.php
+++ b/resources/views/base/index/shared/item_actions.blade.php
@@ -1,6 +1,6 @@
 @foreach($resource->itemActions() as $index => $action)
     @if($action->isSee($item))
-        <a href="{{ $resource->route("action", $item->getKey(), request()->routeIs('*.query-tag') ? ['index' => $index, 'redirect_back' => 1] : ['index' => $index]) }}"
+        <a href="{{ $resource->route("action", $item->getKey(), ['index' => $index]) }}"
            class="text-purple inline-block"
            title="{{ $action->label() }}"
         >
@@ -8,6 +8,12 @@
         </a>
     @endif
 @endforeach
+
+@if($resource->can('show', $item) && in_array('show', $resource->getActiveActions()))
+    <a href="{{ $resource->route("show", $item->getKey()) }}" class="text-purple inline-block">
+        @include("moonshine::shared.icons.show", ["size" => 6, "class" => "mr-2", "color" => "purple"])
+    </a>
+@endif
 
 @if($resource->can('update', $item) && in_array('edit', $resource->getActiveActions()))
     @if($resource->isEditInModal())
@@ -42,10 +48,6 @@
 
                     @if($resource->isRelatable())
                         <input type="hidden" name="relatable_mode" value="1">
-                    @endif
-
-                    @if(request()->routeIs('*.query-tag'))
-                        <input type="hidden" name="redirect_back" value="1">
                     @endif
 
                     @method("delete")

--- a/resources/views/base/show.blade.php
+++ b/resources/views/base/show.blade.php
@@ -1,0 +1,28 @@
+@extends("moonshine::layouts.app")
+
+@section('sidebar-inner')
+    @parent
+
+    <div class="text-center mt-8">
+        @include('moonshine::shared.btn', [
+            'title' => trans('moonshine::ui.back'),
+            'href' => $resource->route("index"),
+            'filled' => true,
+            'icon' => false,
+        ])
+    </div>
+@endsection
+
+@section('header-inner')
+    @parent
+    @include("moonshine::shared.title", ["title" => $resource->title()])
+    @include("moonshine::shared.sub-title", ["subTitle" => $resource->subTitle()])
+@endsection
+
+@section('content')
+    <div class="mt-8"></div>
+
+    <div class="flex flex-col mt-8">
+        @include("moonshine::base.show.show", ["item" => $item])
+    </div>
+@endsection

--- a/resources/views/base/show/show.blade.php
+++ b/resources/views/base/show/show.blade.php
@@ -1,10 +1,11 @@
-<div class="w-full">
+<div>
     {!! $resource->extensions('tabs', $item) !!}
 
     @if($item->exists)
         @foreach($resource->showFields() as $index => $field)
-            <div class="px-6 py-4 whitespace-nowrap">
-                <div class="text-sm leading-5">{!! $field->indexViewValue($item) !!}</div>
+            <div class="flex items-center space-x-2 px-3 py-3 whitespace-nowrap">
+                <span class="text-sm">{{ $field->label() }}</span>:
+                <div class="leading-5">{!! $field->indexViewValue($item) !!}</div>
             </div>
         @endforeach
 

--- a/resources/views/base/show/show.blade.php
+++ b/resources/views/base/show/show.blade.php
@@ -1,0 +1,17 @@
+<div class="w-full">
+    {!! $resource->extensions('tabs', $item) !!}
+
+    @if($item->exists)
+        @foreach($resource->showFields() as $index => $field)
+            <div class="px-6 py-4 whitespace-nowrap">
+                <div class="text-sm leading-5">{!! $field->indexViewValue($item) !!}</div>
+            </div>
+        @endforeach
+
+        @if(!$resource->isPreviewMode())
+            <td class="px-6 py-4 whitespace-nowrap text-right text-sm leading-5 font-medium">
+                @include("moonshine::base.index.shared.item_actions", ["item" => $item, "resource" => $resource])
+            </td>
+        @endif
+    @endif
+</div>

--- a/resources/views/shared/icons/show.blade.php
+++ b/resources/views/shared/icons/show.blade.php
@@ -1,0 +1,3 @@
+<svg class="fill-current w-{{ $size ?? 5 }} h-{{ $size ?? 5 }} {{ $class ?? '' }} {{ isset($color) ? "text-$color" : '' }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+	<path fill-rule="evenodd" d="M2 6a2 2 0 012-2h4a1 1 0 010 2H4v10h10v-4a1 1 0 112 0v4a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" clip-rule="evenodd" />
+</svg>

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -48,6 +48,8 @@ abstract class Field implements HtmlViewable, HasAssets, HasExportViewValue, Has
 
     public bool $showOnUpdateForm = true;
 
+    public bool $showOnDetail = true;
+
     protected Field|null $parent = null;
 
     protected string $hint = '';
@@ -115,6 +117,28 @@ abstract class Field implements HtmlViewable, HasAssets, HasExportViewValue, Has
     public function hideOnForm(mixed $condition = null): static
     {
         $this->showOnForm = Condition::boolean($condition, false);
+
+        return $this;
+    }
+
+    /**
+     * @param mixed|null $conditon
+     * @return $this
+     */
+    public function showOnDetail(mixed $conditon = null): static
+    {
+        $this->showOnDetail = Condition::boolean($conditon, true);
+
+        return $this;
+    }
+
+    /**
+     * @param mixed|null $condition
+     * @return $this
+     */
+    public function hideOnDetail(mixed $condition = null): static
+    {
+        $this->showOnDetail = Condition::boolean($condition, false);
 
         return $this;
     }

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -122,6 +122,7 @@ abstract class Field implements HtmlViewable, HasAssets, HasExportViewValue, Has
     }
 
     /**
+     * Показать поле на детальной странице.
      * @param mixed|null $conditon
      * @return $this
      */
@@ -133,6 +134,7 @@ abstract class Field implements HtmlViewable, HasAssets, HasExportViewValue, Has
     }
 
     /**
+     * Скрыть поле на детальной странице.
      * @param mixed|null $condition
      * @return $this
      */

--- a/src/Fields/ID.php
+++ b/src/Fields/ID.php
@@ -16,7 +16,6 @@ class ID extends Field
 
     protected static string $type = 'hidden';
 
-
     public function indexViewValue(Model $item, bool $container = true): mixed
     {
         return view('moonshine::shared.badge', [

--- a/src/Http/Controllers/MoonShineController.php
+++ b/src/Http/Controllers/MoonShineController.php
@@ -156,6 +156,32 @@ class MoonShineController extends BaseController
     }
 
     /**
+     * todo: detailRender
+     * @return string|View
+     * @throws AuthorizationException
+     */
+    public function detail(): string|View
+    {
+        if ($this->resource->isWithPolicy()) {
+            $this->authorizeForUser(
+                auth(config('moonshine.auth.guard'))->user(),
+                'viewAny',
+                $this->resource->getModel()
+            );
+        }
+
+        $view = view($this->resource->baseDetailView(), [
+            'resource' => $this->resource,
+            'filters' => $this->resource->filters(),
+            'actions' => $this->resource->getActions(),
+            'metrics' => $this->resource->metrics(),
+            'items' => $this->resource->paginate(),
+        ]);
+
+        return $view;
+    }
+
+    /**
      * @throws AuthorizationException|Throwable
      */
     public function index(): string|View
@@ -244,10 +270,17 @@ class MoonShineController extends BaseController
     }
 
     /**
+     * @param $id
+     * @return Application|Factory|View|RedirectResponse|Redirector|mixed|string
      * @throws AuthorizationException
+     * @throws Throwable
      */
-    public function show($id): Redirector|Application|RedirectResponse
+    public function show($id): mixed
     {
+        if (! in_array('show', $this->resource->getActiveActions())) {
+            return redirect($this->resource->route('index'));
+        }
+
         $item = $this->resource->getModel()
             ->newModelQuery()
             ->findOrFail($id);
@@ -260,7 +293,25 @@ class MoonShineController extends BaseController
             );
         }
 
-        return redirect($this->resource->route('index'));
+        $this->resource->setItem($item);
+
+        return $this->showView($item);
+    }
+
+    /**
+     * @todo: Описать
+     * @param Model|null $item
+     * @return Application|Factory|View|mixed|string
+     * @throws Throwable
+     */
+    public function showView(Model $item = null)
+    {
+        $view = view($this->resource->baseShowView(), [
+            'resource' => $this->resource,
+            'item' => $item ?? $this->resource->getModel(),
+        ]);
+
+        return $view;
     }
 
     /**

--- a/src/Http/Controllers/MoonShineController.php
+++ b/src/Http/Controllers/MoonShineController.php
@@ -156,32 +156,6 @@ class MoonShineController extends BaseController
     }
 
     /**
-     * todo: detailRender
-     * @return string|View
-     * @throws AuthorizationException
-     */
-    public function detail(): string|View
-    {
-        if ($this->resource->isWithPolicy()) {
-            $this->authorizeForUser(
-                auth(config('moonshine.auth.guard'))->user(),
-                'viewAny',
-                $this->resource->getModel()
-            );
-        }
-
-        $view = view($this->resource->baseDetailView(), [
-            'resource' => $this->resource,
-            'filters' => $this->resource->filters(),
-            'actions' => $this->resource->getActions(),
-            'metrics' => $this->resource->metrics(),
-            'items' => $this->resource->paginate(),
-        ]);
-
-        return $view;
-    }
-
-    /**
      * @throws AuthorizationException|Throwable
      */
     public function index(): string|View
@@ -270,6 +244,7 @@ class MoonShineController extends BaseController
     }
 
     /**
+     * Метод обработки для детальной страницы элемента.
      * @param $id
      * @return Application|Factory|View|RedirectResponse|Redirector|mixed|string
      * @throws AuthorizationException
@@ -299,12 +274,12 @@ class MoonShineController extends BaseController
     }
 
     /**
-     * @todo: Описать
+     * Метод сборки данных для вызова и передачи их в шаблон детальной страницы.
      * @param Model|null $item
      * @return Application|Factory|View|mixed|string
      * @throws Throwable
      */
-    public function showView(Model $item = null)
+    public function showView(Model $item = null): mixed
     {
         $view = view($this->resource->baseShowView(), [
             'resource' => $this->resource,

--- a/src/Http/Controllers/MoonShineController.php
+++ b/src/Http/Controllers/MoonShineController.php
@@ -265,6 +265,7 @@ class MoonShineController extends BaseController
         $view = view($this->resource->baseShowView(), [
             'resource' => $this->resource,
             'item' => $item ?? $this->resource->getModel(),
+            'show' => true
         ]);
 
         return $view;

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -59,6 +59,7 @@ abstract class Resource implements ResourceContract
 
     public static string $baseEditView = 'moonshine::base.form';
 
+    /** @var string Переменная для хранения шаблона детайльной страницы. */
     public static string $baseShowView = 'moonshine::base.show';
 
     public string $titleField = '';
@@ -195,7 +196,7 @@ abstract class Resource implements ResourceContract
     }
 
     /**
-     * todo: detailRender
+     * Получить название шаблона для детальной страницы.
      * @return string
      */
     public function baseShowView(): string
@@ -295,6 +296,13 @@ abstract class Resource implements ResourceContract
             ->when($action, fn ($str) => $str->append('.')->append($action));
     }
 
+    /**
+     * Метод генерации адреса для страницы ресурса из переданных параметров запроса.
+     * @param string|null $action
+     * @param int|string|null $id
+     * @param array $query
+     * @return string
+     */
     public function route(string $action = null, int|string $id = null, array $query = []): string
     {
         $cacheKey = "moonshine_query_{$this->routeAlias()}".($id ? "_{$id}" : '');
@@ -444,6 +452,11 @@ abstract class Resource implements ResourceContract
             ->filter(fn (Field $field) => $field->showOnIndex);
     }
 
+    /**
+     * Получить коллекцию полей настроенных для детальной страницы.
+     * @return Collection
+     * @throws Throwable
+     */
     public function showFields(): Collection
     {
         return $this->getFields()

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -59,6 +59,8 @@ abstract class Resource implements ResourceContract
 
     public static string $baseEditView = 'moonshine::base.form';
 
+    public static string $baseShowView = 'moonshine::base.show';
+
     public string $titleField = '';
 
     protected static bool $system = false;
@@ -192,6 +194,15 @@ abstract class Resource implements ResourceContract
         return '';
     }
 
+    /**
+     * todo: detailRender
+     * @return string
+     */
+    public function baseShowView(): string
+    {
+        return static::$baseShowView;
+    }
+
     public function baseIndexView(): string
     {
         return static::$baseIndexView;
@@ -286,11 +297,10 @@ abstract class Resource implements ResourceContract
 
     public function route(string $action = null, int|string $id = null, array $query = []): string
     {
-        if (empty($query) && Cache::has("moonshine_query_{$this->routeAlias()}")) {
-            parse_str(
-                Cache::get("moonshine_query_{$this->routeAlias()}", ''),
-                $query
-            );
+        $cacheKey = "moonshine_query_{$this->routeAlias()}".($id ? "_{$id}" : '');
+
+        if (empty($query) && Cache::has($cacheKey)) {
+            parse_str(Cache::get($cacheKey, ''), $query);
         }
 
         if ($this->isRelatable()) {
@@ -432,6 +442,12 @@ abstract class Resource implements ResourceContract
     {
         return $this->getFields()
             ->filter(fn (Field $field) => $field->showOnIndex);
+    }
+
+    public function showFields(): Collection
+    {
+        return $this->getFields()
+            ->filter(fn (Field $field) => $field->showOnDetail);
     }
 
     /**

--- a/tests/Resources/ResourceTest.php
+++ b/tests/Resources/ResourceTest.php
@@ -37,6 +37,5 @@ class ResourceTest extends TestCase
         $this->assertStringContainsString('/moonshine/moonShineUsers/1', $resource->route('show', 1));
         $this->assertStringContainsString('/moonshine/moonShineUsers/1/edit', $resource->route('edit', 1));
         $this->assertStringContainsString('/moonshine/moonShineUsers/1', $resource->route('destroy', 1));
-
     }
 }

--- a/tests/Resources/ResourceTest.php
+++ b/tests/Resources/ResourceTest.php
@@ -34,7 +34,9 @@ class ResourceTest extends TestCase
 
         $this->assertStringContainsString('/moonshine/moonShineUsers', $resource->route('index'));
         $this->assertStringContainsString('/moonshine/moonShineUsers/create', $resource->route('create'));
+        $this->assertStringContainsString('/moonshine/moonShineUsers/1', $resource->route('show', 1));
         $this->assertStringContainsString('/moonshine/moonShineUsers/1/edit', $resource->route('edit', 1));
         $this->assertStringContainsString('/moonshine/moonShineUsers/1', $resource->route('destroy', 1));
+
     }
 }


### PR DESCRIPTION
Добавил возможность включать в ресурсе детальную страницу элемента. Управление через $activeActions ключем show. Для того, чтобы подключить свой view шаблон для деталки нужно использовать переменную public static string $baseShowView. По умолчанию используется наспех накиданный шаблон moonshine::base.show. Для управления выводом поля на деталки можно воспользоваться методом showOnDetail()