### PR TITLE
Fix: assets extension

### DIFF
--- a/src/Utilities/AssetManager.php
+++ b/src/Utilities/AssetManager.php
@@ -27,7 +27,7 @@ class AssetManager
     {
         return collect($this->assets)
             ->filter(
-                fn ($asset): int|bool => preg_match('/\.js$/', (string) $asset)
+                fn ($asset): int|bool => str_contains((string) $asset, '.js')
             )
             ->map(
                 fn ($asset): string => "<script src='" . asset(
@@ -40,7 +40,7 @@ class AssetManager
     {
         return collect($this->assets)
             ->filter(
-                fn ($asset): int|bool => preg_match('/\.css$/', (string) $asset)
+                fn ($asset): int|bool => str_contains((string) $asset, '.css')
             )
             ->map(
                 fn ($asset): string => "<link href='" . asset(


### PR DESCRIPTION
The regular expression used blocks the addition of assets with additional get parameters. Since working with regular expressions requires more computing resources, it is proposed to use the native PHP function str_contains.
Before:
`
 app(AssetManager::class)->add([
        '/libs/mathjax/MathJax.js?config=TeX-MML-AM_HTMLorMML', // will not be added
        '/libs/mathjax/config.js', // will be added
        '/libs/mathjax/preview.js', // will be added
      ]);
`
After:
`
 app(AssetManager::class)->add([
        '/libs/mathjax/MathJax.js?config=TeX-MML-AM_HTMLorMML', // will be added
        '/libs/mathjax/config.js', // will be added
        '/libs/mathjax/preview.js', // will be added
      ]);
`