### PR TITLE
Fix MoonShineRequest softDeletes() and eager loading

### DIFF
--- a/src/MoonShineRequest.php
+++ b/src/MoonShineRequest.php
@@ -94,7 +94,7 @@ class MoonShineRequest extends FormRequest
 
         $this->item = $model->find($this->getId());
 
-        if ($eager && $this->getResource()->hasWith()) {
+        if ($this->item && $eager && $this->getResource()->hasWith()) {
             $this->item->load($this->getResource()->getWith());
         }
 

--- a/src/MoonShineRequest.php
+++ b/src/MoonShineRequest.php
@@ -88,15 +88,15 @@ class MoonShineRequest extends FormRequest
 
         $model = $this->getResource()->getModel();
 
-        if ($eager && $this->getResource()->hasWith()) {
-            $model->load($this->getResource()->getWith());
-        }
-
         if ($this->getResource()->softDeletes()) {
-            $model->withTrashed();
+            $model = $model->withTrashed();
         }
 
         $this->item = $model->find($this->getId());
+
+        if ($eager && $this->getResource()->hasWith()) {
+            $this->item->load($this->getResource()->getWith());
+        }
 
         return $this->item;
     }


### PR DESCRIPTION
Ранее в запросе сначала шло получение связанных записей, а потом уже получение самой записи)
С удаленными тоже было не верно -> withTrashed не устанавливает значение а возвращает query