### PR TITLE
fix(resource): Fix for creating a resource object in pagination

### DIFF
--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -42,10 +42,8 @@ trait ResourceModelQuery
 
     public function transformToResources(Collection $collection): Collection
     {
-        $resourceClass = get_class($this);
-
         return $collection->transform(
-            fn ($value) => (new $resourceClass())->setItem($value)
+            fn ($value) => (clone $this)->setItem($value)
         );
     }
 


### PR DESCRIPTION
Using "clone" method instead of "new"