### PR TITLE
Fix bug Tinymce & CKEditor in modal

### DIFF
--- a/resources/views/fields/ckeditor.blade.php
+++ b/resources/views/fields/ckeditor.blade.php
@@ -1,9 +1,9 @@
-<textarea id='ckeditor_{{ $field->id() }}' name="{{ $field->name() }}">
+<textarea id='ckeditor_{{ $item->getKey() }}_{{ $field->id() }}' name="{{ $field->name() }}">
     {!! $field->formViewValue($item) ?? '' !!}
 </textarea>
 
 <script>
-    CKEDITOR.ClassicEditor.create(document.getElementById("ckeditor_{{ $field->id() }}"), {
+    CKEDITOR.ClassicEditor.create(document.getElementById("ckeditor_{{ $item->getKey() }}_{{ $field->id() }}"), {
         // https://ckeditor.com/docs/ckeditor5/latest/features/toolbar/toolbar.html#extended-toolbar-configuration-format
         toolbar: {
             items: [

--- a/resources/views/fields/tinymce.blade.php
+++ b/resources/views/fields/tinymce.blade.php
@@ -1,11 +1,11 @@
-<textarea id='tinyeditor_{{ $field->id() }}' name="{{ $field->name() }}">
+<textarea id='tinyeditor_{{ $item->getKey() }}_{{ $field->id() }}' name="{{ $field->name() }}">
     {!! $field->formViewValue($item) ?? '' !!}
 </textarea>
 
 <script>
     var editor_config = {
         path_absolute: "/",
-        selector: 'textarea#tinyeditor_{{ $field->id() }}',
+        selector: 'textarea#tinyeditor_{{ $item->getKey() }}_{{ $field->id() }}',
         relative_urls: false,
         plugins: '{{ trim($field->plugins . ' ' . $field->addedPlugins) }}',
         toolbar: '{{ trim($field->toolbar . ' ' . $field->addedToolbar) }}',


### PR DESCRIPTION
При повторном открытии модального окна редакторы не инициализировались из-за наличия дублей id полей