### PR TITLE
feat(resource): SingletonResource

### DIFF
--- a/src/Commands/ResourceCommand.php
+++ b/src/Commands/ResourceCommand.php
@@ -9,7 +9,7 @@ use MoonShine\MoonShine;
 
 class ResourceCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:resource {name?} {--m|model=} {--t|title=}';
+    protected $signature = 'moonshine:resource {name?} {--m|model=} {--t|title=} {--s|singleton} {--id=}';
 
     protected $description = 'Create resource';
 
@@ -26,10 +26,16 @@ class ResourceCommand extends MoonShineCommand
      */
     public function createResource(): void
     {
-        $name = str($this->argument('name'));
+        $name = str($this->argument('name') ?? $this->ask('Name'));
+        $id = null;
 
         if ($name->isEmpty()) {
             $name = str($this->ask('Resource name'));
+        }
+
+        if ($this->option('singleton')) {
+            $id = $this->option('id')
+                ?? $this->ask('Item id', 1);
         }
 
         $name = $name->ucfirst()
@@ -41,16 +47,20 @@ class ResourceCommand extends MoonShineCommand
 
         $resource = $this->getDirectory()."/Resources/{$name}Resource.php";
 
-        $this->copyStub('Resource', $resource, [
+        $stub = $this->option('singleton')
+            ? 'SingletonResource'
+            : 'Resource';
+
+        $this->copyStub($stub, $resource, [
             '{namespace}' => MoonShine::namespace('\Resources'),
             '{model-namespace}' => $model,
             '{model}' => class_basename($model),
+            '{id}' => $id,
             'DummyTitle' => $title,
             'Dummy' => $name,
         ]);
 
         $this->components->info("{$name}Resource file was created: ".str_replace(base_path(), '', $resource));
-
         $this->components->info('Now register resource in menu');
     }
 }

--- a/src/Resources/SingletonResource.php
+++ b/src/Resources/SingletonResource.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Resources;
+
+use Illuminate\Support\Facades\Route;
+use MoonShine\Http\Controllers\ActionController;
+use MoonShine\Http\Controllers\CrudController;
+
+abstract class SingletonResource extends Resource
+{
+    protected string $routeAfterSave = 'edit';
+
+    abstract public function getId(): int|string;
+
+    public function resolveRoutes(): void
+    {
+        Route::prefix('resource')->group(function () {
+            Route::controller(ActionController::class)
+                ->prefix($this->uriKey())
+                ->as("{$this->routeNameAlias()}.actions.")
+                ->group(function () {
+                    Route::get("form/{".$this->routeParam()."}/{index}", 'form')
+                        ->name('form');
+                });
+
+
+            Route::resource($this->uriKey(), CrudController::class)
+                ->parameters([$this->uriKey() => $this->routeParam()])
+                ->only(['show', 'update', 'edit'])
+                ->names($this->routeNameAlias());
+
+            Route::get("{$this->uriKey()}/{$this->getId()}/redirect", function () {
+                return redirect($this->route('edit', $this->getId()));
+            })->name("{$this->routeNameAlias()}.index");
+        });
+    }
+
+    public function search(): array
+    {
+        return [];
+    }
+
+    public function filters(): array
+    {
+        return [];
+    }
+
+    public function actions(): array
+    {
+        return [];
+    }
+}

--- a/stubs/SingletonResource.stub
+++ b/stubs/SingletonResource.stub
@@ -1,0 +1,33 @@
+<?php
+
+namespace {namespace};
+
+use {model-namespace};
+
+use Illuminate\Database\Eloquent\Model;
+use MoonShine\Resources\SingletonResource;
+use MoonShine\Fields\ID;
+
+class DummyResource extends SingletonResource
+{
+	public static string $model = {model}::class;
+
+	public static string $title = 'DummyTitle';
+
+    public function getId(): int|string
+    {
+        return {id};
+    }
+
+	public function fields(): array
+	{
+		return [
+		    ID::make()->sortable(),
+        ];
+	}
+
+	public function rules(Model $item): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
A resource for one entry without the ability to list, add and delete! Perfect for resources with settings. Implements singletonResource in Laravel routing

To use it, you need to implement the getId method specifying the id of the record in the database

```php
// ..

class SettingResource extends SingletonResource
{
    public static string $model = Setting::class;

    public static string $title = 'Settings';

    public function getId(): int|string
    {
        return 1;
    }
// ..
```

```shell
php artisan moonshine:resource Setting --singleton
```

or

```shell
php artisan moonshine:resource Setting --s
```

with id

```shell
php artisan moonshine:resource Setting --s --id=1
```

