### PR TITLE
feat(actions): Confirm modal

### DIFF
--- a/resources/views/crud/shared/bulk-action-item.blade.php
+++ b/resources/views/crud/shared/bulk-action-item.blade.php
@@ -1,4 +1,4 @@
-@if($action->confirmation())
+@if($action->isConfirmed())
     <x-moonshine::modal title="{{ $action->modal()->title() }}">
         <div class="mb-4">
             {{ $action->modal()->content() }}

--- a/resources/views/crud/shared/bulk-action-item.blade.php
+++ b/resources/views/crud/shared/bulk-action-item.blade.php
@@ -1,7 +1,7 @@
 @if($action->confirmation())
-    <x-moonshine::modal title="{{ trans('moonshine::ui.confirm') }}">
+    <x-moonshine::modal title="{{ $action->modal()->title() }}">
         <div class="mb-4">
-            {{ trans('moonshine::ui.confirm_message') }}
+            {{ $action->modal()->content() }}
         </div>
 
         <x-moonshine::form
@@ -19,7 +19,7 @@
             />
 
             <x-moonshine::form.button type="submit" title="{{ $action->label() }}">
-                {{ $action->getIcon(6) }} {{ $action->label() }}
+                {{ $action->getIcon(6) }} {{ $action->modal()->getConfirmButtonText() }}
             </x-moonshine::form.button>
         </x-moonshine::form>
 

--- a/resources/views/crud/shared/confirm-action.blade.php
+++ b/resources/views/crud/shared/confirm-action.blade.php
@@ -1,13 +1,13 @@
-<x-moonshine::modal title="{{ trans('moonshine::ui.confirm') }}">
+<x-moonshine::modal title="{{ $action->modal()->title() }}">
     <div class="mb-4">
-        {{ trans('moonshine::ui.confirm_message') }}
+        {{ $action->modal()->content() }}
     </div>
 
     <x-moonshine::link
         :href="$href"
         :icon="$action->iconValue()"
     >
-        {{ $action->label() }}
+        {{ $action->modal()->getConfirmButtonText() }}
     </x-moonshine::link>
 
     <x-slot name="outerHtml">

--- a/resources/views/crud/shared/form-action-item.blade.php
+++ b/resources/views/crud/shared/form-action-item.blade.php
@@ -1,4 +1,4 @@
-@if($action->confirmation())
+@if($action->isConfirmed())
     @include('moonshine::crud.shared.confirm-action', ['action' => $action, 'href' => $resource->route('actions.form', $item->getKey(), ['index' => $index])])
 @else
     <x-dynamic-component

--- a/resources/views/crud/shared/item-action-item.blade.php
+++ b/resources/views/crud/shared/item-action-item.blade.php
@@ -1,4 +1,4 @@
-@if($action->confirmation())
+@if($action->isConfirmed())
     @include('moonshine::crud.shared.confirm-action', ['action' => $action, 'href' => $resource->route('actions.item', $resource->getItem()->getKey(), request()->routeIs('*.query-tag') ? ['index' => $index, 'redirect_back' => 1] : ['index' => $index])])
 @else
     <x-dynamic-component

--- a/src/Actions/ResourceAction.php
+++ b/src/Actions/ResourceAction.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace MoonShine\Actions;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use MoonShine\Traits\HasCanSee;
+use MoonShine\Traits\InDropdownOrLine;
+use MoonShine\Traits\Makeable;
+use MoonShine\Traits\WithConfirmation;
+use MoonShine\Traits\WithErrorMessage;
+use MoonShine\Traits\WithIcon;
+use MoonShine\Traits\WithLabel;
+
+/**
+ * @method static static make(string $label, Closure $callback, string $message = 'Done')
+ */
+abstract class ResourceAction
+{
+    use Makeable;
+    use WithIcon;
+    use WithLabel;
+    use HasCanSee;
+    use InDropdownOrLine;
+    use WithConfirmation;
+    use WithErrorMessage;
+
+    public function __construct(
+        string $label,
+        protected Closure $callback,
+        protected string $message = 'Done',
+    ) {
+        $this->setLabel($label);
+    }
+
+    public function message(): string
+    {
+        return $this->message;
+    }
+
+    public function callback(Model $model): mixed
+    {
+        return call_user_func($this->callback, $model);
+    }
+}

--- a/src/BulkActions/BulkAction.php
+++ b/src/BulkActions/BulkAction.php
@@ -11,6 +11,7 @@ use MoonShine\Traits\HasCanSee;
 use MoonShine\Traits\InDropdownOrLine;
 use MoonShine\Traits\Makeable;
 use MoonShine\Traits\WithConfirmation;
+use MoonShine\Traits\WithErrorMessage;
 use MoonShine\Traits\WithIcon;
 use MoonShine\Traits\WithLabel;
 
@@ -25,6 +26,7 @@ final class BulkAction implements MassActionContract
     use HasCanSee;
     use InDropdownOrLine;
     use WithConfirmation;
+    use WithErrorMessage;
 
     public function __construct(
         string $label,
@@ -32,6 +34,7 @@ final class BulkAction implements MassActionContract
         protected string $message = 'Done',
     ) {
         $this->setLabel($label);
+        $this->errorMessage = __('moonshine::ui.saved_error');
     }
 
     public function message(): string

--- a/src/BulkActions/BulkAction.php
+++ b/src/BulkActions/BulkAction.php
@@ -4,46 +4,9 @@ declare(strict_types=1);
 
 namespace MoonShine\BulkActions;
 
-use Closure;
-use Illuminate\Database\Eloquent\Model;
+use MoonShine\Actions\ResourceAction;
 use MoonShine\Contracts\Actions\MassActionContract;
-use MoonShine\Traits\HasCanSee;
-use MoonShine\Traits\InDropdownOrLine;
-use MoonShine\Traits\Makeable;
-use MoonShine\Traits\WithConfirmation;
-use MoonShine\Traits\WithErrorMessage;
-use MoonShine\Traits\WithIcon;
-use MoonShine\Traits\WithLabel;
 
-/**
- * @method static static make(string $label, Closure $callback, string $message = 'Done')
- */
-final class BulkAction implements MassActionContract
+final class BulkAction extends ResourceAction implements MassActionContract
 {
-    use Makeable;
-    use WithIcon;
-    use WithLabel;
-    use HasCanSee;
-    use InDropdownOrLine;
-    use WithConfirmation;
-    use WithErrorMessage;
-
-    public function __construct(
-        string $label,
-        protected Closure $callback,
-        protected string $message = 'Done',
-    ) {
-        $this->setLabel($label);
-        $this->errorMessage = __('moonshine::ui.saved_error');
-    }
-
-    public function message(): string
-    {
-        return $this->message;
-    }
-
-    public function callback(Model $model): mixed
-    {
-        return call_user_func($this->callback, $model);
-    }
 }

--- a/src/FormActions/FormAction.php
+++ b/src/FormActions/FormAction.php
@@ -4,48 +4,13 @@ declare(strict_types=1);
 
 namespace MoonShine\FormActions;
 
-use Closure;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\RedirectResponse;
+use MoonShine\Actions\ResourceAction;
 use MoonShine\Contracts\Actions\ItemActionContract;
-use MoonShine\Traits\HasCanSee;
-use MoonShine\Traits\InDropdownOrLine;
-use MoonShine\Traits\Makeable;
-use MoonShine\Traits\WithConfirmation;
-use MoonShine\Traits\WithIcon;
-use MoonShine\Traits\WithLabel;
 
-/**
- * @method static static make(string $label, Closure $callback, string $message = 'Done')
- */
-final class FormAction implements ItemActionContract
+final class FormAction extends ResourceAction implements ItemActionContract
 {
-    use Makeable;
-    use WithIcon;
-    use HasCanSee;
-    use WithLabel;
-    use InDropdownOrLine;
-    use WithConfirmation;
-
     protected ?string $redirectTo = null;
-
-    public function __construct(
-        string $label,
-        protected Closure $callback,
-        protected string $message = 'Done',
-    ) {
-        $this->setLabel($label);
-    }
-
-    public function message(): string
-    {
-        return $this->message;
-    }
-
-    public function callback(Model $model): mixed
-    {
-        return call_user_func($this->callback, $model);
-    }
 
     public function redirectTo(string $redirectTo): self
     {

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -44,21 +44,16 @@ final class ActionController extends BaseController
 
         try {
             $action->callback($request->getItem());
+            MoonShineUI::toast($action->message());
         } catch (Throwable $e) {
             throw_if(! app()->isProduction(), $e);
             report_if(app()->isProduction(), $e);
 
             MoonShineUI::toast(
-                $action->getErrorMessage(),
+                $action->getErrorMessage() ?? __('moonshine::ui.saved_error'),
                 'error'
             );
-
-            return $redirectRoute;
         }
-
-        MoonShineUI::toast(
-            $action->message()
-        );
 
         return $redirectRoute;
     }
@@ -78,19 +73,16 @@ final class ActionController extends BaseController
 
         try {
             $action->callback($request->getItem());
+            MoonShineUI::toast($action->message());
         } catch (Throwable $e) {
             throw_if(! app()->isProduction(), $e);
             report_if(app()->isProduction(), $e);
 
             MoonShineUI::toast(
-                __('moonshine::ui.saved_error'),
+                $action->getErrorMessage() ?? __('moonshine::ui.saved_error'),
                 'error'
             );
-
-            return $redirectRoute;
         }
-
-        MoonShineUI::toast($action->message());
 
         return $redirectRoute;
     }
@@ -121,19 +113,16 @@ final class ActionController extends BaseController
                 );
 
             $items->each(fn ($item) => $action->callback($item));
+            MoonShineUI::toast($action->message());
         } catch (Throwable $e) {
             throw_if(! app()->isProduction(), $e);
             report_if(app()->isProduction(), $e);
 
             MoonShineUI::toast(
-                $action->getErrorMessage(),
+                $action->getErrorMessage() ?? __('moonshine::ui.saved_error'),
                 'error'
             );
-
-            return $redirectRoute;
         }
-
-        MoonShineUI::toast($action->message());
 
         return $redirectRoute;
     }

--- a/src/Http/Controllers/ActionController.php
+++ b/src/Http/Controllers/ActionController.php
@@ -49,7 +49,7 @@ final class ActionController extends BaseController
             report_if(app()->isProduction(), $e);
 
             MoonShineUI::toast(
-                __('moonshine::ui.saved_error'),
+                $action->getErrorMessage(),
                 'error'
             );
 
@@ -126,7 +126,7 @@ final class ActionController extends BaseController
             report_if(app()->isProduction(), $e);
 
             MoonShineUI::toast(
-                __('moonshine::ui.saved_error'),
+                $action->getErrorMessage(),
                 'error'
             );
 

--- a/src/Http/Controllers/CrudController.php
+++ b/src/Http/Controllers/CrudController.php
@@ -254,12 +254,22 @@ class CrudController extends BaseController
 
     public function massDelete(MassDeleteFormRequest $request): RedirectResponse
     {
-        $request->getResource()->massDelete($request->get('ids'));
+        try {
+            $request->getResource()->massDelete($request->get('ids'));
 
-        MoonShineUI::toast(
-            __('moonshine::ui.deleted'),
-            'success'
-        );
+            MoonShineUI::toast(
+                __('moonshine::ui.deleted'),
+                'success'
+            );
+        } catch (Throwable $e) {
+            throw_if(! app()->isProduction(), $e);
+            report_if(app()->isProduction(), $e);
+
+            MoonShineUI::toast(
+                __('moonshine::ui.saved_error'),
+                'error'
+            );
+        }
 
         return $request->redirectRoute(
             $request->getResource()->route('index')

--- a/src/ItemActions/ItemAction.php
+++ b/src/ItemActions/ItemAction.php
@@ -4,46 +4,9 @@ declare(strict_types=1);
 
 namespace MoonShine\ItemActions;
 
-use Closure;
-use Illuminate\Database\Eloquent\Model;
+use MoonShine\Actions\ResourceAction;
 use MoonShine\Contracts\Actions\ItemActionContract;
-use MoonShine\Traits\HasCanSee;
-use MoonShine\Traits\InDropdownOrLine;
-use MoonShine\Traits\Makeable;
-use MoonShine\Traits\WithConfirmation;
-use MoonShine\Traits\WithErrorMessage;
-use MoonShine\Traits\WithIcon;
-use MoonShine\Traits\WithLabel;
 
-/**
- * @method static static make(string $label, Closure $callback, string $message = 'Done')
- */
-final class ItemAction implements ItemActionContract
+final class ItemAction extends ResourceAction implements ItemActionContract
 {
-    use Makeable;
-    use WithIcon;
-    use HasCanSee;
-    use WithLabel;
-    use InDropdownOrLine;
-    use WithConfirmation;
-    use WithErrorMessage;
-
-    public function __construct(
-        string $label,
-        protected Closure $callback,
-        protected string $message = 'Done',
-    ) {
-        $this->setLabel($label);
-        $this->errorMessage = __('moonshine::ui.saved_error');
-    }
-
-    public function message(): string
-    {
-        return $this->message;
-    }
-
-    public function callback(Model $model): mixed
-    {
-        return call_user_func($this->callback, $model);
-    }
 }

--- a/src/ItemActions/ItemAction.php
+++ b/src/ItemActions/ItemAction.php
@@ -11,6 +11,7 @@ use MoonShine\Traits\HasCanSee;
 use MoonShine\Traits\InDropdownOrLine;
 use MoonShine\Traits\Makeable;
 use MoonShine\Traits\WithConfirmation;
+use MoonShine\Traits\WithErrorMessage;
 use MoonShine\Traits\WithIcon;
 use MoonShine\Traits\WithLabel;
 
@@ -25,6 +26,7 @@ final class ItemAction implements ItemActionContract
     use WithLabel;
     use InDropdownOrLine;
     use WithConfirmation;
+    use WithErrorMessage;
 
     public function __construct(
         string $label,
@@ -32,6 +34,7 @@ final class ItemAction implements ItemActionContract
         protected string $message = 'Done',
     ) {
         $this->setLabel($label);
+        $this->errorMessage = __('moonshine::ui.saved_error');
     }
 
     public function message(): string

--- a/src/Modals/ConfirmActionModal.php
+++ b/src/Modals/ConfirmActionModal.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace MoonShine\Modals;
+
+class ConfirmActionModal extends Modal
+{
+    public function __construct(
+        ?string $title = null,
+        ?string $content = null
+    ) {
+        parent::__construct(
+            $title ?? __('moonshine::ui.confirm'),
+            $content ?? __('moonshine::ui.confirm_message')
+        );
+    }
+}

--- a/src/Modals/Modal.php
+++ b/src/Modals/Modal.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace MoonShine\Modals;
+
+use MoonShine\Traits\Makeable;
+
+abstract class Modal
+{
+    use Makeable;
+
+    protected ?string $confirmButtonText = null;
+
+    public function __construct(
+        protected ?string $title,
+        protected ?string $content
+    ) {}
+
+    public function title(): ?string
+    {
+        return $this->title;
+    }
+
+    public function content(): ?string
+    {
+        return $this->content;
+    }
+
+    public function getConfirmButtonText(): ?string
+    {
+        return $this->confirmButtonText;
+    }
+
+    public function confirmButtonText(string $confirmButtonText): Modal
+    {
+        $this->confirmButtonText = $confirmButtonText;
+        return $this;
+    }
+}

--- a/src/Traits/WithConfirmation.php
+++ b/src/Traits/WithConfirmation.php
@@ -4,19 +4,34 @@ declare(strict_types=1);
 
 namespace MoonShine\Traits;
 
+use MoonShine\Modals\ConfirmActionModal;
+
 trait WithConfirmation
 {
     protected bool $confirmation = false;
+
+    protected ?ConfirmActionModal $modal = null;
 
     public function confirmation(): bool
     {
         return $this->confirmation;
     }
 
-    public function withConfirm(): self
-    {
+    public function withConfirm(
+        string $title = null,
+        string $content = null,
+        string $confirmButtonText = null
+    ): self {
         $this->confirmation = true;
 
+        $this->modal = ConfirmActionModal::make($title, $content)
+            ->confirmButtonText($confirmButtonText ?? $this->label());
+
         return $this;
+    }
+
+    public function modal(): ?ConfirmActionModal
+    {
+        return $this->modal;
     }
 }

--- a/src/Traits/WithConfirmation.php
+++ b/src/Traits/WithConfirmation.php
@@ -8,13 +8,13 @@ use MoonShine\Modals\ConfirmActionModal;
 
 trait WithConfirmation
 {
-    protected bool $confirmation = false;
+    protected bool $isConfirmed = false;
 
     protected ?ConfirmActionModal $modal = null;
 
-    public function confirmation(): bool
+    public function isConfirmed(): bool
     {
-        return $this->confirmation;
+        return $this->isConfirmed;
     }
 
     public function withConfirm(
@@ -22,7 +22,7 @@ trait WithConfirmation
         string $content = null,
         string $confirmButtonText = null
     ): self {
-        $this->confirmation = true;
+        $this->isConfirmed = true;
 
         $this->modal = ConfirmActionModal::make($title, $content)
             ->confirmButtonText($confirmButtonText ?? $this->label());

--- a/src/Traits/WithErrorMessage.php
+++ b/src/Traits/WithErrorMessage.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace MoonShine\Traits;
+
+trait WithErrorMessage
+{
+    protected string $errorMessage = '';
+
+    public function getErrorMessage(): string
+    {
+        return $this->errorMessage;
+    }
+
+    public function errorMessage(string $errorMessage): static
+    {
+        $this->errorMessage = $errorMessage;
+        return $this;
+    }
+}

--- a/tests/Unit/ItemActions/FormActionTest.php
+++ b/tests/Unit/ItemActions/FormActionTest.php
@@ -27,9 +27,9 @@ it('new instance', function (): void {
 
 it('confirmation modal', function (): void {
     expect($this->action)
-        ->confirmation()
+        ->isConfirmed()
         ->toBeFalse()
         ->withConfirm()
-        ->confirmation()
+        ->isConfirmed()
         ->toBeTrue();
 });

--- a/tests/Unit/ItemActions/ItemActionTest.php
+++ b/tests/Unit/ItemActions/ItemActionTest.php
@@ -27,9 +27,9 @@ it('new instance', function (): void {
 
 it('confirmation modal', function (): void {
     expect($this->action)
-        ->confirmation()
+        ->isConfirmed()
         ->toBeFalse()
         ->withConfirm()
-        ->confirmation()
+        ->isConfirmed()
         ->toBeTrue();
 });

--- a/tests/Unit/MassActions/BulkActionTest.php
+++ b/tests/Unit/MassActions/BulkActionTest.php
@@ -27,9 +27,9 @@ it('new instance', function (): void {
 
 it('confirmation modal', function (): void {
     expect($this->action)
-        ->confirmation()
+        ->isConfirmed()
         ->toBeFalse()
         ->withConfirm()
-        ->confirmation()
+        ->isConfirmed()
         ->toBeTrue();
 });


### PR DESCRIPTION
Modal window customization on actions. Customizing the error message on actions. Now you can specify the contents of the modal window inside the withConfirm method:
```php
BulkAction::make('Deactivating', function (Model $item) {
                $item->update(['active' => false]);
            }, 'Deactivated')
                ->icon('app')
                ->withConfirm('Title', 'Modal content', 'Accept')
```
In all actions, you can specify your own error message:
```php
ItemAction::make('Deactivating', function (Model $item) {
                $item->update(['active' => false]);
            }, 'Deactivated')
                ->icon('app')
                ->withConfirm('Title', 'Modal content', 'Accept')
                ->errorMessage('Fail')
```