### PR TITLE
[1.5.x] Convert username (email) to lowercase

### DIFF
--- a/src/Commands/UserCommand.php
+++ b/src/Commands/UserCommand.php
@@ -21,7 +21,7 @@ class UserCommand extends MoonShineCommand
 
         if ($username && $name && $password) {
             MoonShineAuth::model()->query()->create([
-                config('moonshine.auth.fields.username', 'email') => $username,
+                config('moonshine.auth.fields.username', 'email') => Str::lower($username),
                 config('moonshine.auth.fields.name', 'name') => $name,
                 config('moonshine.auth.fields.password', 'password') => Hash::make($password),
             ]);


### PR DESCRIPTION
This is necessary because this field is converted to lower case during authorization.