### PR TITLE
feat(components): Tooltip/Popover

### DIFF
--- a/resources/views/components/popover.blade.php
+++ b/resources/views/components/popover.blade.php
@@ -1,0 +1,10 @@
+@props([
+    'title' => '',
+    'placement' => 'right',
+    'trigger',
+])
+<span {{ $attributes }} title="{{ $title }}" data-content="{!! $slot !!}"
+     x-data="popover({placement: '{{ $placement }}'})"
+>
+    {{ $trigger }}
+</span>

--- a/resources/views/components/tooltip.blade.php
+++ b/resources/views/components/tooltip.blade.php
@@ -1,0 +1,10 @@
+@props([
+    'title' => '',
+    'placement' => 'right',
+    'trigger',
+])
+<span {{ $attributes }}
+     x-data="tooltip(`{{ $slot }}`, {placement: '{{ $placement }}'})"
+>
+    {{ $trigger }}
+</span>

--- a/tests/Feature/Components/ComponentsTest.php
+++ b/tests/Feature/Components/ComponentsTest.php
@@ -466,3 +466,30 @@ it('progress', function () {
         />')
         ->assertSee('20%');
 });
+
+it('tooltip', function () {
+    test()
+        ->blade('<x-moonshine::tooltip>
+            <x-slot:trigger>
+                <button>Trigger</button>
+            </x-slot:trigger>
+            Tooltip content
+        </x-moonshine:tooltip>
+        ')
+        ->assertSee('Trigger')
+        ->assertSee('Tooltip content');
+});
+
+it('popover', function () {
+    test()
+        ->blade('<x-moonshine::popover title="Popover title">
+            <x-slot:trigger>
+                <button>Trigger</button>
+            </x-slot:trigger>
+            Popover content
+        </x-moonshine:tooltip>
+        ')
+        ->assertSee('Popover title')
+        ->assertSee('Trigger')
+        ->assertSee('Popover content');
+});


### PR DESCRIPTION
Tooltip/Popover ui components

```blade
// Tooltip (placement optional attribute, default top)

<x-moonshine::tooltip placement="bottom">
<x-slot:trigger>
<button class="btn">Trigger</button>
</x-slot:trigger>

Tooltip text
</x-moonshine::tooltip>

// Popover (title optional attribute)

<x-moonshine::popover title="Popover title" placement="right">
<x-slot:trigger>
<button class="btn">Trigger</button>
</x-slot:trigger>

<p>This is a very beautiful popover, show some love.</p> <div class='flex justify-between mt-3'><button type='button' class='btn btn-sm'>Skip</button><button type='button' class='btn btn-sm btn-primary'>Read More</button></div>
</x-moonshine::popover>


// use tooltip without components

<span x-data="tooltip('Tooltip content', {placement: 'top'})">Tooltip</span>

// or

<span x-data="tooltip" data-tippy-content="Tooltip content">Tooltip</span>

// use popover without components

<span x-data="popover({placement: 'top'}))" title="Popover title" data-content="HTML HERE">Popover</span>

// or

<span x-data="popover" data-content="HTML HERE">Popover</span>

```