### PR TITLE
BREAKING CHANGE: ItemActionContract renaming due to spelling mistake

### DIFF
--- a/src/Contracts/Actions/ItemActionContract.php
+++ b/src/Contracts/Actions/ItemActionContract.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace MoonShine\Contracts\Actions;
 
-interface ItemActionContact
+interface ItemActionContract
 {
 }

--- a/src/FormActions/FormAction.php
+++ b/src/FormActions/FormAction.php
@@ -7,7 +7,7 @@ namespace MoonShine\FormActions;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\RedirectResponse;
-use MoonShine\Contracts\Actions\ItemActionContact;
+use MoonShine\Contracts\Actions\ItemActionContract;
 use MoonShine\Traits\HasCanSee;
 use MoonShine\Traits\InDropdownOrLine;
 use MoonShine\Traits\Makeable;
@@ -15,7 +15,7 @@ use MoonShine\Traits\WithConfirmation;
 use MoonShine\Traits\WithIcon;
 use MoonShine\Traits\WithLabel;
 
-final class FormAction implements ItemActionContact
+final class FormAction implements ItemActionContract
 {
     use Makeable;
     use WithIcon;

--- a/src/ItemActions/ItemAction.php
+++ b/src/ItemActions/ItemAction.php
@@ -6,7 +6,7 @@ namespace MoonShine\ItemActions;
 
 use Closure;
 use Illuminate\Database\Eloquent\Model;
-use MoonShine\Contracts\Actions\ItemActionContact;
+use MoonShine\Contracts\Actions\ItemActionContract;
 use MoonShine\Traits\HasCanSee;
 use MoonShine\Traits\InDropdownOrLine;
 use MoonShine\Traits\Makeable;
@@ -14,7 +14,7 @@ use MoonShine\Traits\WithConfirmation;
 use MoonShine\Traits\WithIcon;
 use MoonShine\Traits\WithLabel;
 
-final class ItemAction implements ItemActionContact
+final class ItemAction implements ItemActionContract
 {
     use Makeable;
     use WithIcon;

--- a/src/ItemActions/ItemActions.php
+++ b/src/ItemActions/ItemActions.php
@@ -6,28 +6,28 @@ namespace MoonShine\ItemActions;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
-use MoonShine\Contracts\Actions\ItemActionContact;
+use MoonShine\Contracts\Actions\ItemActionContract;
 
 final class ItemActions extends Collection
 {
     public function onlyVisible(Model $item): self
     {
         return $this->filter(
-            fn (ItemActionContact $action) => $action->isSee($item)
+            fn (ItemActionContract $action) => $action->isSee($item)
         );
     }
 
     public function inDropdown(): self
     {
         return $this->filter(
-            static fn (ItemActionContact $action) => $action->inDropdown()
+            static fn (ItemActionContract $action) => $action->inDropdown()
         );
     }
 
     public function inLine(): self
     {
         return $this->filter(
-            static fn (ItemActionContact $action) => ! $action->inDropdown()
+            static fn (ItemActionContract $action) => ! $action->inDropdown()
         );
     }
 }


### PR DESCRIPTION
Переименование интерфейса `ItemActionContact` в `ItemActionContract`. Т.к. этот интерфейс может использоваться пользователями MoonShine, то PR помечен как  **критическое изменение**.