### PR TITLE
feat: Page content view

### DIFF
--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -20,5 +20,7 @@
         'subTitle' => $subtitle
     ])
 
+    @includeWhen($contentView ?? false, $contentView)
+
     <x-moonshine::components :components="$components" />
 @endsection

--- a/src/Pages/Page.php
+++ b/src/Pages/Page.php
@@ -33,6 +33,9 @@ abstract class Page implements MoonShineRenderable, HasResourceContract, MenuFil
 
     protected string $layout = 'moonshine::layouts.app';
 
+    protected ?string $contentView = null;
+
+
     protected ?PageType $pageType = null;
 
     public function __construct(?string $title = null, ?string $alias = null, ?ResourceContract $resource = null)
@@ -136,6 +139,18 @@ abstract class Page implements MoonShineRenderable, HasResourceContract, MenuFil
         return $this->layout;
     }
 
+    public function setContentView(string $contentView): static
+    {
+        $this->contentView = $contentView;
+
+        return $this;
+    }
+
+    public function contentView(): ?string
+    {
+        return $this->contentView;
+    }
+
     public function route(array $params = []): string
     {
         return MoonShineRouter::to(
@@ -160,8 +175,15 @@ abstract class Page implements MoonShineRenderable, HasResourceContract, MenuFil
             === $this->uriKey();
     }
 
+    protected function viewData(): array
+    {
+        return [];
+    }
+
     public function render(): View|Closure|string
     {
+        $data = $this->viewData();
+
         request()
             ?->route()
             ?->setParameter('pageUri', $this->uriKey());
@@ -175,7 +197,8 @@ abstract class Page implements MoonShineRenderable, HasResourceContract, MenuFil
                 : null,
             'breadcrumbs' => $this->breadcrumbs(),
             'components' => $this->getComponents(),
-        ])
+            'contentView' => $this->contentView(),
+        ] + $data)
             ->fragmentIf(
                 moonshineRequest()->isFragmentLoad(),
                 moonshineRequest()->getFragmentLoad()


### PR DESCRIPTION
If you need to change not the entire display, but only part of the content and make an implementation not based on components, then you can use contentView

Page property
 
```php
protected ?string $contentView = 'path_to_blade';
```

method
```php
 public function getContentView(): ?string
{
    return $this->contentView;
}
```

Pass custom data to view
```php
protected function viewData(): array
{
    return [
        'orders' => Order::all()
    ];
}
```

Instance approach
```php
CustomPage::make()->setContentView('path_to_blade')
```