### PR TITLE
fix: allow 'with' to be configurable

### DIFF
--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -117,7 +117,7 @@ trait ResourceModelQuery
 
     public function hasWith(): bool
     {
-        return static::$with !== [];
+        return static::getWith() !== [];
     }
 
     public function getWith(): array

--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -117,7 +117,7 @@ trait ResourceModelQuery
 
     public function hasWith(): bool
     {
-        return static::getWith() !== [];
+        return $this->getWith() !== [];
     }
 
     public function getWith(): array


### PR DESCRIPTION
То же самое, что  и #421 , но для статической переменной `ResourceModelQuery::$with`.