### PR TITLE
feat(table-header): Label

### DIFF
--- a/resources/views/components/table/index.blade.php
+++ b/resources/views/components/table/index.blade.php
@@ -17,7 +17,7 @@
                 @if(is_array($columns))
                     @foreach($columns as $name => $label)
                         <th>
-                            {{ $label }}
+                            {!! $label !!}
                         </th>
                     @endforeach
                 @endif

--- a/resources/views/crud/shared/table-head.blade.php
+++ b/resources/views/crud/shared/table-head.blade.php
@@ -11,7 +11,7 @@
 @foreach($resource->getFields()->indexFields() as $field)
     <th>
         <div class="flex items-baseline gap-x-1">
-            {{ $field->label() }}
+            {!! $field->label() !!}
 
             @if(!$resource->isPreviewMode() && $field->isSortable())
                 <a href="{{ $field->sortQuery() }}" class="shrink-0" @click.prevent="canBeAsync">


### PR DESCRIPTION
Unescaped string in labels of table, for use like: "Цена: <br> В прайсе" on stack fields