### PR TITLE
feat(traits): SelectTrait, change options method

### DIFF
--- a/src/Traits/Fields/SelectTrait.php
+++ b/src/Traits/Fields/SelectTrait.php
@@ -10,13 +10,15 @@ use JsonException;
 use MoonShine\Fields\Enum;
 use UnitEnum;
 
+use Closure;
+
 trait SelectTrait
 {
     protected array $options = [];
 
-    public function options(array $data): static
+    public function options(array|Closure $data): static
     {
-        $this->options = $data;
+        $this->options = is_callable($data) ? call_user_func($data) : $data;
 
         return $this;
     }


### PR DESCRIPTION
The options method now also gets functions, this is quite handy if for example I have all types of statuses saved in the config file and I just want to return them in a nice format.

It's handy for moments like this. And in general it doesn't interfere.

                        Select::make(trans('moonshine::general.status'), 'status')
                            ->options(function(){
                                $result = [];
                                foreach(config('orders.order_status') as $key => $value){
                                    $result[$value] = $key;
                                }

                                return $result;
                            })