### PR TITLE
ChangeLog

### DIFF
--- a/resources/views/crud/form.blade.php
+++ b/resources/views/crud/form.blade.php
@@ -17,6 +17,4 @@
 
 @section('content')
     @include('moonshine::crud.shared.form', ['item' => $item])
-
-    @include('moonshine::crud.shared.changelog', ['resource' => $resource, 'item' => $item])
 @endsection

--- a/resources/views/form-components/change-log.blade.php
+++ b/resources/views/form-components/change-log.blade.php
@@ -1,5 +1,9 @@
-@if($logs = \MoonShine\MoonShine::changeLogs($item))
-    <div class="my-6 text-lg">@lang('moonshine::ui.last_changes')</div>
+@if($element->logs($item)->isNotEmpty())
+    <div class="my-4">
+        <div class="text-lg">{{ $element->label() }}</div>
+        <div class="text-sm">@lang('moonshine::ui.last_changes')</div>
+    </div>
+
     <x-moonshine::table>
         <x-slot:thead>
             <th>
@@ -13,7 +17,7 @@
             </th>
         </x-slot:thead>
         <x-slot:tbody>
-            @foreach($logs->take(5) as $log)
+            @foreach($element->logs($item)->take(5) as $log)
                 <tr>
                     <td>
                         @include('moonshine::ui.badge', [

--- a/src/FormComponents/ChangeLogFormComponent.php
+++ b/src/FormComponents/ChangeLogFormComponent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\FormComponents;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+final class ChangeLogFormComponent extends FormComponent
+{
+    protected static string $view = 'moonshine::form-components.change-log';
+
+    public static function logs(Model $item): Collection
+    {
+        if (! isset($item->changeLogs) || ! $item->changeLogs instanceof Collection) {
+            return collect();
+        }
+
+        return $item->changeLogs
+            ->filter(static fn ($log) => $log->states_after);
+    }
+}

--- a/src/Models/MoonshineUser.php
+++ b/src/Models/MoonshineUser.php
@@ -7,14 +7,15 @@ namespace MoonShine\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use MoonShine\Traits\Models\HasMoonShineChangeLog;
+use MoonShine\Traits\Models\HasMoonShinePermissions;
 
 class MoonshineUser extends Authenticatable
 {
     use HasMoonShineChangeLog;
+    use HasMoonShinePermissions;
     use HasFactory;
     use Notifiable;
 
@@ -37,10 +38,5 @@ class MoonshineUser extends Authenticatable
     public function moonshineSocialites(): HasMany
     {
         return $this->hasMany(MoonshineSocialite::class);
-    }
-
-    public function moonshineUserPermission(): HasOne
-    {
-        return $this->hasOne(MoonshineUserPermission::class);
     }
 }

--- a/src/MoonShine.php
+++ b/src/MoonShine.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MoonShine;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
 use MoonShine\Contracts\Resources\ResourceContract;
@@ -157,18 +156,5 @@ class MoonShine
                     $resource->resolveRoutes();
                 });
             });
-    }
-
-    public static function changeLogs(Model $item): ?Collection
-    {
-        if (! isset($item->changeLogs) || ! $item->changeLogs instanceof Collection) {
-            return null;
-        }
-
-        if ($item->changeLogs->isNotEmpty()) {
-            return $item->changeLogs->filter(static fn ($log) => $log->states_after);
-        }
-
-        return null;
     }
 }

--- a/src/Resources/MoonShineUserResource.php
+++ b/src/Resources/MoonShineUserResource.php
@@ -20,6 +20,7 @@ use MoonShine\Fields\PasswordRepeat;
 use MoonShine\Fields\Text;
 use MoonShine\Filters\DateFilter;
 use MoonShine\Filters\TextFilter;
+use MoonShine\FormComponents\ChangeLogFormComponent;
 use MoonShine\FormComponents\PermissionFormComponent;
 use MoonShine\Http\Controllers\PermissionController;
 use MoonShine\Models\MoonshineUser;
@@ -105,6 +106,9 @@ class MoonShineUserResource extends Resource
     {
         return [
             PermissionFormComponent::make('Permissions')
+                ->canSee(fn ($user) => $user->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID),
+
+            ChangeLogFormComponent::make('Change log')
                 ->canSee(fn ($user) => $user->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID),
         ];
     }

--- a/src/Traits/Models/HasMoonShinePermissions.php
+++ b/src/Traits/Models/HasMoonShinePermissions.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Traits\Models;
+
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use MoonShine\Models\MoonshineUserPermission;
+
+trait HasMoonShinePermissions
+{
+    public function moonshineUserPermission(): HasOne
+    {
+        return $this->hasOne(MoonshineUserPermission::class);
+    }
+}


### PR DESCRIPTION
Moved to FormComponent

Example 

```php
 public function components(): array
    {
        return [
            ChangeLogFormComponent::make('Change log')
                ->canSee(fn ($user) => $user->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID),
        ];
    }
```

Usage

1. Use trait
2. Add component