### PR TITLE
Simplify sort query string

### DIFF
--- a/src/Forms/FiltersForm.php
+++ b/src/Forms/FiltersForm.php
@@ -25,10 +25,9 @@ final class FiltersForm
             ->fields(
                 $filters
                     ->when(
-                        request('sort.column'),
+                        request('sort'),
                         static fn ($fields): Fields => $fields
-                            ->prepend(Hidden::make(column: 'sort.direction')->setValue(request('sort.direction')))
-                            ->prepend(Hidden::make(column: 'sort.column')->setValue(request('sort.column')))
+                            ->prepend(Hidden::make(column: 'sort')->setValue(request('sort')))
                     )
                     ->when(
                         request('query-tag'),

--- a/src/Traits/Fields/WithSorts.php
+++ b/src/Traits/Fields/WithSorts.php
@@ -30,11 +30,7 @@ trait WithSorts
     public function sortQuery(?string $url = null): string
     {
         $sortData = [
-            'sort' => [
-                'column' => $this->column(),
-                'direction' => $this->sortActive() && $this->sortDirection('asc') ? 'desc'
-                    : 'asc',
-            ],
+            'sort' => ($this->sortActive() && $this->sortDirection('asc') ? '-' : '').$this->column(),
             'page' => request('page', 1),
         ];
 
@@ -46,16 +42,34 @@ trait WithSorts
 
         $separator = empty($urlParse['query']) ? '?' : '&';
 
-        return $url . $separator . Arr::query($sortData);
+        return $url.$separator.Arr::query($sortData);
     }
 
     public function sortActive(): bool
     {
-        return request('sort.column') === $this->column();
+        return $this->getSortColumnFromRequest() === $this->column();
     }
 
     public function sortDirection(string $type): bool
     {
-        return request('sort.direction') === strtolower($type);
+        return $this->getSortDirectionFromRequest() === strtolower($type);
+    }
+
+    private function getSortColumnFromRequest(): ?string
+    {
+        if (($sort = request('sort')) && is_string($sort)) {
+            return ltrim($sort, '-');
+        }
+
+        return null;
+    }
+
+    private function getSortDirectionFromRequest(): ?string
+    {
+        if (($sort = request('sort')) && is_string($sort)) {
+            return str_starts_with($sort, '-') ? 'desc' : 'asc';
+        }
+
+        return null;
     }
 }

--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -134,6 +134,7 @@ trait ResourceModelQuery
     {
         return $this->simplePaginate;
     }
+
     /**
      * @throws Throwable
      */
@@ -143,10 +144,7 @@ trait ResourceModelQuery
             ->resolveSearch()
             ->resolveFilters()
             ->resolveParentResource()
-            ->resolveOrder(
-                request('sort.column', $this->sortColumn()),
-                request('sort.direction', $this->sortDirection())
-            )
+            ->resolveOrder()
             ->cacheQueryParams();
 
         return $this->query();
@@ -270,8 +268,16 @@ trait ResourceModelQuery
         });
     }
 
-    protected function resolveOrder(string $column, string $direction): static
+    protected function resolveOrder(): static
     {
+        $column = $this->sortColumn();
+        $direction = $this->sortDirection();
+
+        if (($sort = request('sort')) && is_string($sort)) {
+            $column = ltrim($sort, '-');
+            $direction = str_starts_with($sort, '-') ? 'desc' : 'asc';
+        }
+
         $this->query()->orderBy($column, $direction);
 
         return $this;

--- a/tests/Feature/Controllers/RelationModelFieldControllerTest.php
+++ b/tests/Feature/Controllers/RelationModelFieldControllerTest.php
@@ -74,10 +74,7 @@ it('pagination has many sort', function () {
         'resourceUri' => 'test-item-resource',
         'resourceItem' => $item->id,
         '_relation' => 'comments',
-        'sort' => [
-            'column' => 'id',
-            'direction' => 'asc',
-        ],
+        'sort' => 'id',
     ]))
         ->assertOk()
         ->assertSee('asyncRequest')


### PR DESCRIPTION
### Query string before

`sort[column]=id&sort[direction]=asc`
`sort[column]=id&sort[direction]=desc`

### Query string after

`sort=id`
`sort=-id`