### PR TITLE
Added auto paddings for layout wrapper with a sidebar or topbar

### DIFF
--- a/resources/css/base/layout.css
+++ b/resources/css/base/layout.css
@@ -1,25 +1,25 @@
 /* Theme layout */
 .layout {
   &-wrapper {
-    @apply relative flex min-h-screen flex-col gap-y-5 px-3 pt-16 pb-3 transition-all md:px-5 lg:flex-row lg:py-6 xl:pr-6 ;
+    @apply relative flex min-h-screen flex-col gap-y-5 p-3 transition-all md:px-5 lg:flex-row lg:py-6 xl:pr-6 ;
 
     &-short {
       @apply lg:pl-[6rem];
     }
 
-    &:has(>.layout-menu) {
-      @apply lg:pl-[5.75rem] xl:pl-72
+    &:has(>.layout-menu) { /* Paddings for sidebar */
+      @apply pt-16 lg:pl-[5.75rem] xl:pl-72
     }
 
-    &--sidebar { /* Workaround for Firefox */
-      @apply lg:pl-[5.75rem] xl:pl-72
+    &--sidebar { /* Paddings for sidebar: workaround for Firefox */
+      @apply pt-16 lg:pl-[5.75rem] xl:pl-72
     }
 
-    &:has(>.layout-menu-horizontal) {
+    &:has(>.layout-menu-horizontal) { /* Paddings for topbar */
       @apply flex-col px-3 pt-[4.5rem] pb-6 transition-none md:px-5 lg:pt-24;
     }
 
-    &--top-menu { /* Workaround for Firefox */
+    &--top-menu { /* Paddings for topbar: workaround for Firefox */
       @apply flex-col pt-[4.5rem] pb-6 transition-none md:px-5 lg:pt-24;
     }
   }

--- a/resources/css/base/layout.css
+++ b/resources/css/base/layout.css
@@ -1,26 +1,42 @@
 /* Theme layout */
 .layout {
   &-wrapper {
-    @apply relative flex min-h-screen flex-col gap-y-5 p-3 transition-all md:px-5 lg:flex-row lg:py-6 xl:pr-6 ;
+    @apply relative flex min-h-screen flex-col gap-y-5 p-3 transition-all md:p-5 lg:flex-row lg:p-6 ;
 
-    &-short {
+    /* SIDEBAR */
+    /* selector :has not supported */
+
+    &--sidebar {
+      @apply pt-16 md:pt-5 lg:pt-6 lg:pl-[5.75rem] xl:pl-72;
+    }
+
+    &--sidebar&-short {
       @apply lg:pl-[6rem];
     }
 
-    &:has(>.layout-menu) { /* Paddings for sidebar */
-      @apply pt-16 lg:pl-[5.75rem] xl:pl-72
+    /* selector :has supported */
+    @supports selector(:has(*)) {
+      &:has(>.layout-menu) {
+        @apply pt-16 md:pt-5 lg:pt-6 lg:pl-[5.75rem] xl:pl-72
+      }
+
+      &-short:has(>.layout-menu) {
+        @apply lg:pl-[6rem];
+      }
     }
 
-    &--sidebar { /* Paddings for sidebar: workaround for Firefox */
-      @apply pt-16 lg:pl-[5.75rem] xl:pl-72
-    }
+    /* TOPBAR */
+    /* selector :has not supported */
 
-    &:has(>.layout-menu-horizontal) { /* Paddings for topbar */
+    &--top-menu {
       @apply flex-col px-3 pt-[4.5rem] pb-6 transition-none md:px-5 lg:pt-24;
     }
 
-    &--top-menu { /* Paddings for topbar: workaround for Firefox */
-      @apply flex-col pt-[4.5rem] pb-6 transition-none md:px-5 lg:pt-24;
+    /* selector :has supported */
+    @supports selector(:has(*)) {
+      &:has(>.layout-menu-horizontal) {
+        @apply flex-col px-3 pt-[4.5rem] pb-6 transition-none md:px-5 lg:pt-24;
+      }
     }
   }
 

--- a/resources/css/base/layout.css
+++ b/resources/css/base/layout.css
@@ -1,14 +1,26 @@
 /* Theme layout */
 .layout {
   &-wrapper {
-    @apply relative flex min-h-screen flex-col gap-y-5 px-3 pt-16 pb-3 transition-all md:px-5 lg:flex-row lg:py-6 lg:pl-[5.75rem] xl:pr-6 xl:pl-72;
+    @apply relative flex min-h-screen flex-col gap-y-5 px-3 pt-16 pb-3 transition-all md:px-5 lg:flex-row lg:py-6 xl:pr-6 ;
 
     &-short {
       @apply lg:pl-[6rem];
     }
 
-    &--top-menu {
+    &:has(>.layout-menu) {
+      @apply lg:pl-[5.75rem] xl:pl-72
+    }
+
+    &--sidebar { /* Workaround for Firefox */
+      @apply lg:pl-[5.75rem] xl:pl-72
+    }
+
+    &:has(>.layout-menu-horizontal) {
       @apply flex-col px-3 pt-[4.5rem] pb-6 transition-none md:px-5 lg:pt-24;
+    }
+
+    &--top-menu { /* Workaround for Firefox */
+      @apply flex-col pt-[4.5rem] pb-6 transition-none md:px-5 lg:pt-24;
     }
   }
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,5 @@
 import './bootstrap'
+import './layout'
 
 import Alpine from 'alpinejs'
 import persist from '@alpinejs/persist'

--- a/resources/js/layout.js
+++ b/resources/js/layout.js
@@ -1,18 +1,18 @@
 /**
  * Classes for layout wrapper with a sidebar or topbar.
- * Workaround for Firefox (~12% usage).
- * Probably has selector coming in version 120.
+ * Workaround for browsers that do not support the :has selector (Firefox).
+ * Probably :has selector coming in Firefox 120.
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=418039
  */
-if (navigator.userAgent.match(/firefox|fxios/i)) {
-  document.addEventListener('DOMContentLoaded', event => {
+if (!CSS.supports('selector(:has(*))')) {
+  document.addEventListener('DOMContentLoaded', () => {
     const wrapperElement = document.querySelector('.layout-wrapper')
-    if (!wrapperElement) {
-      return
-    }
-    if (wrapperElement.querySelector(':scope > .layout-menu')) {
+
+    if (wrapperElement && wrapperElement.querySelector(':scope > .layout-menu')) {
       wrapperElement.classList.add('layout-wrapper--sidebar')
     }
-    if (wrapperElement.querySelector(':scope > .layout-menu-horizontal')) {
+
+    if (wrapperElement && wrapperElement.querySelector(':scope > .layout-menu-horizontal')) {
       wrapperElement.classList.add('layout-wrapper--top-menu')
     }
   })

--- a/resources/js/layout.js
+++ b/resources/js/layout.js
@@ -1,0 +1,19 @@
+/**
+ * Classes for layout wrapper with a sidebar or topbar.
+ * Workaround for Firefox (~12% usage).
+ * Probably has selector coming in version 120.
+ */
+if (navigator.userAgent.match(/firefox|fxios/i)) {
+  document.addEventListener('DOMContentLoaded', event => {
+    const wrapperElement = document.querySelector('.layout-wrapper')
+    if (!wrapperElement) {
+      return
+    }
+    if (wrapperElement.querySelector(':scope > .layout-menu')) {
+      wrapperElement.classList.add('layout-wrapper--sidebar')
+    }
+    if (wrapperElement.querySelector(':scope > .layout-menu-horizontal')) {
+      wrapperElement.classList.add('layout-wrapper--top-menu')
+    }
+  })
+}


### PR DESCRIPTION
## Benefits

1. No longer a need to [manually add](https://moonshine-laravel.com/docs/section/appearance-layout_builder#topbar) the `layout-wrapper--top-menu` class when using topbar
2. Became possible to use a layout without a sidebar and topbar