### PR TITLE
Alpha3 fixes [2.x]

### DIFF
--- a/resources/js/alpine/formBuilder.js
+++ b/resources/js/alpine/formBuilder.js
@@ -69,12 +69,14 @@ export default () => ({
         const data = response.data
 
         if (data.redirect) {
-          window.location = data.redirect
+          //window.location = data.redirect
         }
 
         t.$dispatch('toast', {type: 'success', text: data.message})
 
-        submitState(form, false)
+        submitState(form, false, true)
+
+        t.$dispatch('update-relation')
       })
       .catch(errorResponse => {
         const data = errorResponse.response.data
@@ -101,10 +103,13 @@ export default () => ({
   getInputs,
 })
 
-function submitState(form, loading = true) {
+function submitState(form, loading = true, isAsync = false) {
   if (!loading) {
     form.querySelector('.form_submit_button_loader').style.display = 'none'
     form.querySelector('.form_submit_button').removeAttribute('disabled')
+    if(isAsync) {
+      form.reset()
+    }
   } else {
     form.querySelector('.form_submit_button').setAttribute('disabled', 'true')
     form.querySelector('.form_submit_button_loader').style.display = 'block'

--- a/resources/js/alpine/formBuilder.js
+++ b/resources/js/alpine/formBuilder.js
@@ -69,12 +69,20 @@ export default () => ({
         const data = response.data
 
         if (data.redirect) {
-          //window.location = data.redirect
+          window.location = data.redirect
         }
 
         t.$dispatch('toast', {type: 'success', text: data.message})
 
-        submitState(form, false, true)
+        let isFormReset = false;
+        const modalParent = t.$el.closest('.modal')
+
+        if(modalParent !== null) {
+          modalParent.querySelector('.btn-close').click()
+          isFormReset = true
+        }
+
+        submitState(form, false, isFormReset)
 
         t.$dispatch('update-relation')
       })
@@ -103,11 +111,11 @@ export default () => ({
   getInputs,
 })
 
-function submitState(form, loading = true, isAsync = false) {
+function submitState(form, loading = true, isFormReset = false) {
   if (!loading) {
     form.querySelector('.form_submit_button_loader').style.display = 'none'
     form.querySelector('.form_submit_button').removeAttribute('disabled')
-    if(isAsync) {
+    if(isFormReset) {
       form.reset()
     }
   } else {

--- a/resources/js/alpine/tableBuilder.js
+++ b/resources/js/alpine/tableBuilder.js
@@ -1,11 +1,12 @@
 import {crudFormQuery} from './formFunctions'
 import Sortable from 'sortablejs'
 
-export default (creatable = false, sortable = false, reindex = false, async = false) => ({
+export default (creatable = false, sortable = false, reindex = false, async = false, asyncUrl = '') => ({
   actionsOpen: false,
   lastRow: null,
   table: null,
   async: async,
+  asyncUrl: asyncUrl,
   sortable: sortable,
   creatable: creatable,
   reindex: reindex,
@@ -101,7 +102,7 @@ export default (creatable = false, sortable = false, reindex = false, async = fa
 
     const isForm = this.$el.tagName === 'FORM'
 
-    let url = this.$el.href
+    let url = this.$el.href ? this.$el.href : this.asyncUrl
 
     if (isForm) {
       const urlObject = new URL(this.$el.getAttribute('action'))
@@ -119,7 +120,8 @@ export default (creatable = false, sortable = false, reindex = false, async = fa
     const resultUrl = new URL(url)
 
     if (resultUrl.searchParams.get('_relation') === null) {
-      url = url + '&_relation=' + (this.table?.dataset?.name ?? 'crud-table')
+      let separator = resultUrl.searchParams.size ? '&' : '?';
+      url = url + separator + '_relation=' + (this.table?.dataset?.name ?? 'crud-table')
     }
 
     axios

--- a/resources/views/components/table/builder.blade.php
+++ b/resources/views/components/table/builder.blade.php
@@ -18,7 +18,8 @@
 {{ (int) $creatable }},
 {{ (int) $sortable }},
 {{ (int) $reindex }},
-{{ (int) $async }}
+{{ (int) $async }},
+'{{ $asyncUrl }}'
 )"
 @add-table-row.window="add(true)"
 >

--- a/src/Buttons/HasOneOrManyFields/HasManyCreateButton.php
+++ b/src/Buttons/HasOneOrManyFields/HasManyCreateButton.php
@@ -39,15 +39,15 @@ final class HasManyCreateButton
                 fn (ActionButton $action): string => (string) FormBuilder::make($action->url())
                     ->switchFormMode($resource->isAsync())
                     ->name($field->getRelationName())
-                    ->cast($field->getResource()->getModelCast())
+                    ->fillValues(
+                        [$field->getRelation()?->getForeignKeyName() => $resourceId],
+                        $field->getResource()->getModelCast()
+                    )
                     ->fields(
                         $fields
                         ->push(Hidden::make('_relation')->setValue($field->getRelationName()))
                         ->toArray()
                     )
-                    ->fill([
-                        $field->getRelation()?->getForeignKeyName() => $resourceId,
-                    ])
             );
     }
 }

--- a/src/Buttons/HasOneOrManyFields/HasManyCreateButton.php
+++ b/src/Buttons/HasOneOrManyFields/HasManyCreateButton.php
@@ -39,7 +39,7 @@ final class HasManyCreateButton
                 fn (ActionButton $action): string => (string) FormBuilder::make($action->url())
                     ->switchFormMode($resource->isAsync())
                     ->name($field->getRelationName())
-                    ->fillValues(
+                    ->fillCast(
                         [$field->getRelation()?->getForeignKeyName() => $resourceId],
                         $field->getResource()->getModelCast()
                     )

--- a/src/Buttons/HasOneOrManyFields/HasManyCreateButton.php
+++ b/src/Buttons/HasOneOrManyFields/HasManyCreateButton.php
@@ -14,7 +14,7 @@ final class HasManyCreateButton
     /**
      * @throws Throwable
      */
-    public static function for(HasMany $field, int $resourceId, bool $isParentAsync = false): ActionButton
+    public static function for(HasMany $field, int $resourceId): ActionButton
     {
         $action = to_relation_route(
             'store',
@@ -27,8 +27,6 @@ final class HasManyCreateButton
             ? $field->getFields()->formFields()
             : $resource->getFormFields();
 
-        $isAsync = $resource->isAsync() || $isParentAsync;
-
         return ActionButton::make(__('moonshine::ui.add'), url: $action)
             ->primary()
             ->icon('heroicons.outline.plus')
@@ -39,7 +37,7 @@ final class HasManyCreateButton
             ->inModal(
                 fn (): array|string|null => __('moonshine::ui.create'),
                 fn (ActionButton $action): string => (string) FormBuilder::make($action->url())
-                    ->switchFormMode($isAsync)
+                    ->switchFormMode($resource->isAsync())
                     ->name($field->getRelationName())
                     ->cast($field->getResource()->getModelCast())
                     ->fields(

--- a/src/Buttons/HasOneOrManyFields/HasManyCreateButton.php
+++ b/src/Buttons/HasOneOrManyFields/HasManyCreateButton.php
@@ -14,7 +14,7 @@ final class HasManyCreateButton
     /**
      * @throws Throwable
      */
-    public static function for(HasMany $field, int $resourceId): ActionButton
+    public static function for(HasMany $field, int $resourceId, bool $isParentAsync = false): ActionButton
     {
         $action = to_relation_route(
             'store',
@@ -27,6 +27,8 @@ final class HasManyCreateButton
             ? $field->getFields()->formFields()
             : $resource->getFormFields();
 
+        $isAsync = $resource->isAsync() || $isParentAsync;
+
         return ActionButton::make(__('moonshine::ui.add'), url: $action)
             ->primary()
             ->icon('heroicons.outline.plus')
@@ -37,7 +39,7 @@ final class HasManyCreateButton
             ->inModal(
                 fn (): array|string|null => __('moonshine::ui.create'),
                 fn (ActionButton $action): string => (string) FormBuilder::make($action->url())
-                    ->precognitive()
+                    ->switchFormMode($isAsync)
                     ->name($field->getRelationName())
                     ->cast($field->getResource()->getModelCast())
                     ->fields(

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -8,6 +8,7 @@ use Illuminate\View\ComponentAttributeBag;
 use MoonShine\Fields\Field;
 use MoonShine\Fields\Fields;
 use MoonShine\Fields\Hidden;
+use MoonShine\Resources\ModelResource;
 use MoonShine\Traits\HasAsync;
 
 /**
@@ -48,6 +49,15 @@ final class FormBuilder extends RowComponent
             'enctype' => 'multipart/form-data',
             'x-data' => 'formBuilder',
         ]);
+    }
+
+    public function fillFromModelResource(ModelResource $resource)
+    {
+        $item = $resource->getItem();
+
+        return $this
+            ->fill($item ? $resource->getModelCast()->dehydrate($item) : [])
+            ->cast($resource->getModelCast());
     }
 
     public function action(string $action): self

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\Components;
 
 use Illuminate\View\ComponentAttributeBag;
+use MoonShine\Contracts\MoonShineDataCast;
 use MoonShine\Fields\Field;
 use MoonShine\Fields\Fields;
 use MoonShine\Fields\Hidden;
@@ -51,13 +52,20 @@ final class FormBuilder extends RowComponent
         ]);
     }
 
-    public function fillFromModelResource(ModelResource $resource)
+    public function fillFromModelResource(ModelResource $resource): self
     {
         $item = $resource->getItem();
 
         return $this
             ->fill($item ? $resource->getModelCast()->dehydrate($item) : [])
             ->cast($resource->getModelCast());
+    }
+
+    public function fillValues(array $values, MoonShineDataCast $cast): self
+    {
+        return $this
+            ->cast($cast)
+            ->fill($values);
     }
 
     public function action(string $action): self

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -132,6 +132,11 @@ final class FormBuilder extends RowComponent
         return $this->submitLabel ?? __('moonshine::ui.save');
     }
 
+    public function switchFormMode(bool $isAsync): self
+    {
+        return $isAsync ? $this->async() : $this->precognitive();
+    }
+
     protected function viewData(): array
     {
         $fields = $this->preparedFields();

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -56,12 +56,13 @@ final class FormBuilder extends RowComponent
     {
         $item = $resource->getItem();
 
-        return $this
-            ->fill($item ? $resource->getModelCast()->dehydrate($item) : [])
-            ->cast($resource->getModelCast());
+        return $this->fillCast(
+            $item ? $resource->getModelCast()->dehydrate($item) : [],
+            $resource->getModelCast()
+        );
     }
 
-    public function fillValues(array $values, MoonShineDataCast $cast): self
+    public function fillCast(array $values, MoonShineDataCast $cast): self
     {
         return $this
             ->cast($cast)

--- a/src/Fields/Relationships/HasMany.php
+++ b/src/Fields/Relationships/HasMany.php
@@ -222,7 +222,7 @@ class HasMany extends ModelRelationField implements HasFields
             return null;
         }
 
-        return HasManyCreateButton::for($this, $this->getRelatedModel()?->getKey(), moonshineRequest()->getResource()->isAsync());
+        return HasManyCreateButton::for($this, $this->getRelatedModel()?->getKey());
     }
 
     protected function tableValue(): MoonShineRenderable

--- a/src/Fields/Relationships/HasMany.php
+++ b/src/Fields/Relationships/HasMany.php
@@ -222,7 +222,7 @@ class HasMany extends ModelRelationField implements HasFields
             return null;
         }
 
-        return HasManyCreateButton::for($this, $this->getRelatedModel()?->getKey());
+        return HasManyCreateButton::for($this, $this->getRelatedModel()?->getKey(), moonshineRequest()->getResource()->isAsync());
     }
 
     protected function tableValue(): MoonShineRenderable
@@ -244,6 +244,9 @@ class HasMany extends ModelRelationField implements HasFields
                 $this->isNowOnForm(),
                 fn (TableBuilder $table): TableBuilder => $table->withNotFound()
             )
+            ->customAttributes([
+                '@update-relation.window' => 'asyncRequest',
+            ])
             ->buttons([
                 DetailButton::forMode($resource),
                 FormButton::forMode($resource),

--- a/src/Fields/Relationships/HasOne.php
+++ b/src/Fields/Relationships/HasOne.php
@@ -121,9 +121,10 @@ class HasOne extends ModelRelationField
             $this->getRelatedModel()?->getKey(),
         );
 
+        $isAsync = $parentResource->isAsync() || $resource->isAsync();
+
         return FormBuilder::make($action)
-            ->precognitive()
-            ->async()
+            ->switchFormMode($isAsync)
             ->name($this->getRelationName())
             ->fields(
                 $fields->when(

--- a/src/Fields/Relationships/HasOne.php
+++ b/src/Fields/Relationships/HasOne.php
@@ -134,7 +134,7 @@ class HasOne extends ModelRelationField
                     Hidden::make('_relation')->setValue($this->getRelationName()),
                 )->toArray()
             )
-            ->fillValues($item?->attributesToArray() ?? [
+            ->fillCast($item?->attributesToArray() ?? [
                 $this->getRelation()?->getForeignKeyName() => $this->getRelatedModel()?->getKey(),
             ], $resource->getModelCast())
             ->buttons(is_null($item) ? [] : [

--- a/src/Fields/Relationships/HasOne.php
+++ b/src/Fields/Relationships/HasOne.php
@@ -134,10 +134,9 @@ class HasOne extends ModelRelationField
                     Hidden::make('_relation')->setValue($this->getRelationName()),
                 )->toArray()
             )
-            ->fill($item?->attributesToArray() ?? [
+            ->fillValues($item?->attributesToArray() ?? [
                 $this->getRelation()?->getForeignKeyName() => $this->getRelatedModel()?->getKey(),
-            ])
-            ->cast($resource->getModelCast())
+            ], $resource->getModelCast())
             ->buttons(is_null($item) ? [] : [
                 ActionButton::make(
                     __('moonshine::ui.delete'),

--- a/src/Fields/Relationships/HasOne.php
+++ b/src/Fields/Relationships/HasOne.php
@@ -121,10 +121,8 @@ class HasOne extends ModelRelationField
             $this->getRelatedModel()?->getKey(),
         );
 
-        $isAsync = $parentResource->isAsync() || $resource->isAsync();
-
         return FormBuilder::make($action)
-            ->switchFormMode($isAsync)
+            ->switchFormMode($resource->isAsync())
             ->name($this->getRelationName())
             ->fields(
                 $fields->when(

--- a/src/Forms/FiltersForm.php
+++ b/src/Forms/FiltersForm.php
@@ -20,7 +20,7 @@ final class FiltersForm
 
         return FormBuilder::make($resource->currentRoute(), 'GET')
             ->name('filters-form')
-            ->fillValues($values, $resource->getModelCast())
+            ->fillCast($values, $resource->getModelCast())
             ->fields(
                 $filters
                     ->when(

--- a/src/Forms/FiltersForm.php
+++ b/src/Forms/FiltersForm.php
@@ -20,7 +20,7 @@ final class FiltersForm
 
         return FormBuilder::make($resource->currentRoute(), 'GET')
             ->name('filters-form')
-            ->cast($resource->getModelCast())
+            ->fillValues($values, $resource->getModelCast())
             ->fields(
                 $filters
                     ->when(
@@ -36,7 +36,6 @@ final class FiltersForm
                     )
                     ->toArray()
             )
-            ->fill($values)
             ->submit(__('moonshine::ui.search'))
             ->when(
                 request('filters'),

--- a/src/Http/Controllers/RelationModelFieldController.php
+++ b/src/Http/Controllers/RelationModelFieldController.php
@@ -204,6 +204,12 @@ class RelationModelFieldController extends MoonShineController
             'success'
         );
 
+        if ($request->ajax()) {
+            return response()->json([
+                'message' => __('moonshine::ui.saved'),
+            ]);
+        }
+
         return $request->redirectRoute(
             $parentResource->redirectAfterSave()
         );

--- a/src/Pages/Crud/FormPage.php
+++ b/src/Pages/Crud/FormPage.php
@@ -96,6 +96,7 @@ class FormPage extends Page
         return [
             Fragment::make([
                 form($action)
+                    ->fillFromModelResource($this->getResource())
                     ->when(
                         moonshineRequest()->isFragmentLoad('crud-form'),
                         fn (FormBuilder $form): FormBuilder => $form->precognitive()
@@ -120,8 +121,6 @@ class FormPage extends Page
                         fn (FormBuilder $formBuilder): FormBuilder => $formBuilder->precognitive()
                     )
                     ->name('crud')
-                    ->fill($item ? $this->getResource()->getModelCast()->dehydrate($item) : [])
-                    ->cast($this->getResource()->getModelCast())
                     ->submit(__('moonshine::ui.save'), ['class' => 'btn-primary btn-lg']),
             ])->withName('crud-form'),
         ];

--- a/src/Traits/Fields/UpdateOnPreview.php
+++ b/src/Traits/Fields/UpdateOnPreview.php
@@ -6,6 +6,8 @@ namespace MoonShine\Traits\Fields;
 
 use Closure;
 use Illuminate\Contracts\View\View;
+use MoonShine\MoonShineRouter;
+use MoonShine\Resources\Resource;
 use MoonShine\Support\Condition;
 
 trait UpdateOnPreview
@@ -30,12 +32,20 @@ trait UpdateOnPreview
         return parent::readonly($condition);
     }
 
-    public function updateOnPreview(?Closure $url = null, mixed $condition = null): static
+    public function updateOnPreview(?Resource $resource = null, ?Closure $url = null, mixed $condition = null): static
     {
-        $this->updateOnPreviewUrl = $url;
+        $this->updateOnPreviewUrl = $resource ? $this->getDefaultUpdateRoute($resource) : $url;
         $this->updateOnPreview = Condition::boolean($condition, true);
 
         return $this;
+    }
+
+    protected function getDefaultUpdateRoute(Resource $resource): Closure
+    {
+        return fn ($item) => MoonShineRouter::to('resource.update-column', [
+            'resourceItem' => $item->getKey(),
+            'resourceUri' => $resource->uriKey()
+        ]);
     }
 
     public function isUpdateOnPreview(): bool

--- a/tests/Unit/Fields/SwitcherFieldTest.php
+++ b/tests/Unit/Fields/SwitcherFieldTest.php
@@ -43,7 +43,7 @@ it('preview with not auto update', function (): void {
 });
 
 it('preview with auto update', function (): void {
-    expect($this->field->updateOnPreview(fn () => '/')->preview())
+    expect($this->field->updateOnPreview(url: fn () => '/')->preview())
         ->toBe(
             view('moonshine::fields.switch', [
                 'element' => $this->field,


### PR DESCRIPTION
1. New methods for FormBuilder to use fill and cast simultaneously:
```php
public function fillFromModelResource(ModelResource $resource): self

public function fillCast(array $values, MoonShineDataCast $cast): self
```
2. HasOne and HasMany can now work asynchronously; to do this, you need to enable $isAsync in the relationship resource
3. Now you just need to pass a resource to the updateOnPreview method to create a link to edit the resource parameter on the preview page:
```php
//Inside the resource
Switcher::make('Is public')->updateOnPreview($this)
```