### PR TITLE
feat(pages):  PageType (issue #508) [2.x]

### DIFF
--- a/src/Enums/PageType.php
+++ b/src/Enums/PageType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Enums;
+
+enum PageType: string
+{
+    case  INDEX = 'index-page';
+
+    case  FORM = 'form-page';
+
+    case  DETAIL = 'detail-page';
+
+    public static function getTypeFromUri(string $uri): ?PageType
+    {
+        return match ($uri) {
+            'index-page' => PageType::INDEX,
+            'form-page' => PageType::FORM,
+            'detail-page' => PageType::DETAIL,
+            default => null
+        };
+    }
+}

--- a/src/Pages/Crud/DetailPage.php
+++ b/src/Pages/Crud/DetailPage.php
@@ -11,11 +11,14 @@ use MoonShine\Decorations\Block;
 use MoonShine\Decorations\Divider;
 use MoonShine\Decorations\Flex;
 use MoonShine\Decorations\Fragment;
+use MoonShine\Enums\PageType;
 use MoonShine\Pages\Page;
 use Throwable;
 
 class DetailPage extends Page
 {
+    protected ?PageType $pageType = PageType::DETAIL;
+
     public function breadcrumbs(): array
     {
         $breadcrumbs = parent::breadcrumbs();

--- a/src/Pages/Crud/FormPage.php
+++ b/src/Pages/Crud/FormPage.php
@@ -9,12 +9,15 @@ use MoonShine\Components\FormBuilder;
 use MoonShine\Decorations\Divider;
 use MoonShine\Decorations\Flex;
 use MoonShine\Decorations\Fragment;
+use MoonShine\Enums\PageType;
 use MoonShine\Fields\Fields;
 use MoonShine\Fields\Hidden;
 use MoonShine\Pages\Page;
 
 class FormPage extends Page
 {
+    protected ?PageType $pageType = PageType::FORM;
+
     public function breadcrumbs(): array
     {
         $breadcrumbs = parent::breadcrumbs();

--- a/src/Pages/Crud/IndexPage.php
+++ b/src/Pages/Crud/IndexPage.php
@@ -23,12 +23,15 @@ use MoonShine\Decorations\Flex;
 use MoonShine\Decorations\Fragment;
 use MoonShine\Decorations\Grid;
 use MoonShine\Decorations\LineBreak;
+use MoonShine\Enums\PageType;
 use MoonShine\Forms\FiltersForm;
 use MoonShine\Pages\Page;
 use Throwable;
 
 class IndexPage extends Page
 {
+    protected ?PageType $pageType = PageType::INDEX;
+
     /**
      * @throws Throwable
      */

--- a/src/Pages/Page.php
+++ b/src/Pages/Page.php
@@ -10,6 +10,7 @@ use MoonShine\Contracts\HasResourceContract;
 use MoonShine\Contracts\Menu\MenuFiller;
 use MoonShine\Contracts\MoonShineRenderable;
 use MoonShine\Contracts\Resources\ResourceContract;
+use MoonShine\Enums\PageType;
 use MoonShine\MoonShineRouter;
 use MoonShine\Traits\HasResource;
 use MoonShine\Traits\Makeable;
@@ -31,6 +32,8 @@ abstract class Page implements MoonShineRenderable, HasResourceContract, MenuFil
     protected string $subtitle = '';
 
     protected string $layout = 'moonshine::layouts.app';
+
+    protected ?PageType $pageType = null;
 
     public function __construct(?string $title = null, ?string $alias = null, ?ResourceContract $resource = null)
     {
@@ -64,6 +67,11 @@ abstract class Page implements MoonShineRenderable, HasResourceContract, MenuFil
     protected function bottomLayer(): array
     {
         return [];
+    }
+
+    public function pageType(): ?PageType
+    {
+        return $this->pageType;
     }
 
     public function breadcrumbs(): array

--- a/src/Pages/Pages.php
+++ b/src/Pages/Pages.php
@@ -6,6 +6,7 @@ namespace MoonShine\Pages;
 
 use Illuminate\Support\Collection;
 use MoonShine\Contracts\Resources\ResourceContract;
+use MoonShine\Enums\PageType;
 
 /**
  * @template TKey of array-key
@@ -24,7 +25,12 @@ final class Pages extends Collection
         Page $default = null
     ): ?Page {
         return $this->first(
-            static fn (Page $page): bool => $page->uriKey() === $uri,
+            function (Page $page) use ($uri): bool {
+                if($page->uriKey() === $uri) {
+                    return true;
+                }
+                return $page->pageType() === PageType::getTypeFromUri($uri);
+            },
             $default
         );
     }


### PR DESCRIPTION
Added page types to control linking and redirect behavior. If a page is named non-standardly, but we want its behavior to be the same as the behavior of standard crud pages, we need to specify its specific type:

```php
class TestMyForm extends Page
{
    protected ?PageType $pageType = PageType::FORM;

    ...
```