### PR TITLE
Fix style decoration block

### DIFF
--- a/resources/views/decorations/block.blade.php
+++ b/resources/views/decorations/block.blade.php
@@ -1,4 +1,4 @@
-<div class="bg-white dark:bg-darkblue shadow-md rounded-lg mb-4 text-white">
+<div class="bg-white dark:bg-darkblue shadow-md rounded-lg mb-4">
     <x-moonshine::resource-renderable
         :components="$decoration->fields()"
         :item="$item"


### PR DESCRIPTION
Удалил класс text-white у декоративного блока, из-за этого класса в заголовках вложенных таблиц был белый цвет если использовать fieldContainer(false)

