### PR TITLE
Fix delete files

### DIFF
--- a/tests/Feature/Fields/FileFieldTest.php
+++ b/tests/Feature/Fields/FileFieldTest.php
@@ -166,3 +166,19 @@ it('successful mass delete files', function () {
         Storage::disk('public')->assertMissing('moonshine_users/'.$avatar->hashName());
     }
 });
+
+it('checking if file is saved after request', function () {
+    $avatar = UploadedFile::fake()->image('avatar-to-delete.png');
+
+    expect()->storeAvatarFile($avatar, $this->field, $this->item);
+
+    Storage::disk('public')->assertExists('files/'.$avatar->hashName());
+
+    fakeRequest(method: 'POST', parameters: [
+        'hidden_avatar' => 'files/'.$avatar->hashName()
+    ]);
+
+    $this->field->save($this->item);
+
+    Storage::disk('public')->assertExists('files/'.$avatar->hashName());
+});


### PR DESCRIPTION
Removing conditions from disableDeleteFiles and enableDeleteDir methods. disableDeleteFiles is now set to false and enableDeleteDir is set to true automatically. Fix an error with deleting a file from a form. Fix checkAndDelete method - adding compatibility with collections