### PR TITLE
fix(Resource): Fix display components on Moonshine UserResource

### DIFF
--- a/src/Resources/MoonShineUserResource.php
+++ b/src/Resources/MoonShineUserResource.php
@@ -138,14 +138,14 @@ class MoonShineUserResource extends Resource
                 ->canSee(
                     fn (
                         $user
-                    ): bool => $user->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID
+                    ): bool => auth()?->user->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID
                 ),
 
             ChangeLogFormComponent::make('Change log')
                 ->canSee(
                     fn (
                         $user
-                    ): bool => $user->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID
+                    ): bool => auth()?->user->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID
                 ),
         ];
     }

--- a/src/Resources/MoonShineUserResource.php
+++ b/src/Resources/MoonShineUserResource.php
@@ -138,7 +138,7 @@ class MoonShineUserResource extends Resource
                 ->canSee(
                     fn (
                         $user
-                    ): bool => auth()?->user()->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID
+                    ): bool => auth()?->user()?->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID
                 ),
 
             ChangeLogFormComponent::make('Change log')

--- a/src/Resources/MoonShineUserResource.php
+++ b/src/Resources/MoonShineUserResource.php
@@ -138,14 +138,14 @@ class MoonShineUserResource extends Resource
                 ->canSee(
                     fn (
                         $user
-                    ): bool => auth()?->user->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID
+                    ): bool => auth()?->user()->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID
                 ),
 
             ChangeLogFormComponent::make('Change log')
                 ->canSee(
                     fn (
                         $user
-                    ): bool => auth()?->user->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID
+                    ): bool => auth()?->user()->moonshine_user_role_id === MoonshineUserRole::DEFAULT_ROLE_ID
                 ),
         ];
     }


### PR DESCRIPTION
In the canSee method in the $user variable, the entry that we are currently editing is coming. Each user can only give rights to himself and cannot edit the rights of others. I, as the Administrator of the Admin Panel, cannot edit access rights for other users.