### PR TITLE
BREAKING CHANGE: MassActionContract renaming due to spelling mistake

### DIFF
--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\Actions;
 
 use MoonShine\Contracts\Actions\ActionContract;
-use MoonShine\Contracts\Actions\MassActionContact;
+use MoonShine\Contracts\Actions\MassActionContract;
 use MoonShine\Contracts\Resources\ResourceContract;
 use MoonShine\Exceptions\ActionException;
 use MoonShine\Traits\HasCanSee;
@@ -15,7 +15,7 @@ use MoonShine\Traits\WithIcon;
 use MoonShine\Traits\WithLabel;
 use MoonShine\Traits\WithView;
 
-abstract class Action implements ActionContract, MassActionContact
+abstract class Action implements ActionContract, MassActionContract
 {
     use Makeable;
     use WithView;

--- a/src/Actions/MassActions.php
+++ b/src/Actions/MassActions.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace MoonShine\Actions;
 
 use Illuminate\Support\Collection;
-use MoonShine\Contracts\Actions\MassActionContact;
+use MoonShine\Contracts\Actions\MassActionContract;
 use MoonShine\MoonShineRequest;
 
 final class MassActions extends Collection
 {
-    public function mergeIfNotExists(MassActionContact $new): self
+    public function mergeIfNotExists(MassActionContract $new): self
     {
         return $this->when(
             ! $this->first(static fn (Action $action) => get_class($action) === get_class($new)),
@@ -21,21 +21,21 @@ final class MassActions extends Collection
     public function onlyVisible(): self
     {
         return $this->filter(
-            static fn (MassActionContact $action) => $action->isSee(app(MoonShineRequest::class))
+            static fn (MassActionContract $action) => $action->isSee(app(MoonShineRequest::class))
         );
     }
 
     public function inDropdown(): self
     {
         return $this->filter(
-            static fn (MassActionContact $action) => $action->inDropdown()
+            static fn (MassActionContract $action) => $action->inDropdown()
         );
     }
 
     public function inLine(): self
     {
         return $this->filter(
-            static fn (MassActionContact $action) => ! $action->inDropdown()
+            static fn (MassActionContract $action) => ! $action->inDropdown()
         );
     }
 }

--- a/src/BulkActions/BulkAction.php
+++ b/src/BulkActions/BulkAction.php
@@ -6,7 +6,7 @@ namespace MoonShine\BulkActions;
 
 use Closure;
 use Illuminate\Database\Eloquent\Model;
-use MoonShine\Contracts\Actions\MassActionContact;
+use MoonShine\Contracts\Actions\MassActionContract;
 use MoonShine\Traits\HasCanSee;
 use MoonShine\Traits\InDropdownOrLine;
 use MoonShine\Traits\Makeable;
@@ -14,7 +14,7 @@ use MoonShine\Traits\WithConfirmation;
 use MoonShine\Traits\WithIcon;
 use MoonShine\Traits\WithLabel;
 
-final class BulkAction implements MassActionContact
+final class BulkAction implements MassActionContract
 {
     use Makeable;
     use WithIcon;

--- a/src/Contracts/Actions/MassActionContract.php
+++ b/src/Contracts/Actions/MassActionContract.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace MoonShine\Contracts\Actions;
 
-interface MassActionContact
+interface MassActionContract
 {
 }


### PR DESCRIPTION
Тоже самое, что и #297 .