### PR TITLE
fix(fields): display nested json

### DIFF
--- a/src/Traits/WithFields.php
+++ b/src/Traits/WithFields.php
@@ -156,7 +156,7 @@ trait WithFields
                     }
 
                     foreach ($fields as $field) {
-                        $values[$index][$field->field()] = $field->indexViewValue($data, false);
+                        $values[$index][$field->field()] = $field->indexViewValue($data, true);
                     }
                 }
             }


### PR DESCRIPTION
Исправил ошибку описанную в [issue 408](https://github.com/moonshine-software/moonshine/issues/408).
Честно говоря - я не до конца понимаю, как работает и на что влияет переменная $container в функции indexViewValue. Но смена её с false на true в поле Json исправило эту ошибку.