### PR TITLE
New features: loading parent resource values and HasMany onlyLink display [2.x]

### DIFF
--- a/routes/moonshine.php
+++ b/routes/moonshine.php
@@ -25,7 +25,7 @@ Route::prefix(config('moonshine.route.prefix', ''))
                     ->only(['store', 'update', 'destroy']);
 
                 Route::any('handler/{handlerUri}', HandlerController::class)->name('handler');
-                Route::get('{pageUri}', PageController::class)->name('resource.page');
+                Route::get('{pageUri}/{parentId?}', PageController::class)->name('resource.page');
                 Route::put('/{resourceItem}', UpdateColumnController::class)->name('resource.update-column');
             });
 

--- a/src/Fields/Relationships/HasMany.php
+++ b/src/Fields/Relationships/HasMany.php
@@ -10,19 +10,14 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use MoonShine\ActionButtons\ActionButton;
-use MoonShine\Buttons\HasOneField\HasManyCreateButton;
 use MoonShine\Buttons\IndexPage\DeleteButton;
 use MoonShine\Buttons\IndexPage\DetailButton;
 use MoonShine\Buttons\IndexPage\FormButton;
 use MoonShine\Buttons\IndexPage\MassDeleteButton;
 use MoonShine\Components\TableBuilder;
 use MoonShine\Contracts\Fields\HasFields;
-use MoonShine\Decorations\Block;
 use MoonShine\Fields\Field;
 use MoonShine\Fields\Fields;
-use MoonShine\MoonShineRouter;
-use MoonShine\Resources\ModelResource;
-use MoonShine\Support\Condition;
 use MoonShine\Traits\WithFields;
 use Throwable;
 
@@ -78,11 +73,13 @@ class HasMany extends ModelRelationField implements HasFields
 
     public function onlyLink(Closure|bool|null $condition = null): static
     {
-        $this->onlyLink = $condition;
-
         if(is_null($condition)) {
             $this->onlyLink = true;
+
+            return $this;
         }
+
+        $this->onlyLink = $condition;
 
         return $this;
     }
@@ -140,10 +137,10 @@ class HasMany extends ModelRelationField implements HasFields
         $parentName = str_replace('-resource', '', moonshineRequest()->getResourceUri());
 
         return ActionButton::make(
-            __('moonshine::ui.show'). " ($countItems)",
+            "($countItems)",
             to_page($this->getResource(), 'index-page', ['parentId' => $parentName . '-'. $casted->{$casted->getKeyName()}])
         )
-            ->customAttributes(['class' => 'btn btn-primary'])
+            ->icon('heroicons.outline.eye')
             ->render()
         ;
     }

--- a/src/Fields/Relationships/HasMany.php
+++ b/src/Fields/Relationships/HasMany.php
@@ -33,6 +33,8 @@ class HasMany extends ModelRelationField implements HasFields
 
     protected Closure | bool $onlyLink = false;
 
+    protected ?string $linkRelation = null;
+
     public function preview(): View|string
     {
         $casted = $this->getRelatedModel();
@@ -71,8 +73,10 @@ class HasMany extends ModelRelationField implements HasFields
         return $this;
     }
 
-    public function onlyLink(Closure|bool|null $condition = null): static
+    public function onlyLink(?string $linkRelation = null, Closure|bool|null $condition = null): static
     {
+        $this->linkRelation = $linkRelation;
+
         if(is_null($condition)) {
             $this->onlyLink = true;
 
@@ -134,11 +138,13 @@ class HasMany extends ModelRelationField implements HasFields
 
         $countItems = $this->toValue()->count();
 
-        $parentName = str_replace('-resource', '', moonshineRequest()->getResourceUri());
+        if(is_null($relationName = $this->linkRelation)) {
+            $relationName = str_replace('-resource', '', moonshineRequest()->getResourceUri());
+        }
 
         return ActionButton::make(
             "($countItems)",
-            to_page($this->getResource(), 'index-page', ['parentId' => $parentName . '-'. $casted->{$casted->getKeyName()}])
+            to_page($this->getResource(), 'index-page', ['parentId' => $relationName . '-'. $casted->{$casted->getKeyName()}])
         )
             ->icon('heroicons.outline.eye')
             ->render()
@@ -184,12 +190,14 @@ class HasMany extends ModelRelationField implements HasFields
 
     protected function linkValue()
     {
-        $parentName = str_replace('-resource', '', moonshineRequest()->getResourceUri());
+        if(is_null($relationName = $this->linkRelation)) {
+            $relationName = str_replace('-resource', '', moonshineRequest()->getResourceUri());
+        }
 
         return
             ActionButton::make(
                 __('moonshine::ui.show'). " ({$this->toValue()->total()})",
-                to_page($this->getResource(), 'index-page', ['parentId' => $parentName . '-' . request('resourceItem')])
+                to_page($this->getResource(), 'index-page', ['parentId' => $relationName . '-' . request('resourceItem')])
             )
                 ->customAttributes(['class' => 'btn btn-primary'])
         ;

--- a/src/Fields/Relationships/HasMany.php
+++ b/src/Fields/Relationships/HasMany.php
@@ -87,6 +87,28 @@ class HasMany extends ModelRelationField implements HasFields
 
     protected function resolvePreview(): View|string
     {
+        return $this->isOnlyLink() ? $this->linkPreview() : $this->tablePreview();
+    }
+
+    protected function linkPreview(): View|string
+    {
+        $casted = $this->getRelatedModel();
+
+        $items = $casted->{$this->getRelationName()}->count();
+
+        $parentName = str_replace('-resource', '', moonshineRequest()->getResourceUri());
+
+        return ActionButton::make(
+            __('moonshine::ui.show'). " ($items)",
+            to_page($this->getResource(), 'index-page', ['parentId' => $parentName . '-'. $casted->{$casted->getKeyName()}])
+        )
+            ->customAttributes(['class' => 'btn btn-primary'])
+            ->render()
+        ;
+    }
+
+    protected function tablePreview(): View|string
+    {
         $casted = $this->getRelatedModel();
 
         $items = $casted->{$this->getRelationName()};
@@ -121,14 +143,10 @@ class HasMany extends ModelRelationField implements HasFields
 
     protected function resolveValue(): mixed
     {
-        if($this->isOnlyLink()) {
-            return $this->buttonsValueView();
-        }
-
-        return $this->tableValueView();
+        return $this->isOnlyLink() ? $this->linkValue() : $this->tableValue();
     }
 
-    protected function buttonsValueView()
+    protected function linkValue()
     {
         $resource = $this->getResource();
 
@@ -154,7 +172,7 @@ class HasMany extends ModelRelationField implements HasFields
         ;
     }
 
-    protected function tableValueView()
+    protected function tableValue()
     {
         $resource = $this->getResource();
 

--- a/src/Fields/Relationships/HasOne.php
+++ b/src/Fields/Relationships/HasOne.php
@@ -16,18 +16,24 @@ class HasOne extends HasMany
 {
     protected bool $toOne = true;
 
+    public function value(bool $withOld = true): mixed
+    {
+        $this->setValue($this->getRelatedModel()->{$this->getRelationName()});
+
+        return ModelRelationField::value($withOld);
+    }
+
     /**
      * @throws FieldException
      * @throws Throwable
      */
     protected function resolveValue(): mixed
     {
-        $casted = $this->getRelatedModel();
-
-        $item = $casted->{$this->getRelationName()};
-
         $resource = $this->getResource();
+
         $parentResource = moonshineRequest()->getResource();
+
+        $item = $this->toValue();
 
         if(is_null($parentResource)) {
             throw new FieldException('Parent resource is required');

--- a/src/MoonShineRequest.php
+++ b/src/MoonShineRequest.php
@@ -73,6 +73,11 @@ class MoonShineRequest extends Request
         return $this->route('resourceUri');
     }
 
+    public function getParentResourceId(): ?string
+    {
+        return $this->route('parentId');
+    }
+
     public function getPageUri(): ?string
     {
         return $this->route('pageUri');

--- a/src/MoonShineRequest.php
+++ b/src/MoonShineRequest.php
@@ -78,6 +78,22 @@ class MoonShineRequest extends Request
         return $this->route('parentId');
     }
 
+    public function getParentRelationName(): ?string
+    {
+        return
+            ! is_null($parentResource = $this->getParentResourceId())
+                ? explode('-', $parentResource)[0] ?? null
+                : null;
+    }
+
+    public function getParentRelationId(): int|string|null
+    {
+        return
+            ! is_null($parentResource = $this->getParentResourceId())
+                ? explode('-', $parentResource)[1] ?? null
+                : null;
+    }
+
     public function getPageUri(): ?string
     {
         return $this->route('pageUri');

--- a/src/Pages/Crud/FormPage.php
+++ b/src/Pages/Crud/FormPage.php
@@ -121,7 +121,7 @@ class FormPage extends Page
         foreach ($this->getResource()->getOutsideFields() as $field) {
             $components[] = Divider::make($field->label());
 
-            if (! $field->toOne() && ! $field->isOnlyLink()) {
+            if (! $field->toOne()) {
                 $components[] = HasManyCreateButton::for($field, $item->getKey());
                 $components[] = Divider::make();
             }

--- a/src/Pages/Crud/FormPage.php
+++ b/src/Pages/Crud/FormPage.php
@@ -121,7 +121,7 @@ class FormPage extends Page
         foreach ($this->getResource()->getOutsideFields() as $field) {
             $components[] = Divider::make($field->label());
 
-            if (! $field->toOne()) {
+            if (! $field->toOne() && ! $field->isOnlyLink()) {
                 $components[] = HasManyCreateButton::for($field, $item->getKey());
                 $components[] = Divider::make();
             }

--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use MoonShine\Attributes\SearchUsingFullText;
 use MoonShine\Contracts\ApplyContract;
+use MoonShine\Exceptions\ResourceException;
 use MoonShine\Fields\Field;
 use MoonShine\MoonShineRouter;
 use MoonShine\QueryTags\QueryTag;
@@ -326,7 +327,7 @@ trait ResourceModelQuery
             return $this;
         }
 
-        return $this;
+        throw new ResourceException("Relation $relation not found for current resource");
     }
 
     public function hasWith(): bool

--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MoonShine\Traits\Resource;
 
+use App\Models\Comment;
+use App\MoonShine\Resources\CategoryResource;
 use Closure;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
@@ -15,6 +17,7 @@ use Illuminate\Support\Facades\Cache;
 use MoonShine\Attributes\SearchUsingFullText;
 use MoonShine\Contracts\ApplyContract;
 use MoonShine\Fields\Field;
+use MoonShine\MoonShineRouter;
 use MoonShine\QueryTags\QueryTag;
 use MoonShine\Resources\ModelResource;
 use MoonShine\Support\Attributes;
@@ -39,6 +42,8 @@ trait ResourceModelQuery
     protected ?Builder $query = null;
 
     protected ?Builder $customBuilder = null;
+
+    protected array $parentRelations = [];
 
     public function getItemID(): int|string|null
     {
@@ -127,6 +132,7 @@ trait ResourceModelQuery
         $this->resolveTags()
             ->resolveSearch()
             ->resolveFilters()
+            ->resolveParentResource()
             ->resolveOrder(
                 request('sort.column', $this->sortColumn()),
                 request('sort.direction', $this->sortDirection())
@@ -286,6 +292,37 @@ trait ResourceModelQuery
         return $this;
     }
 
+    protected function resolveParentResource(): self
+    {
+        $parentIdUri = moonshineRequest()->getParentResourceId();
+
+        if(is_null($parentIdUri) || empty($this->parentRelations())) {
+            return $this;
+        }
+
+        $relation = '';
+        $parentId = 0;
+
+        foreach ($this->parentRelations() as $relationName) {
+            if(str_contains($parentIdUri, $relationName)) {
+                $relation = $relationName;
+                $parentId = str_replace($relationName. '-', '', $parentIdUri);
+                break;
+            }
+        }
+
+        if(empty($relation)) {
+            return $this;
+        }
+
+        $this->query()->where(
+            $this->getModel()->{$relation}()->getForeignKeyName(),
+            $parentId
+        );
+
+        return $this;
+    }
+
     public function hasWith(): bool
     {
         return $this->with !== [];
@@ -329,5 +366,10 @@ trait ResourceModelQuery
     public function isPaginationUsed(): bool
     {
         return $this->usePagination;
+    }
+
+    public function parentRelations(): array
+    {
+        return $this->parentRelations;
     }
 }

--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -294,17 +294,10 @@ trait ResourceModelQuery
 
     protected function resolveParentResource(): self
     {
-        $parentIdUri = moonshineRequest()->getParentResourceId();
-
-        if(is_null($parentIdUri)) {
-            return $this;
-        }
-
-        $parentInfo = explode('-', $parentIdUri);
-        $relation = $parentInfo[0] ?? null;
-        $parentId = $parentInfo[1] ?? null;
-
-        if(is_null($relation) || is_null($parentId)) {
+        if(
+            is_null($relation = moonshineRequest()->getParentRelationName())
+            || is_null($parentId = moonshineRequest()->getParentRelationId())
+        ) {
             return $this;
         }
 

--- a/tests/Feature/Fields/Relationships/HasManyFieldTest.php
+++ b/tests/Feature/Fields/Relationships/HasManyFieldTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 uses()->group('model-relation-fields');
 uses()->group('has-many-field');
 
+use MoonShine\Fields\Field;
 use MoonShine\Fields\ID;
 use MoonShine\Fields\Relationships\HasMany;
 use MoonShine\Fields\Text;
@@ -85,7 +86,7 @@ it('onlyLink preview condition', function () {
         ID::make(),
         Text::make('Имя', 'name'),
         HasMany::make('Comments title', 'comments', resource: new TestCommentResource())
-            ->onlyLink(function ($count) {
+            ->onlyLink(condition: function (int $count): bool {
                 return $count > 10;
             })
         ,
@@ -107,7 +108,7 @@ it('onlyLink value condition', function () {
         ID::make(),
         Text::make('Имя', 'name'),
         HasMany::make('Comments title', 'comments', resource: new TestCommentResource())
-            ->onlyLink(function ($count, $field) {
+            ->onlyLink(condition: function (int $count, Field $field): bool {
                 return $field->toValue()->total() > 20;
             })
         ,

--- a/tests/Feature/Fields/Relationships/HasManyFieldTest.php
+++ b/tests/Feature/Fields/Relationships/HasManyFieldTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+uses()->group('model-relation-fields');
+uses()->group('has-many-field');
+
+use MoonShine\Fields\ID;
+use MoonShine\Fields\Relationships\HasMany;
+use MoonShine\Fields\Text;
+use MoonShine\Tests\Fixtures\Models\Item;
+use MoonShine\Tests\Fixtures\Resources\TestCommentResource;
+use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
+
+it('onlyLink preview', function () {
+    createItem(countComments: 6);
+
+    $resource = TestResourceBuilder::new(Item::class)->setTestFields([
+        ID::make(),
+        Text::make('Имя', 'name'),
+        HasMany::make('Комментарии', 'comments', resource: new TestCommentResource())
+            ->onlyLink(),
+    ]);
+
+    asAdmin()
+        ->get(to_page($resource, 'index-page'))
+        ->assertOk()
+        ->assertSee('(6)')
+    ;
+});
+
+it('onlyLink preview empty', function () {
+    createItem(countComments: 0);
+
+    $resource = TestResourceBuilder::new(Item::class)->setTestFields([
+        ID::make(),
+        Text::make('Имя', 'name'),
+        HasMany::make('Комментарии', 'comments', resource: new TestCommentResource())
+            ->onlyLink(),
+    ]);
+
+    asAdmin()
+        ->get(to_page($resource, 'index-page'))
+        ->assertOk()
+    ;
+});
+
+it('onlyLink value', function () {
+    $item = createItem(countComments: 16);
+
+    $resource = TestResourceBuilder::new(Item::class)->setTestFields([
+        ID::make(),
+        Text::make('Имя', 'name'),
+        HasMany::make('Комментарии', 'comments', resource: new TestCommentResource())
+            ->onlyLink(),
+    ]);
+
+    asAdmin()
+        ->get(to_page($resource, 'form-page', ['resourceItem' => $item->id]))
+        ->assertSee('(16)')
+        ->assertOk()
+    ;
+});
+
+it('onlyLink value empty', function () {
+    $item = createItem(countComments: 0);
+
+    $resource = TestResourceBuilder::new(Item::class)->setTestFields([
+        ID::make(),
+        Text::make('Имя', 'name'),
+        HasMany::make('Комментарии', 'comments', resource: new TestCommentResource())
+            ->onlyLink(),
+    ]);
+
+    asAdmin()
+        ->get(to_page($resource, 'form-page', ['resourceItem' => $item->id]))
+        ->assertOk()
+    ;
+});
+
+it('onlyLink preview condition', function () {
+    $item = createItem(countComments: 6);
+
+    $resource = TestResourceBuilder::new(Item::class)->setTestFields([
+        ID::make(),
+        Text::make('Имя', 'name'),
+        HasMany::make('Comments title', 'comments', resource: new TestCommentResource())
+            ->onlyLink(function ($count) {
+                return $count > 10;
+            })
+        ,
+    ]);
+
+    asAdmin()
+        ->get(to_page($resource, 'index-page'))
+        ->assertOk()
+        ->assertSee('Comments title')
+        ->assertSee($item->comments[0]->content)
+        ->assertDontSee('(6)')
+    ;
+});
+
+it('onlyLink value condition', function () {
+    $item = createItem(countComments: 16);
+
+    $resource = TestResourceBuilder::new(Item::class)->setTestFields([
+        ID::make(),
+        Text::make('Имя', 'name'),
+        HasMany::make('Comments title', 'comments', resource: new TestCommentResource())
+            ->onlyLink(function ($count, $field) {
+                return $field->toValue()->total() > 20;
+            })
+        ,
+    ]);
+
+    asAdmin()
+        ->get(to_page($resource, 'form-page', ['resourceItem' => $item->id]))
+        ->assertOk()
+        ->assertSee('Comments title')
+        ->assertSee($item->comments[15]->content)
+        ->assertDontSee('(16)')
+    ;
+});


### PR DESCRIPTION
1. The {parentId?} parameter has been added to the page route. If you specify it, Moonshine will start building a request on the page based on the parentId value. The parentId contains {name of the relation}-{id of the relation}, for example user-10. The full path might look like this:

 `/resource/comment-resource/index-page/user-10`

All comments with user_id = 10 will be built. If you need to specify a non-standard name for a relationship, you need to add it to the $parentRelations array of the resource:

```php
class CommentResource extends ModelResource
{
    protected array $parentRelations = ['moonshineUser'];
```
Now this relationship can be specified in the request /resource/comment-resource/index-page/moonshineUser-10

2. Added onlyLink method for HasMany. This method allows, instead of displaying a table with values, to show a link to the HasMany resource, which indicates the number of these values. Method signature:

`public function onlyLink(?string $linkRelation = null, Closure|bool|null $condition = null): static`

$linkRelation - specify a link to the relation
$condition - bool or closure that should return bool, signature:

`function (int $count, Field $field): bool`

Examples:

```php
HasMany::make('Comments')->onlyLink()
```

```php
HasMany::make('Comments')->onlyLink('moonshineUser') ..//the link to the resource will look like /index-page/moonshineUser-{id}
```

```php
HasMany::make('Comments', 'comments')
  ->onlyLink(condition: function (int $count, Field $field): bool {
      return $count > 10;
  })