### PR TITLE
updateOnPreview refactoring

### DIFF
--- a/src/Http/Controllers/UpdateFieldController.php
+++ b/src/Http/Controllers/UpdateFieldController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\Http\Controllers;
 
 use Illuminate\Http\Response;
+use MoonShine\Contracts\Fields\HasFields;
 use MoonShine\Exceptions\ResourceException;
 use MoonShine\Fields\Field;
 use MoonShine\Fields\Fields;
@@ -23,6 +24,10 @@ class UpdateFieldController extends MoonShineController
     public function relation(RelationModelColumnUpdateRequest $request): Response
     {
         $relationField = $request->getField();
+
+        if($relationField instanceof HasFields) {
+            $relationField->preparedFields();
+        }
 
         $resource = $relationField->getResource();
 

--- a/src/Http/Requests/Relations/RelationModelColumnUpdateRequest.php
+++ b/src/Http/Requests/Relations/RelationModelColumnUpdateRequest.php
@@ -23,7 +23,7 @@ class RelationModelColumnUpdateRequest extends RelationModelFieldRequest
 
     protected function prepareForValidation(): void
     {
-        $this->merge([
+        request()->merge([
             $this->get('field') => $this->get('value'),
         ]);
     }

--- a/src/Traits/Fields/UpdateOnPreview.php
+++ b/src/Traits/Fields/UpdateOnPreview.php
@@ -21,9 +21,9 @@ trait UpdateOnPreview
 
     protected ?Closure $url = null;
 
-    protected ?string $resourceUri = null;
+    protected ?string $updateColumnResourceUri = null;
 
-    protected ?string $pageUri = null;
+    protected ?string $updateColumnPageUri = null;
 
     protected function prepareFill(array $raw = [], mixed $casted = null): mixed
     {
@@ -46,15 +46,15 @@ trait UpdateOnPreview
     ): static {
         $this->url = $url;
 
-        $resultResource = $resource ?? moonshineRequest()->getResource();
+        $resource = $resource ?? moonshineRequest()->getResource();
 
-        if(is_null($resultResource) && is_null($url)) {
+        if(is_null($resource) && is_null($url)) {
             throw new FieldException('updateOnPreview must accept either $resource or $url parameters');
         }
 
-        if(!is_null($resultResource)) {
-            $this->resourceUri = $resultResource->uriKey();
-            $this->pageUri = $resultResource->formPage()->uriKey();
+        if(!is_null($resource)) {
+            $this->updateColumnResourceUri = $resource->uriKey();
+            $this->updateColumnPageUri = $resource->formPage()->uriKey();
         }
 
         $this->updateOnPreviewUrl = $this->getUrl() ?? $this->getDefaultUpdateRoute();
@@ -97,12 +97,12 @@ trait UpdateOnPreview
 
     public function getResourceUriForUpdate(): ?string
     {
-        return $this->resourceUri;
+        return $this->updateColumnResourceUri;
     }
 
     public function getPageUriForUpdate(): ?string
     {
-        return $this->pageUri;
+        return $this->updateColumnPageUri;
     }
 
     public function preview(): View|string

--- a/src/Traits/Fields/UpdateOnPreview.php
+++ b/src/Traits/Fields/UpdateOnPreview.php
@@ -40,23 +40,24 @@ trait UpdateOnPreview
     }
 
     public function updateOnPreview(
-        ?ResourceContract $resource = null,
         ?Closure $url = null,
+        ?ResourceContract $resource = null,
         mixed $condition = null
     ): static {
+        $this->url = $url;
 
-        if(is_null($resource) && is_null($url)) {
+        $resultResource = $resource ?? moonshineRequest()->getResource();
+
+        if(is_null($resultResource) && is_null($url)) {
             throw new FieldException('updateOnPreview must accept either $resource or $url parameters');
         }
 
-        $this->url = $url;
-
-        if(! is_null($resource)) {
-            $this->resourceUri = $resource->uriKey();
-            $this->pageUri = $resource->formPage()->uriKey();
+        if(!is_null($resultResource)) {
+            $this->resourceUri = $resultResource->uriKey();
+            $this->pageUri = $resultResource->formPage()->uriKey();
         }
 
-        $this->updateOnPreviewUrl = $resource ? $this->getDefaultUpdateRoute() : $this->getUrl();
+        $this->updateOnPreviewUrl = $this->getUrl() ?? $this->getDefaultUpdateRoute();
         $this->updateOnPreview = Condition::boolean($condition, true);
 
         return $this;

--- a/tests/Feature/Fields/SwitcherFieldTest.php
+++ b/tests/Feature/Fields/SwitcherFieldTest.php
@@ -195,7 +195,6 @@ it('relation update column', function () {
                 '_relation' => 'comments',
                 'field' => 'active',
                 'value' => 0,
-                'active' => 0, //TODO Strange behavior, if not specified explicitly, will not work
             ]
         )
     )
@@ -240,7 +239,6 @@ it('relation update column in resource', function () {
                 '_relation' => 'comments',
                 'field' => 'active',
                 'value' => 0,
-                'active' => 0, //TODO Strange behavior, if not specified explicitly, will not work
             ]
         )
     )

--- a/tests/Fixtures/Migrations/2023_08_27_155352_create_comments.php
+++ b/tests/Fixtures/Migrations/2023_08_27_155352_create_comments.php
@@ -14,6 +14,7 @@ return new class () extends Migration {
             $table->id();
             $table->unsignedBigInteger('user_id');
             $table->unsignedBigInteger('item_id');
+            $table->boolean('active')->default(1);
             $table->text('content');
             $table->json('data')->nullable();
             $table->timestamps();

--- a/tests/Fixtures/Resources/TestHasManyCommentResource.php
+++ b/tests/Fixtures/Resources/TestHasManyCommentResource.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Tests\Fixtures\Resources;
+
+use Illuminate\Database\Eloquent\Model;
+use MoonShine\Fields\ID;
+use MoonShine\Fields\Number;
+use MoonShine\Fields\Switcher;
+use MoonShine\Fields\Text;
+use MoonShine\Resources\ModelResource;
+use MoonShine\Tests\Fixtures\Models\Comment;
+
+/**
+ * A duplicate of the TestCommentResource resource was made in order to test the behavior of Switcher->updateOnPreview when the resource is not specified in the method. For this to work in tests, before creating the resource, you must call the fakeRequest method, to which the resourceUri is passed
+ */
+class TestHasManyCommentResource extends ModelResource
+{
+    protected string $model = Comment::class;
+
+    protected int $itemsPerPage = 2;
+
+    public function fields(): array
+    {
+        return [
+            ID::make()->sortable(),
+            Number::make('User id'),
+            Text::make('Comment title', 'content')->sortable(),
+            //A class has been created for this field
+            Switcher::make('Active title', 'active')->updateOnPreview(),
+        ];
+    }
+
+    public function rules(Model $item): array
+    {
+        return  [
+            'content' => 'required',
+        ];
+    }
+}

--- a/tests/Fixtures/Resources/TestItemResource.php
+++ b/tests/Fixtures/Resources/TestItemResource.php
@@ -12,6 +12,7 @@ use MoonShine\Fields\Image;
 use MoonShine\Fields\Relationships\BelongsTo;
 use MoonShine\Fields\Relationships\HasMany;
 use MoonShine\Fields\Relationships\MorphMany;
+use MoonShine\Fields\Switcher;
 use MoonShine\Fields\Text;
 use MoonShine\Fields\TinyMce;
 use MoonShine\Resources\ModelResource;
@@ -47,6 +48,7 @@ class TestItemResource extends ModelResource
                 HasMany::make('Comments title', 'comments', resource: new TestCommentResource())->fields([
                     ID::make()->sortable(),
                     Text::make('Comment title', 'content')->sortable(),
+                    Switcher::make('Active title', 'active')->updateOnPreview(resource: $this),
                 ]),
 
                 MorphMany::make('Images title', 'images', resource: new TestImageResource())

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -52,6 +52,9 @@ function createItem(int $countItems = 1, int $countComments = 3)
         ->first();
 }
 
+/**
+ * @deprecated
+ */
 function addFieldToTestResource(Field $field): TestResource
 {
     return addFieldsToTestResource([$field]);


### PR DESCRIPTION
The $resource parameter is no longer required to be passed to updateOnPreview. It will be taken from uri. The resource parameter must be passed when the field operates outside of a resource and there is no resourceUri parameter in the uri

BREAKING CHANGE: $resource and $url parameters have been swapped in updateOnPreview

```php
public function updateOnPreview(?Closure $url = null, ?ResourceContract $resource = null, mixed $condition = null): static
```