### PR TITLE
[1.x] Conver username (email) to lowercase

### DIFF
--- a/src/Commands/UserCommand.php
+++ b/src/Commands/UserCommand.php
@@ -21,7 +21,9 @@ class UserCommand extends MoonShineCommand
 
         if ($email && $name && $password) {
             MoonshineUser::query()->create([
-                'email' => $email,
+                'email' => (string) str($email)
+                    ->lower()
+                    ->trim(),
                 'name' => $name,
                 'password' => Hash::make($password),
             ]);


### PR DESCRIPTION
This is necessary because this field is converted to lower case during authorization.