### PR TITLE
Disable flex decoration in mobile

### DIFF
--- a/resources/views/decorations/flex.blade.php
+++ b/resources/views/decorations/flex.blade.php
@@ -1,5 +1,5 @@
-<div class="flex
-    @if(!$decoration->isWithoutSpace()) space-x-4 @endif
+<div class="md:flex
+    @if(!$decoration->isWithoutSpace()) gap-4 @endif
     items-{{ $decoration->getItemsAlign() }}
     justify-{{ $decoration->getJustifyAlign() }}"
 >


### PR DESCRIPTION
На мобильных устройствах flex не нужен
<img width="305" alt="Снимок экрана 2023-02-07 в 13 48 30" src="https://user-images.githubusercontent.com/12373059/217202392-d6d2fc5b-6d8c-4845-8306-96d591c1e866.png">

так думаю лучше
<img width="301" alt="Снимок экрана 2023-02-07 в 13 48 57" src="https://user-images.githubusercontent.com/12373059/217202511-ea4049ca-d0a1-46c9-8140-709730daa17b.png">