### PR TITLE
wide

### DIFF
--- a/resources/views/components/async-modal.blade.php
+++ b/resources/views/components/async-modal.blade.php
@@ -2,7 +2,7 @@
     'id',
     'route',
 ])
-<x-moonshine::modal>
+<x-moonshine::modal :wide="true">
     <div x-data="{}" id="{{ $id }}">
         <div class="moonshine-loader" style="height: 50px; width: 50px;"></div>
     </div>

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -1,3 +1,4 @@
+@props(['wide'=>false])
 <span x-data="{isOpen: false}" x-cloak x-init="$refs.cover.classList.remove('hidden')">
     <div x-ref="cover" :class="isOpen == false ? 'hidden' : ''" class="fixed z-30 inset-0 overflow-y-auto hidden">
         <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
@@ -11,7 +12,7 @@
 
             <div class="inline-block align-bottom rounded-lg
             text-left overflow-hidden shadow-xl transform transition-all
-            sm:my-8 sm:align-middle sm:w-full sm:max-w-xl md:max-w-2xl lg:max-w-4xl lg:max-w-4xl xl:max-w-6xl 2xl:max-w-7xl"
+            sm:my-8 sm:align-middle sm:w-full sm:max-w-xl {{ $wide ? 'md:max-w-2xl lg:max-w-4xl lg:max-w-4xl xl:max-w-6xl 2xl:max-w-7xl' : '' }}"
                  role="dialog" aria-modal="true" aria-labelledby="modal-headline"
                  x-show="isOpen" @click.outside="isOpen = false" x-transition:enter="ease-out transition-slow"
                  x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"


### PR DESCRIPTION
![Screen Shot 2023-01-27 at 12 04 37](https://user-images.githubusercontent.com/12836836/215048628-13474e46-18cb-486b-9123-243e3013d5ca.png)
