### PR TITLE
Update tables.css

### DIFF
--- a/resources/css/components/tables.css
+++ b/resources/css/components/tables.css
@@ -53,7 +53,7 @@ table {
     thead {
         td,
         th {
-            @apply max-w-lg whitespace-nowrap px-5 py-3 text-2xs font-semibold dark:border-dark-300;
+            @apply max-w-lg px-5 py-3 text-2xs font-semibold dark:border-dark-300;
         }
     }
 


### PR DESCRIPTION
Удаление whitespace-nowrap у заголовков столбцов, как было раньше, а то теперь прямо нереально огромные колонки получаются
![2023-05-04_16-08-34](https://user-images.githubusercontent.com/12836836/236215095-abcaaaf7-3f4c-4309-9f42-e7753b8eb595.png)
