### PR TITLE
Relations after delete events

### DIFF
--- a/src/Fields/Relationships/HasMany.php
+++ b/src/Fields/Relationships/HasMany.php
@@ -320,4 +320,13 @@ class HasMany extends ModelRelationField implements HasFields
     {
         return static fn ($item) => $item;
     }
+
+    protected function resolveAfterDestroy(mixed $data): mixed
+    {
+        $this->getResource()
+            ->getFormFields()
+            ->each(fn(Field $field) => $field->resolveFill($data->toArray())->afterDestroy($data));
+
+        return $data;
+    }
 }

--- a/src/Fields/Relationships/HasOne.php
+++ b/src/Fields/Relationships/HasOne.php
@@ -160,4 +160,13 @@ class HasOne extends ModelRelationField implements HasFields
             )
             ->submit(__('moonshine::ui.save'), ['class' => 'btn-primary btn-lg']);
     }
+
+    protected function resolveAfterDestroy(mixed $data): mixed
+    {
+        $this->getResource()
+            ->getFormFields()
+            ->each(fn(Field $field) => $field->resolveFill($data->toArray())->afterDestroy($data));
+
+        return $data;
+    }
 }

--- a/tests/Feature/Resources/ResourceWithCustomPageTest.php
+++ b/tests/Feature/Resources/ResourceWithCustomPageTest.php
@@ -15,7 +15,7 @@ use MoonShine\Tests\Fixtures\Pages\NoType\CustomNoTypeForm;
 use MoonShine\Tests\Fixtures\Pages\NoType\CustomNoTypeIndex;
 use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
 
-uses()->group('pages-feature');
+uses()->group('resources-feature');
 uses()->group('pages-custom');
 
 beforeEach(function (): void {

--- a/tests/Feature/Resources/ResourceWithFileHasManyTest.php
+++ b/tests/Feature/Resources/ResourceWithFileHasManyTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
+use MoonShine\Fields\ID;
+use MoonShine\Fields\Relationships\HasMany;
+use MoonShine\Fields\Text;
+use MoonShine\Pages\Crud\FormPage;
+use MoonShine\Resources\ModelResource;
+use MoonShine\Tests\Fixtures\Models\Item;
+use MoonShine\Tests\Fixtures\Resources\TestFileResource;
+use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
+
+uses()->group('resources-feature');
+uses()->group('resources-has-many-files');
+
+beforeEach(function (): void {
+
+    $this->item = createItem(1, 1);
+
+    $this->resource = TestResourceBuilder::new(Item::class)
+        ->setTestFields([
+            ID::make()->sortable(),
+            Text::make('Name', 'name')->sortable(),
+            HasMany::make('Files', 'itemFiles', resource: new TestFileResource())
+        ])
+    ;
+});
+
+it('resource with has many', function () {
+    asAdmin()->get(
+        to_page(page: FormPage::class, resource: $this->resource, params: ['resourceItem' => $this->item->id])
+    )
+        ->assertOk()
+        ->assertSee('Name')
+        ->assertSee('Files')
+    ;
+});
+
+it('delete a has many file after delete item', function () {
+    $file = addFile(new TestFileResource(), $this->item);
+
+    $this->resource->setDeleteRelationships();
+
+    deleteItem($this->resource, $this->item->getKey());
+
+    Storage::disk('public')->assertMissing($file->hashName());
+
+});
+
+it('not delete a has many file after delete item', function () {
+    $file = addFile(new TestFileResource(), $this->item);
+
+    deleteItem($this->resource, $this->item->getKey());
+
+    Storage::disk('public')->assertExists($file->hashName());
+});
+
+function addFile(ModelResource $resource, Model $item)
+{
+    $file = UploadedFile::fake()->create('test.csv');
+
+    $data = [
+        'path' => $file,
+        'item_id' => $item->id,
+    ];
+
+    asAdmin()->post(
+        $resource->route('crud.store', $item->getKey()),
+        $data
+    )
+        ->assertRedirect();
+
+    $item->refresh();
+
+    expect($fileHasMany = $item->itemFiles()->first())
+        ->not()->toBeNull()
+        ->and($fileHasMany->path)
+        ->toBe($file->hashName())
+    ;
+
+    Storage::disk('public')->assertExists($file->hashName());
+
+    return $file;
+}
+
+function deleteItem(ModelResource $resource, int $itemId): void
+{
+    asAdmin()->delete(
+        $resource->route('crud.destroy', $itemId),
+    )
+        ->assertRedirect()
+    ;
+
+    $item = Item::query()->where('id', $itemId)->first();
+
+    expect($item)->toBeNull();
+}

--- a/tests/Fixtures/Migrations/2023_05_22_130914_create_files.php
+++ b/tests/Fixtures/Migrations/2023_05_22_130914_create_files.php
@@ -13,11 +13,13 @@ return new class () extends Migration {
         Schema::create('files', static function (Blueprint $table): void {
             $table->id();
 
-            $table->morphs('fileable');
+            $table->string('path');
 
-            $table->text('name')->nullable();
+            $table->unsignedBigInteger('item_id');
 
             $table->timestamps();
+
+            $table->foreign('item_id')->references('id')->on('items')->cascadeOnDelete();
         });
     }
 

--- a/tests/Fixtures/Models/FileModel.php
+++ b/tests/Fixtures/Models/FileModel.php
@@ -5,26 +5,21 @@ declare(strict_types=1);
 namespace MoonShine\Tests\Fixtures\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class FileModel extends Model
 {
     protected $table = 'files';
 
     protected $fillable = [
-        'fileable_id',
-        'fileable_type',
-        'name',
+        'path',
+        'item_id',
         'created_at',
         'updated_at',
     ];
 
-    protected $casts = [
-        'name' => 'array',
-    ];
-
-    public function fileable(): MorphTo
+    public function item(): BelongsTo
     {
-        return $this->morphTo();
+        return $this->belongsTo(Item::class, 'item_id');
     }
 }

--- a/tests/Fixtures/Models/Item.php
+++ b/tests/Fixtures/Models/Item.php
@@ -68,6 +68,11 @@ class Item extends Model
         return $this->hasMany(Comment::class, 'item_id');
     }
 
+    public function itemFiles(): HasMany
+    {
+        return $this->hasMany(FileModel::class, 'item_id');
+    }
+
     public function imageable(): MorphMany
     {
         return $this->morphMany(ImageModel::class, 'imageable');

--- a/tests/Fixtures/Models/Item.php
+++ b/tests/Fixtures/Models/Item.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use MoonShine\Models\MoonshineUser;
 use MoonShine\Tests\Fixtures\Factories\ItemFactory;
@@ -71,6 +72,11 @@ class Item extends Model
     public function itemFiles(): HasMany
     {
         return $this->hasMany(FileModel::class, 'item_id');
+    }
+
+    public function itemFile(): HasOne
+    {
+        return $this->hasOne(FileModel::class, 'item_id');
     }
 
     public function imageable(): MorphMany

--- a/tests/Fixtures/Resources/TestFileResource.php
+++ b/tests/Fixtures/Resources/TestFileResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace MoonShine\Tests\Fixtures\Resources;
+
+use Illuminate\Database\Eloquent\Model;
+use MoonShine\Fields\File;
+use MoonShine\Fields\ID;
+use MoonShine\Fields\Relationships\BelongsTo;
+use MoonShine\Resources\ModelResource;
+use MoonShine\Tests\Fixtures\Models\FileModel;
+
+class TestFileResource extends ModelResource
+{
+    protected string $model = FileModel::class;
+
+    protected array $with = ['item'];
+
+    public function fields(): array
+    {
+        return [
+            ID::make()->sortable(),
+            File::make('File', 'path'),
+            BelongsTo::make('Item', resource: new TestItemResource())
+        ];
+    }
+
+    public function rules(Model $item): array
+    {
+        return [];
+    }
+}

--- a/tests/Fixtures/Resources/TestResource.php
+++ b/tests/Fixtures/Resources/TestResource.php
@@ -215,4 +215,9 @@ class TestResource extends ModelResource
     {
         $this->simplePaginate = true;
     }
+
+    public function setDeleteRelationships(): void
+    {
+        $this->deleteRelationships = true;
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,6 +22,7 @@ use MoonShine\Resources\MoonShineUserRoleResource;
 use MoonShine\Tests\Fixtures\Resources\TestCategoryResource;
 use MoonShine\Tests\Fixtures\Resources\TestCommentResource;
 use MoonShine\Tests\Fixtures\Resources\TestCoverResource;
+use MoonShine\Tests\Fixtures\Resources\TestFileResource;
 use MoonShine\Tests\Fixtures\Resources\TestImageResource;
 use MoonShine\Tests\Fixtures\Resources\TestItemResource;
 use MoonShine\Tests\Fixtures\TestServiceProvider;
@@ -114,6 +115,7 @@ class TestCase extends Orchestra
             new TestItemResource(),
             new TestCommentResource(),
             new TestImageResource(),
+            new TestFileResource(),
 
             new MoonShineUserRoleResource(),
         ], newCollection: true);


### PR DESCRIPTION
Now HasOne/Many has a delete event that will trigger all events on nested fields. If a relation may have a large number of records, then raising field events is not desirable. Therefore, to perform this action, a flag was introduced for the resource:
```php
protected bool $deleteRelationships = true;
```
By default the value is set to false