### PR TITLE
feat: Сanceling the default sorting in LineChart

### DIFF
--- a/src/Metrics/LineChartMetric.php
+++ b/src/Metrics/LineChartMetric.php
@@ -14,6 +14,8 @@ class LineChartMetric extends Metric
 
     protected array $colors = [];
 
+    protected bool $withoutSortKeys = false;
+
     protected array $assets = [
         'vendor/moonshine/libs/apexcharts/apexcharts.min.js',
         'vendor/moonshine/libs/apexcharts/apexcharts-config.js',
@@ -51,7 +53,7 @@ class LineChartMetric extends Metric
         return collect($this->lines())
             ->collapse()
             ->mapWithKeys(fn ($item) => $item)
-            ->sortKeys()
+            ->when(! $this->isWithoutSortKeys, fn ($items) => $items->sortKeys())
             ->keys()
             ->toArray();
     }
@@ -59,5 +61,17 @@ class LineChartMetric extends Metric
     public function lines(): array
     {
         return $this->lines;
+    }
+
+    public function withoutSortKeys(): static
+    {
+        $this->withoutSortKeys = true;
+
+        return $this;
+    }
+
+    public function isWithoutSortKeys(): bool
+    {
+        return $thisd->withoutSortKeys();
     }
 }

--- a/src/Metrics/LineChartMetric.php
+++ b/src/Metrics/LineChartMetric.php
@@ -53,7 +53,7 @@ class LineChartMetric extends Metric
         return collect($this->lines())
             ->collapse()
             ->mapWithKeys(fn ($item) => $item)
-            ->when(! $this->isWithoutSortKeys, fn ($items) => $items->sortKeys())
+            ->when(! $this->isWithoutSortKeys(), fn ($items) => $items->sortKeys())
             ->keys()
             ->toArray();
     }
@@ -72,6 +72,6 @@ class LineChartMetric extends Metric
 
     public function isWithoutSortKeys(): bool
     {
-        return $this->withoutSortKeys();
+        return $this->withoutSortKeys;
     }
 }

--- a/src/Metrics/LineChartMetric.php
+++ b/src/Metrics/LineChartMetric.php
@@ -72,6 +72,6 @@ class LineChartMetric extends Metric
 
     public function isWithoutSortKeys(): bool
     {
-        return $thisd->withoutSortKeys();
+        return $this->withoutSortKeys();
     }
 }


### PR DESCRIPTION
Добавил нвый метод в LineChart: withoutSortKeys()
Метод отменяет дефолтную сортировку в графике.

Пример использования
`LineChartMetric::make('Orders')->line(...)->withoutSortKeys()`

Сортировка по умолчанию:
![image](https://github.com/moonshine-software/moonshine/assets/17690542/60bd1675-ff06-40ec-bd34-1809ed6f5470)
После вызова:
![image](https://github.com/moonshine-software/moonshine/assets/17690542/08917e3d-785c-4ae5-b32e-e5a3f22cce5a)
