### PR TITLE
fix(files): Fix display of file paths on view fields pages

### DIFF
--- a/src/Fields/File.php
+++ b/src/Fields/File.php
@@ -45,9 +45,9 @@ class File extends Field implements Fileable, RemovableContract
 
         $files = $this->isMultiple()
             ? collect($item->{$this->field()})
-                ->map(fn ($value) => $this->path($value))
+                ->map(fn ($value) => $this->pathWithDir($value))
                 ->toArray()
-            : [$this->path($item->{$this->field()})];
+            : [$this->pathWithDir($item->{$this->field()})];
 
         return view('moonshine::components.files', [
             'files' => $files,

--- a/src/Fields/Image.php
+++ b/src/Fields/Image.php
@@ -19,13 +19,13 @@ class Image extends File
         if ($this->isMultiple()) {
             return view('moonshine::ui.image', [
                 'values' => collect($item->{$this->field()})
-                    ->map(fn ($value) => $this->path($value ?? ''))
+                    ->map(fn ($value) => $this->pathWithDir($value ?? ''))
                     ->toArray(),
             ])->render();
         }
 
         return view('moonshine::ui.image', [
-            'value' => $this->path($item->{$this->field()}),
+            'value' => $this->pathWithDir($item->{$this->field()}),
         ])->render();
     }
 }

--- a/src/Traits/Fields/FileTrait.php
+++ b/src/Traits/Fields/FileTrait.php
@@ -77,6 +77,14 @@ trait FileTrait
         return Storage::disk($this->getDisk())->url($value);
     }
 
+    public function pathWithDir(string $value): string
+    {
+        $dir = !(empty($this->getDir())) ? $this->getDir(). '/' : '';
+        return $this->path(str($value)->remove($dir)
+            ->prepend($dir)
+            ->value());
+    }
+
     /**
      * @throws Throwable
      */


### PR DESCRIPTION
The getDir() method is now used in indexViewValue methods for images and files. The FileTrait has been expanded and the pathWithDir() method has been added