### PR TITLE
fix(showWhen): showWhen function

### DIFF
--- a/resources/js/alpine/showWhenFunctions.js
+++ b/resources/js/alpine/showWhenFunctions.js
@@ -40,7 +40,14 @@ export function showWhenVisibilityChange(fieldName, inputs, field) {
     return
   }
 
-  const fieldContainer = inputElement.closest('.form-group')
+  //TODO in resources/views/components/resource-renderable.blade.php put a field in a container
+  let fieldContainer = inputElement.closest('.moonshine-field')
+  if(fieldContainer === null) {
+    fieldContainer = inputElement.closest('.form-group')
+  }
+  if(fieldContainer === null) {
+    fieldContainer = inputElement
+  }
 
   let validateShow = false
 

--- a/resources/views/components/form/input-wrapper.blade.php
+++ b/resources/views/components/form/input-wrapper.blade.php
@@ -6,7 +6,7 @@
     'beforeSlot',
     'afterSlot'
 ])
-<div {{ $attributes->merge(['class' => 'form-group'])
+<div {{ $attributes->merge(['class' => 'form-group moonshine-field'])
     ->only(['class', 'x-show']) }}
     id="wrapper_{{ $attributes->get('id') }}"
 >


### PR DESCRIPTION
Fixed the showWhen function when showing some input elements when the input should have been hidden. The bug occurred when the field consisted of several nested form-group classes. Now a special class has been added to the main container of the field, according to which input is hidden. Also fixed a bug with the fieldContainer field method when passing a parameter with the value false. Input is now hiding correctly.