### PR TITLE
fix: switch Resource::softDeletes() to use object

### DIFF
--- a/src/Models/SoftDeleteMoonshineUser.php
+++ b/src/Models/SoftDeleteMoonshineUser.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Models;
+
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class SoftDeleteMoonshineUser extends MoonshineUser
+{
+    use SoftDeletes;
+}

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -440,7 +440,7 @@ abstract class Resource implements ResourceContract
     {
         return in_array(
             SoftDeletes::class,
-            class_uses_recursive(static::$model),
+            class_uses_recursive(get_class($this->getModel())),
             true
         );
     }

--- a/tests/Unit/Resources/ResourceTestTest.php
+++ b/tests/Unit/Resources/ResourceTestTest.php
@@ -12,6 +12,7 @@ use MoonShine\FormActions\FormAction;
 use MoonShine\ItemActions\ItemAction;
 use MoonShine\ItemActions\ItemActions;
 use MoonShine\Models\MoonshineUser;
+use MoonShine\Models\SoftDeleteMoonshineUser;
 use MoonShine\QueryTags\QueryTag;
 use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
 
@@ -167,9 +168,19 @@ it('resource authorization', function (): void {
         ->toBeFalse();
 });
 
-it('soft deletes', function (): void {
+it('does not soft deleted', function (): void {
     expect($this->resource->softDeletes())
         ->toBeFalse();
+});
+
+it('soft deleted', function (): void {
+    $resource = TestResourceBuilder::new(
+        SoftDeleteMoonshineUser::class,
+        true
+    );
+
+    expect($resource->softDeletes())
+        ->toBeTrue();
 });
 
 it('precognition mode', function (): void {


### PR DESCRIPTION
Иногда в ресурсах нужно привязать модель динамически, основываясь на некой бизнес логике. Для этого вместо статического поля ресурса `$model` можно использовать метод `getModel()` ресурса. Этот метод возвращает объект модели. Но проверка модели на _soft delete_ в текущей реализации работает с полем `$model`, которое в подобном случае будет пустым. Данный PR исправляет этот баг.