### PR TITLE
Patch checkbox mass actions

### DIFF
--- a/resources/views/base/index/foot.blade.php
+++ b/resources/views/base/index/foot.blade.php
@@ -1,4 +1,4 @@
-@if(!$resource->isPreviewMode())
+@if($resource->isMassAction())
 <tr>
     <td class="px-6 py-3 text-left text-xs leading-4 font-medium uppercase tracking-wider"
         colspan="{{ count($resource->indexFields())+2 }}"

--- a/resources/views/base/index/foot.blade.php
+++ b/resources/views/base/index/foot.blade.php
@@ -74,6 +74,12 @@
                             }
                         }
 
+                        if(document.querySelector('.actionBarCheckboxRow:not(:checked)') != null) {
+                            document.querySelector('.actionBarCheckboxMain').checked = false;
+                        } else {
+                            document.querySelector('.actionBarCheckboxMain').checked = true;
+                        }
+
                         if(document.querySelector('.actionBarCheckboxRow:checked') != null) {
                             this.actionBarOpen = true;
                         } else {

--- a/resources/views/base/index/head.blade.php
+++ b/resources/views/base/index/head.blade.php
@@ -1,5 +1,5 @@
 <tr>
-    @if(!$resource->isPreviewMode())
+    @if($resource->isMassAction())
         <th class="px-6 py-3 text-left text-xs leading-4 font-medium uppercase tracking-wider">
             <input type="checkbox" @change="actionBar('main')" class="actionBarCheckboxMain" value="1" />
         </th>

--- a/resources/views/base/index/items.blade.php
+++ b/resources/views/base/index/items.blade.php
@@ -1,6 +1,6 @@
 @foreach($items as $item)
     <tr style="{{ $resource->trStyles($item, $loop->index) }}">
-        @if(!$resource->isPreviewMode())
+        @if($resource->isMassAction())
             <td class="px-6 py-4 whitespace-nowrap" style="{{ $resource->tdStyles($item, $loop->index, 0) }}">
                 <input class="actionBarCheckboxRow" @change='actionBar("item")' name="items[{{ $item->getKey() }}]"
                        type="checkbox" value="{{ $item->getKey() }}"/>

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -900,7 +900,7 @@ abstract class Resource implements ResourceContract
 
     public function isMassAction(): bool
     {
-        return !$this->isPreviewMode() && (
+        return ! $this->isPreviewMode() && (
             count($this->bulkActions()) || (
                 $this->can('massDelete') && in_array('delete', $this->getActiveActions())
             )

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -898,6 +898,15 @@ abstract class Resource implements ResourceContract
         ]);
     }
 
+    public function isMassAction(): bool
+    {
+        return !$this->isPreviewMode() && (
+            count($this->bulkActions()) || (
+                $this->can('massDelete') && in_array('delete', $this->getActiveActions())
+            )
+        );
+    }
+
     protected function _render(HtmlViewable $field, Model $item, int $level = 0): Factory|View|Application
     {
         if ($field->hasRelationship() && ($field->belongToOne() || $field->manyToMany())) {


### PR DESCRIPTION
Отображаются чекбоксы массовых действий даже если их нет
<img width="768" alt="1" src="https://user-images.githubusercontent.com/12373059/218299382-b60fcf6c-5f0f-45ff-a22e-58bc8cda3a4b.png">
<img width="768" alt="2" src="https://user-images.githubusercontent.com/12373059/218299393-666cf38b-3ff5-49c7-a7db-fdd7d00c5588.png">

профиксил главный чекбокс, он оставался активным, если снять выделение хоть с одного элемента, а так же не становился активным если поставить вручную все чекбоксы
<img width="768" alt="3" src="https://user-images.githubusercontent.com/12373059/218299457-3aa4095f-0e21-4850-a6b7-3c6cfd895fe6.png">
