### PR TITLE
feat: ViewPage

### DIFF
--- a/src/Buttons/HasOneOrManyFields/HasManyCreateButton.php
+++ b/src/Buttons/HasOneOrManyFields/HasManyCreateButton.php
@@ -31,8 +31,8 @@ final class HasManyCreateButton
             ->primary()
             ->icon('heroicons.outline.plus')
             ->canSee(
-                fn (?Model $item): bool => ! is_null($item) && in_array('create', $resource->getActiveActions())
-                && $resource->setItem($item)->can('create')
+                fn (?Model $item): bool => in_array('create', $resource->getActiveActions())
+                && $resource->can('create')
             )
             ->inModal(
                 fn (): array|string|null => __('moonshine::ui.create'),

--- a/src/Buttons/IndexPage/AsyncCreateButton.php
+++ b/src/Buttons/IndexPage/AsyncCreateButton.php
@@ -22,8 +22,8 @@ final class AsyncCreateButton
             ->primary()
             ->icon('heroicons.outline.plus')
             ->canSee(
-                fn (?Model $item): bool => ! is_null($item) && in_array('create', $resource->getActiveActions())
-                && $resource->setItem($item)->can('create')
+                fn (?Model $item): bool => in_array('create', $resource->getActiveActions())
+                && $resource->can('create')
             )
             ->inModal(
                 fn (): array|string|null => __('moonshine::ui.create'),

--- a/src/Buttons/IndexPage/CreateButton.php
+++ b/src/Buttons/IndexPage/CreateButton.php
@@ -13,7 +13,7 @@ final class CreateButton
     {
         return $resource->isCreateInModal()
             ? AsyncCreateButton::for($resource)
-            : CreateButton::for($resource);
+            : self::for($resource);
     }
 
     public static function for(ModelResource $resource): ActionButton
@@ -27,8 +27,8 @@ final class CreateButton
         )
             ->primary()
             ->canSee(
-                fn (?Model $item): bool => ! is_null($item) && in_array('create', $resource->getActiveActions())
-                && $resource->setItem($item)->can('create')
+                fn (?Model $item): bool => in_array('create', $resource->getActiveActions())
+                && $resource->can('create')
             )
             ->icon('heroicons.outline.plus');
     }

--- a/src/Fields/Relationships/HasMany.php
+++ b/src/Fields/Relationships/HasMany.php
@@ -222,7 +222,11 @@ class HasMany extends ModelRelationField implements HasFields
             return null;
         }
 
-        return HasManyCreateButton::for($this, $this->getRelatedModel()?->getKey());
+        $button = HasManyCreateButton::for($this, $this->getRelatedModel()?->getKey());
+
+        return $button->isSee($this->getRelatedModel())
+            ? $button
+            : null;
     }
 
     protected function tableValue(): MoonShineRenderable

--- a/src/Fields/Relationships/HasOne.php
+++ b/src/Fields/Relationships/HasOne.php
@@ -146,6 +146,10 @@ class HasOne extends ModelRelationField
                         relation: $this->getRelationName()
                     )
                 )
+                    ->canSee(
+                        fn (?Model $item): bool => ! is_null($item) && in_array('delete', $resource->getActiveActions())
+                            && $resource->setItem($item)->can('delete')
+                    )
                     ->secondary()
                     ->customAttributes(['class' => 'btn-lg'])
                     ->inModal(

--- a/src/Http/Controllers/MoonShineController.php
+++ b/src/Http/Controllers/MoonShineController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace MoonShine\Http\Controllers;
 
 use Illuminate\Routing\Controller as BaseController;
+use MoonShine\Pages\Page;
+use MoonShine\Pages\ViewPage;
 use MoonShine\Traits\Controller\InteractsWithAuth;
 use MoonShine\Traits\Controller\InteractsWithUI;
 
@@ -12,4 +14,13 @@ abstract class MoonShineController extends BaseController
 {
     use InteractsWithUI;
     use InteractsWithAuth;
+
+    public function view(string $path, array $data = []): Page
+    {
+        $page = ViewPage::make();
+
+        $page->beforeRender();
+
+        return $page->setContentView($path, $data);
+    }
 }

--- a/src/Pages/Crud/IndexPage.php
+++ b/src/Pages/Crud/IndexPage.php
@@ -98,8 +98,10 @@ class IndexPage extends Page
             Grid::make([
                 Column::make([
                     Flex::make([
-                        CreateButton::forMode($this->getResource()),
-                        ...$this->getResource()->actions(),
+                        ActionGroup::make([
+                            CreateButton::forMode($this->getResource()),
+                            ...$this->getResource()->actions(),
+                        ]),
                     ])->justifyAlign('start'),
 
                     ActionGroup::make()->when(

--- a/src/Pages/Page.php
+++ b/src/Pages/Page.php
@@ -35,6 +35,8 @@ abstract class Page implements MoonShineRenderable, HasResourceContract, MenuFil
 
     protected ?string $contentView = null;
 
+    protected array $viewData = [];
+
 
     protected ?PageType $pageType = null;
 
@@ -139,9 +141,10 @@ abstract class Page implements MoonShineRenderable, HasResourceContract, MenuFil
         return $this->layout;
     }
 
-    public function setContentView(string $contentView): static
+    public function setContentView(string $contentView, array $data = []): static
     {
         $this->contentView = $contentView;
+        $this->viewData = $data;
 
         return $this;
     }
@@ -177,7 +180,9 @@ abstract class Page implements MoonShineRenderable, HasResourceContract, MenuFil
 
     protected function viewData(): array
     {
-        return [];
+        return [
+            ...$this->viewData
+        ];
     }
 
     public function render(): View|Closure|string

--- a/src/Pages/ViewPage.php
+++ b/src/Pages/ViewPage.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Pages;
+
+final class ViewPage extends Page
+{
+    public function components(): array
+    {
+        return [];
+    }
+}

--- a/stubs/Controller.stub
+++ b/stubs/Controller.stub
@@ -13,9 +13,18 @@ final class DummyClass extends MoonshineController
     public function __invoke(MoonShineRequest $request): Response
     {
         // Examples
+
         // $this->toast('Hello world');
         // $request->getPage();
         // $request->getResource();
+
+        /*
+        // Render custom content
+        return $this
+            ->view('path_to_blade', ['param' => 'value'])
+            ->setLayout('custom_layout')
+            ->render();
+        */
 
         return back();
     }


### PR DESCRIPTION
Now you can use a MoonshineController and conveniently render blade views in the MoonShine itself and beyond, while preserving all assets and layout

```php
class HomeController extends MoonShineController
{
    public function __invoke()
    {
        return $this->view('home', [
            'articles' => Article::all(),
        ])->render();
    }
}
```

```php
class HomeController extends MoonShineController
{
    public function __invoke()
    {
        return $this->view('home', [
            'articles' => Article::all(),
        ])->setTitle('Title')->setLayout('custom_layout')->render();
    }
}
```

Simple Page class - ViewPage

```php
MenuItem::make('Custom', ViewPage::make()->setTitle('Hello')->setContentView('my-form')),
```