### PR TITLE
feat(filters): nullable slide filter

### DIFF
--- a/resources/views/components/form/range.blade.php
+++ b/resources/views/components/form/range.blade.php
@@ -24,7 +24,6 @@
                 x-on:input="mintrigger"
                 x-model="minValue"
                 class="form-range-input"
-                x-bind:name="`{{ $fromName }}`"
                 x-on:change="onChangeField($event)"
             />
 
@@ -36,7 +35,6 @@
                 x-on:input="maxtrigger"
                 x-model="maxValue"
                 class="form-range-input"
-                x-bind:name="`{{ $toName }}`"
                 x-on:change="onChangeField($event)"
             />
 

--- a/src/Filters/SlideFilter.php
+++ b/src/Filters/SlideFilter.php
@@ -36,7 +36,11 @@ class SlideFilter extends Filter implements
         return $query->where(function (Builder $query) use ($values): void {
             $query
                 ->where($this->field(), '>=', $values[$this->fromField])
-                ->where($this->field(), '<=', $values[$this->toField]);
+                ->where($this->field(), '<=', $values[$this->toField])
+                ->when(
+                    ($this->isNullable() && (float)$values['from'] === (float)$this->min),
+                    fn(Builder $query) => $query->orWhereNull($this->field())
+                );
         });
     }
 }

--- a/src/Filters/SlideFilter.php
+++ b/src/Filters/SlideFilter.php
@@ -36,7 +36,11 @@ class SlideFilter extends Filter implements
         return $query->where(function (Builder $query) use ($values): void {
             $query
                 ->where($this->field(), '>=', $values[$this->fromField])
-                ->where($this->field(), '<=', $values[$this->toField]);
+                ->where($this->field(), '<=', $values[$this->toField])
+                ->when(
+                    ($this->isNullable() && (float)$values[$this->fromField] === (float)$this->min),
+                    fn(Builder $query) => $query->orWhereNull($this->field())
+                );
         });
     }
 }


### PR DESCRIPTION
По умолчанию если применить фильтры со стандартными значениями, SlideFilter скрывал null поля, так как min = 0. Это искажало результаты фильтрации.
- Теперь если указать для фильтра  ->nullable(), мы не будем скрывать такие значения.
- Добавил значения по умолчанию через null coalescing, чтобы не возникало ошибки при открытии ссылки, если вдруг не будет указан from или to.
- Также поправил баг с дублированием GET полей from и to при применении фильтра.