### PR TITLE
fix: allow itemsPerPage to be configurable

### DIFF
--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -28,6 +28,11 @@ trait ResourceModelQuery
 
     protected ?Builder $customBuilder = null;
 
+    public static function getItemsPerPage(): int
+    {
+        return static::$itemsPerPage;
+    }
+
     /**
      * @throws Throwable
      */
@@ -37,10 +42,10 @@ trait ResourceModelQuery
             ->when(
                 static::$simplePaginate,
                 fn (Builder $query): Paginator => $query->simplePaginate(
-                    static::$itemsPerPage
+                    static::getItemsPerPage()
                 ),
                 fn (Builder $query): LengthAwarePaginator => $query->paginate(
-                    static::$itemsPerPage
+                    static::getItemsPerPage()
                 ),
             )
             ->appends(request()->except('page'));

--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -28,11 +28,6 @@ trait ResourceModelQuery
 
     protected ?Builder $customBuilder = null;
 
-    public static function getItemsPerPage(): int
-    {
-        return static::$itemsPerPage;
-    }
-
     /**
      * @throws Throwable
      */
@@ -42,10 +37,10 @@ trait ResourceModelQuery
             ->when(
                 static::$simplePaginate,
                 fn (Builder $query): Paginator => $query->simplePaginate(
-                    static::getItemsPerPage()
+                    $this->getItemsPerPage()
                 ),
                 fn (Builder $query): LengthAwarePaginator => $query->paginate(
-                    static::getItemsPerPage()
+                    $this->getItemsPerPage()
                 ),
             )
             ->appends(request()->except('page'));
@@ -172,5 +167,10 @@ trait ResourceModelQuery
     public function isPaginationUsed(): bool
     {
         return $this->usePagination;
+    }
+
+    protected function getItemsPerPage(): int
+    {
+        return static::$itemsPerPage;
     }
 }


### PR DESCRIPTION
Иногда требуется реализовывать `ResourceModelQuery::$itemsPerPage` на основе некой бизнес логики. Например, автор пакета хочет сделать этот функционал настраиваемым через функцию `config()`. Данный PR добавляет такую возможность. Например, в неком ресурсе можно сделать так:

```php
<?php

declare(strict_types=1);

namespace Acme\CustomPackage\Resources;

use MoonShine\Resources\Resource;

class CustomResource extends Resource
{
    public static function getItemsPerPage(): int
    {
        return config('resources.custom.items_per_page');
    }
}
```