### PR TITLE
fix(fields): Select group mode

### DIFF
--- a/src/Fields/Select.php
+++ b/src/Fields/Select.php
@@ -58,6 +58,6 @@ class Select extends Field implements
                 ->implode(',');
         }
 
-        return (string) ($this->values()[$value] ?? '');
+        return (string) ($this->smoothedValues()[$value] ?? '');
     }
 }

--- a/src/Fields/Select.php
+++ b/src/Fields/Select.php
@@ -58,6 +58,6 @@ class Select extends Field implements
                 ->implode(',');
         }
 
-        return (string) ($this->smoothedValues()[$value] ?? '');
+        return (string) ($this->flattenValues()[$value] ?? '');
     }
 }

--- a/src/Traits/Fields/SelectTrait.php
+++ b/src/Traits/Fields/SelectTrait.php
@@ -26,6 +26,13 @@ trait SelectTrait
         return $this->options;
     }
 
+    public function smoothedValues() : array
+    {
+        return collect($this->values())->mapWithKeys(function($item, $i) : array {
+            return is_array($item) ? $item : [$i => $item];
+        })->toArray();
+    }
+
     /**
      * @throws JsonException
      */

--- a/src/Traits/Fields/SelectTrait.php
+++ b/src/Traits/Fields/SelectTrait.php
@@ -26,11 +26,11 @@ trait SelectTrait
         return $this->options;
     }
 
-    public function smoothedValues() : array
+    public function flattenValues(): array
     {
-        return collect($this->values())->mapWithKeys(function($item, $i) : array {
-            return is_array($item) ? $item : [$i => $item];
-        })->toArray();
+        return collect($this->values())
+            ->mapWithKeys(fn ($value, $key): array => is_array($value) ? $value : [$key => $value])
+            ->toArray();
     }
 
     /**


### PR DESCRIPTION
Поле Select имеет возможность принимать значения в виде многоуровневого массива - для построения групп.
Но в этом случае выбранное значение не будет отображено в index/show.
Это происходит по той причине, что в функции indexViewValue возвращается значение взятое из массива по ключу.
А если массив поделен на группы - это значение достать не получится.

Мое решение заключается в том, что я добавил новую функцию smoothedValues и использую её в indexViewValue.
Эта функция сглаживает массив до одного уровня, убирая деление на группы.

Я использовал mapWithKeys вместо того-же flatten, дабы не потерять ключи.

------

Остается одна проблема, которую на мой взгляд не нужно решать. Она заключается в том, если в options передали массив поделенный на группы, но при этом не поставили ключи массиву, пример:

```php
'group1' => [
    'test1', // ключ 0
    'test2', // ключ 1
],
'group2' => [
    'test3', // ключ 0
    'test4', // ключ 1
]
``` 

В этом случае при сглаживании некоторые значения пропадут из-за не уникальных ключей.
Можно дописать функцию options, делая ключи уникальными. Но в этом случае, если ключи были и так уникальными мы их просто собьем.

Не вижу делать доп.проверки на то, уникальные ли уже ключи и если нет - делать уникальными. Это задача пользователя, так-что единственное что я рекомендую, упомянуть в документации к информации про группы, что ключи должны быть уникальными.