### PR TITLE
small fix trix & quill editors

### DIFF
--- a/resources/views/fields/quill.blade.php
+++ b/resources/views/fields/quill.blade.php
@@ -1,5 +1,7 @@
-<div id="quill_{{ $element->id() }}" style="height: auto;">
-    {!! $element->formViewValue($item) ?? '' !!}
+<div>
+    <div id="quill_{{ $element->id() }}" style="height: auto;">
+        {!! $element->formViewValue($item) ?? '' !!}
+    </div>
 </div>
 
 <script>

--- a/resources/views/fields/wysiwyg.blade.php
+++ b/resources/views/fields/wysiwyg.blade.php
@@ -6,7 +6,9 @@
     ])
 </div>
 
-<trix-editor class="trix-editor" input="{{ $element->id() }}"></trix-editor>
+<div>
+    <trix-editor class="trix-editor" input="{{ $element->id() }}"></trix-editor>
+</div>
 
 <script>
     (function () {


### PR DESCRIPTION
gap от родительского div добавлял отступы в редакторы

Было
![image](https://user-images.githubusercontent.com/12373059/229270761-2f14b4d6-c792-4f12-931d-7b6dd12ae850.png)

Стало
![image](https://user-images.githubusercontent.com/12373059/229270785-1f7b5e6a-9697-43c5-b734-e83a92e0ced3.png)
