### PR TITLE
Fix assets field [2.x] 

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -12,7 +12,6 @@ use MoonShine\Traits\Fields\Applies;
 use MoonShine\Traits\Fields\LinkTrait;
 use MoonShine\Traits\Fields\ShowOrHide;
 use MoonShine\Traits\Fields\ShowWhen;
-use MoonShine\Traits\Makeable;
 use MoonShine\Traits\WithHint;
 use MoonShine\Traits\WithIsNowOnRoute;
 use MoonShine\Traits\WithLabel;
@@ -22,7 +21,6 @@ use MoonShine\Traits\WithLabel;
  */
 abstract class Field extends FormElement
 {
-    use Makeable;
     use WithLabel;
     use WithHint;
     use ShowWhen;

--- a/src/Fields/FormElement.php
+++ b/src/Fields/FormElement.php
@@ -14,12 +14,14 @@ use MoonShine\Contracts\MoonShineRenderable;
 use MoonShine\Helpers\Condition;
 use MoonShine\Traits\Fields\WithFormElementAttributes;
 use MoonShine\Traits\HasCanSee;
+use MoonShine\Traits\Makeable;
 use MoonShine\Traits\WithAssets;
 use MoonShine\Traits\WithComponentAttributes;
 use MoonShine\Traits\WithView;
 
 abstract class FormElement implements MoonShineRenderable, HasAssets
 {
+    use Makeable;
     use WithFormElementAttributes;
     use WithComponentAttributes;
     use WithView;


### PR DESCRIPTION
Перенес makeable в FormElement, т.к. именно в нем находится переопределяющий метод afterMake 