### PR TITLE
skip empty collection per filter, filling in timestamp fields

### DIFF
--- a/database/migrations/2020_10_04_115514_create_moonshine_roles_table.php
+++ b/database/migrations/2020_10_04_115514_create_moonshine_roles_table.php
@@ -24,6 +24,8 @@ return new class extends Migration
         DB::table('moonshine_user_roles')->insert([
             'id' => MoonshineUserRole::DEFAULT_ROLE_ID,
             'name' => 'Admin',
+            'created_at' => now(),
+            'updated_at' => now(),
         ]);
     }
 

--- a/src/Menu/Menu.php
+++ b/src/Menu/Menu.php
@@ -17,7 +17,7 @@ class Menu
 
     public function all(): Collection|null
     {
-        return $this->menu->filter(function ($item) {
+        return $this->menu?->filter(function ($item) {
             if ($item->isGroup()) {
                 $item->setItems(
                     $item->items()->filter(fn ($subItem) => $subItem->isSee(request()))


### PR DESCRIPTION
Если пуская коллекция с меню, то выдается ошибка, что нет метода filter у null. А так как меню может быть пустым по аннатациям, то нужна проверка или просто пропуск.

Записывалась роль админа с пустыми timestamps.