### PR TITLE
fix command create custom page [1.5.x]

### DIFF
--- a/src/Commands/CustomPageCommand.php
+++ b/src/Commands/CustomPageCommand.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace MoonShine\Commands;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Support\Facades\File;
 use MoonShine\MoonShine;
 
 class CustomPageCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:custom {name?} {--a|alias=} {--t|title=} {--view=}';
+    protected $signature = 'moonshine:page {name?} {--a|alias=} {--t|title=} {--view=}';
 
     protected $description = 'Create custom page';
 
@@ -32,9 +33,11 @@ class CustomPageCommand extends MoonShineCommand
 
         $alias = $this->option('alias') ?? $name->kebab()->lower()->value();
 
-        $view = $this->option('view') ?? $name->snake()->lower()->value();
+        $view = $this->option('view') ?? '';
 
         $resource = $this->getDirectory() . "/Pages/{$name}.php";
+
+        File::ensureDirectoryExists(dirname($resource));
 
         $this->copyStub('CustomPage', $resource, [
             '{namespace}' => MoonShine::namespace('\Pages'),
@@ -45,12 +48,12 @@ class CustomPageCommand extends MoonShineCommand
         ]);
 
         $this->components->info(
-            "{$name}CustomPage file was created: " . str_replace(
+            "{$name} file was created: " . str_replace(
                 base_path(),
                 '',
                 $resource
             )
         );
-        $this->components->info('Now register custom page in menu');
+        $this->components->info('Now register page in menu');
     }
 }

--- a/src/Providers/MoonShineServiceProvider.php
+++ b/src/Providers/MoonShineServiceProvider.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
+use MoonShine\Commands\CustomPageCommand;
 use MoonShine\Commands\InstallCommand;
 use MoonShine\Commands\ResourceCommand;
 use MoonShine\Commands\UserCommand;
@@ -31,6 +32,7 @@ class MoonShineServiceProvider extends ServiceProvider
         InstallCommand::class,
         ResourceCommand::class,
         UserCommand::class,
+        CustomPageCommand::class,
     ];
 
     protected array $middlewareGroups = [

--- a/stubs/CustomPage.stub
+++ b/stubs/CustomPage.stub
@@ -4,7 +4,7 @@ namespace {namespace};
 
 use MoonShine\Resources\CustomPage;
 
-class DummyCustomPage extends CustomPage
+class Dummy extends CustomPage
 {
 	public string $title = 'DummyTitle';
 


### PR DESCRIPTION
Поправлена команда для добавления кастомных страниц:
- переименована команда в page
- добавлена в MoonShineServiceProvider
- удален CustomPage из названий классов
- по дефолту view = ''