### PR TITLE
Fixed select when using enum

### DIFF
--- a/src/Fields/Select.php
+++ b/src/Fields/Select.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MoonShine\Fields;
 
+use UnitEnum;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use JsonException;
@@ -60,7 +61,7 @@ class Select extends Field implements
 
         if (
             version_compare(version1: PHP_VERSION, version2: '8.0.0', operator: '>=')
-            && $value instanceof \UnitEnum
+            && $value instanceof UnitEnum
         ) {
             $value = $value->value;
         }

--- a/src/Fields/Select.php
+++ b/src/Fields/Select.php
@@ -58,6 +58,13 @@ class Select extends Field implements
                 ->implode(',');
         }
 
+        if (
+            version_compare(version1: PHP_VERSION, version2: '8.0.0', operator: '>=')
+            && $value instanceof \UnitEnum
+        ) {
+            $value = $value->value;
+        }
+
         return (string) ($this->values()[$value] ?? '');
     }
 }

--- a/src/Fields/Select.php
+++ b/src/Fields/Select.php
@@ -60,7 +60,7 @@ class Select extends Field implements
         }
 
         if (
-            version_compare(version1: PHP_VERSION, version2: '8.0.0', operator: '>=')
+            version_compare(version1: PHP_VERSION, version2: '8.1.0', operator: '>=')
             && $value instanceof UnitEnum
         ) {
             $value = $value->value;


### PR DESCRIPTION
If a model uses casting to Enum type, then in Fields\Select we get the error "Illegal offset type"