### PR TITLE
feat(console): Use plural title for moonshine:resource command

### DIFF
--- a/src/Commands/ResourceCommand.php
+++ b/src/Commands/ResourceCommand.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace MoonShine\Commands;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Support\Pluralizer;
+use Illuminate\Support\Str;
 use MoonShine\MoonShine;
 
 class ResourceCommand extends MoonShineCommand
@@ -39,7 +41,7 @@ class ResourceCommand extends MoonShineCommand
             ->value();
 
         $model = $this->qualifyModel($this->option('model') ?? $name);
-        $title = $this->option('title') ?? $name;
+        $title = $this->option('title') ?? ($this->option('singleton') ? $name : $this->plural($name));
 
         $resource = $this->getDirectory()."/Resources/{$name}Resource.php";
 
@@ -58,5 +60,17 @@ class ResourceCommand extends MoonShineCommand
 
         $this->components->info("{$name}Resource file was created: ".str_replace(base_path(), '', $resource));
         $this->components->info('Now register resource in menu');
+    }
+
+    private function plural(string $value): string
+    {
+        // If main app uses language other than English.
+        // Run English for this command only.
+        Pluralizer::useLanguage('english');
+
+        $valuePlural = Str::plural(Str::singular($value));
+
+        // if true - value is already plural
+        return $valuePlural === $value ? $value : $valuePlural;
     }
 }

--- a/src/Commands/ResourceCommand.php
+++ b/src/Commands/ResourceCommand.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace MoonShine\Commands;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
-use Illuminate\Support\Pluralizer;
-use Illuminate\Support\Str;
 use MoonShine\MoonShine;
 
 class ResourceCommand extends MoonShineCommand
@@ -41,7 +39,8 @@ class ResourceCommand extends MoonShineCommand
             ->value();
 
         $model = $this->qualifyModel($this->option('model') ?? $name);
-        $title = $this->option('title') ?? ($this->option('singleton') ? $name : $this->plural($name));
+        $title = $this->option('title') ??
+            ($this->option('singleton') ? $name : str($name)->singular()->plural()->value());
 
         $resource = $this->getDirectory()."/Resources/{$name}Resource.php";
 
@@ -60,17 +59,5 @@ class ResourceCommand extends MoonShineCommand
 
         $this->components->info("{$name}Resource file was created: ".str_replace(base_path(), '', $resource));
         $this->components->info('Now register resource in menu');
-    }
-
-    private function plural(string $value): string
-    {
-        // If main app uses language other than English.
-        // Run English for this command only.
-        Pluralizer::useLanguage('english');
-
-        $valuePlural = Str::plural(Str::singular($value));
-
-        // if true - value is already plural
-        return $valuePlural === $value ? $value : $valuePlural;
     }
 }

--- a/tests/Feature/Commands/ResourceCommandTest.php
+++ b/tests/Feature/Commands/ResourceCommandTest.php
@@ -1,8 +1,8 @@
 <?php
 
 use MoonShine\Commands\ResourceCommand;
-
 use MoonShine\MoonShine;
+
 use function Pest\Laravel\artisan;
 
 use Symfony\Component\Console\Command\Command;

--- a/tests/Feature/Commands/ResourceCommandTest.php
+++ b/tests/Feature/Commands/ResourceCommandTest.php
@@ -2,6 +2,7 @@
 
 use MoonShine\Commands\ResourceCommand;
 
+use MoonShine\MoonShine;
 use function Pest\Laravel\artisan;
 
 use Symfony\Component\Console\Command\Command;
@@ -37,12 +38,13 @@ it('generates correct resource title', function (
         '--id' => $id,
     ])->assertExitCode(Command::SUCCESS);
 
-    $resourceFileName = ucfirst($name).'Resource.php';
-    $contents = file_get_contents(__DIR__.'/../../../app/MoonShine/Resources/'.$resourceFileName);
+    $path = MoonShine::path().'/app/MoonShine/Resources/'.ucfirst($name).'Resource.php';
+    $contents = file_get_contents($path);
 
     expect($contents)
         ->toContain('public static string $title = \''.$result.'\';');
 
+    @unlink($path);
 })->with([
     'singular resource' => [
         'Children', // result

--- a/tests/Feature/Commands/ResourceCommandTest.php
+++ b/tests/Feature/Commands/ResourceCommandTest.php
@@ -22,3 +22,83 @@ it('reports progress singleton', function () {
         ->expectsOutputToContain('Now register resource in menu')
         ->assertExitCode(Command::SUCCESS);
 });
+
+it('generates correct resource title', function (
+    string $result,
+    string $name,
+    bool $singleton,
+    int $id = null,
+    string $title = null,
+) {
+    artisan(ResourceCommand::class, [
+        'name' => $name,
+        '--title' => $title,
+        '--singleton' => $singleton,
+        '--id' => $id,
+    ])->assertExitCode(Command::SUCCESS);
+
+    $resourceFileName = ucfirst($name).'Resource.php';
+    $contents = file_get_contents(__DIR__.'/../../../app/MoonShine/Resources/'.$resourceFileName);
+
+    expect($contents)
+        ->toContain('public static string $title = \''.$result.'\';');
+
+})->with([
+    'singular resource' => [
+        'Children', // result
+        'Child', // resource name
+        false, // is singleton
+        null, // id of singleton resource
+        null, // title
+    ],
+    'singular singleton resource' => [
+        'Child', // result
+        'Child', // resource name
+        true, // is singleton
+        1, // id of singleton resource
+        null, // title
+    ],
+    'singular resource with title' => [
+        'Boys', // result
+        'Child', // resource name
+        false, // is singleton
+        null, // id of singleton resource
+        'Boys', // title
+    ],
+    'singular singleton resource with title' => [
+        'Boy', // result
+        'Child', // resource name
+        true, // is singleton
+        1, // id of singleton resource
+        'Boy', // title
+    ],
+
+    'plural resource' => [
+        'Children', // result
+        'Children', // resource name
+        false, // is singleton
+        null, // id of singleton resource
+        null, // title
+    ],
+    'plural singleton resource' => [
+        'Children', // result
+        'Children', // resource name
+        true, // is singleton
+        1, // id of singleton resource
+        null, // title
+    ],
+    'plural resource with title' => [
+        'Boys', // result
+        'Children', // resource name
+        false, // is singleton
+        null, // id of singleton resource
+        'Boys', // title
+    ],
+    'plural singleton resource with title' => [
+        'Boy', // result
+        'Children', // resource name
+        true, // is singleton
+        1, // id of singleton resource
+        'Boy', // title
+    ],
+]);

--- a/tests/Feature/Commands/ResourceCommandTest.php
+++ b/tests/Feature/Commands/ResourceCommandTest.php
@@ -38,7 +38,7 @@ it('generates correct resource title', function (
         '--id' => $id,
     ])->assertExitCode(Command::SUCCESS);
 
-    $path = MoonShine::path().'/app/MoonShine/Resources/'.ucfirst($name).'Resource.php';
+    $path = MoonShine::path('app/MoonShine/Resources/'.ucfirst($name).'Resource.php');
     $contents = file_get_contents($path);
 
     expect($contents)


### PR DESCRIPTION
Предложение.
Если создаётся не синглтон ресурс, то ожидается, что название (`title`) ресура будет во множественном числе: `Users`, `Orders`, `Products` и т.д. Сейчас же название генерируется в единственном числе, что приводит к лишней работе со стороны разработчика. Даже в документации и видео-уроках делается эта лишняя работа по переименованию. 
Данный фикс устраняет эту проблему:
- если передана опция `--title`, то значение берется напрямую и никакой обработки не происходит;
- иначе, если передана опция `--singleton`, то берется значение параметра `name` (как и ранее), т.к. предполагается, что `name` всегда в единственном числе;
- иначе, производится перевод параметра `name` во множественное число в английской нотации.