### PR TITLE
fix: softDeletes() performance optimization

### DIFF
--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -438,11 +438,7 @@ abstract class Resource implements ResourceContract
      */
     public function softDeletes(): bool
     {
-        return in_array(
-            SoftDeletes::class,
-            class_uses_recursive($this->getModel()::class),
-            true
-        );
+        return isset(class_uses_recursive($this->getModel())[SoftDeletes::class]);
     }
 
     public function relatable(): self


### PR DESCRIPTION
Сложность по времени функции `in_array()` - `O(n)`, где `n` - размер входного массива. Если посмотреть, как реализована функция `class_uses_recursive()`, можно заметить, что ключи и значения итогового массива равны. А это значит, что для поиска мы можем использовать ключи, а не значения, потому что сложность по времени поиска по ключам - `O(1)`.  Данный фикс предлагает использование конструкции `isset()` для поиска по ключам.