### PR TITLE
feat: allow to register menu items in automatic mode

### DIFF
--- a/src/MoonShine.php
+++ b/src/MoonShine.php
@@ -27,6 +27,8 @@ class MoonShine
 
     protected static ?Collection $menu = null;
 
+    protected static ?Collection $customItems = null;
+
     public static function path(string $path = ''): string
     {
         return realpath(
@@ -82,7 +84,7 @@ class MoonShine
         self::$pages = self::getPages();
         self::$menu = collect();
 
-        collect($data)->each(function ($item): void {
+        collect($data)->merge(self::getCustomItems())->each(function ($item): void {
             $item = is_string($item) ? new $item() : $item;
 
             if ($item instanceof Resource) {
@@ -192,5 +194,21 @@ class MoonShine
         $middlewares = request()?->route()?->gatherMiddleware() ?? [];
 
         return in_array('auth.moonshine', $middlewares);
+    }
+
+    /**
+     * Get custom menu items for automatic registration
+     */
+    public static function getCustomItems(): Collection
+    {
+        return self::$customItems ?? collect();
+    }
+
+    /**
+     * Set custom menu items to register them automatically later.
+     */
+    public static function customItems(array $items): void
+    {
+        self::$customItems = self::getCustomItems()->merge(collect($items));
     }
 }

--- a/tests/Unit/MoonShineTest.php
+++ b/tests/Unit/MoonShineTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use MoonShine\Menu\MenuGroup;
+use MoonShine\Menu\MenuItem;
 use MoonShine\Menu\MenuSection;
 use MoonShine\MoonShine;
+use MoonShine\Resources\MoonShineUserRoleResource;
 use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
 
 uses()->group('core');
@@ -29,4 +32,41 @@ it('menu', function (): void {
         ->toHaveCount(1)
         ->first()
         ->toBeInstanceOf(MenuSection::class);
+});
+
+it('registers custom single menu item', function (): void {
+    MoonShine::customItems([
+        new MoonShineUserRoleResource(),
+    ]);
+
+    MoonShine::menu([
+        $this->resource,
+    ]);
+
+    $menu = MoonShine::getMenu();
+    expect($menu)
+        ->toBeCollection()
+        ->toHaveCount(2)
+        ->and($menu->last()->resource())
+        ->toBeInstanceOf(MoonShineUserRoleResource::class);
+});
+
+it('registers custom group menu item', function (): void {
+    MoonShine::customItems([
+        MenuGroup::make('Permission', [
+            MenuItem::make('Roles', new MoonShineUserRoleResource())
+        ]),
+    ]);
+
+    MoonShine::menu([
+        $this->resource,
+    ]);
+
+    $menuLast = MoonShine::getMenu()->last();
+    expect($menuLast)
+        ->toBeInstanceOf(MenuGroup::class)
+        ->and($menuLast->items())
+        ->toHaveCount(1)
+        ->and($menuLast->items()->first()->resource())
+        ->toBeInstanceOf(MoonShineUserRoleResource::class);
 });


### PR DESCRIPTION
Новый функционал позволяет авторам пакетов регистрировать свои пункты меню. Для этого нужно вызвать метод   `MoonShine::customItems()` в методе `boot()` пакетного сервис провайдера. Передавать в метод  `MoonShine::customItems()` можно всё тоже самое, что передаётся в метод `MoonShine::menu()` стандартного провайдера муншайн `App\Providers\MoonShineServiceProvider`. Например:
```php
<?php

declare(strict_types=1);

namespace Acme\CustomPackage;

use Acme\CustomPackage\Resources\CustomResource;
use Illuminate\Support\ServiceProvider;
use MoonShine\MoonShine;

class CustomServiceProvider extends ServiceProvider
{
    public function boot(): void
    {
        app(MoonShine::class)->customItems([new CustomResource()]);
    }
}
```