### PR TITLE
feat(resources): ResourceWithParent trait

### DIFF
--- a/src/MoonShine.php
+++ b/src/MoonShine.php
@@ -53,6 +53,14 @@ class MoonShine
         return (config('moonshine.namespace') ?? static::NAMESPACE) . $path;
     }
 
+    public static function getResourceFromClassName(string $className): ?ResourceContract
+    {
+        return self::getResources()
+            ->first(
+                fn (ResourceContract $resource): bool => get_class($resource) === $className
+            );
+    }
+
     public static function getResourceFromUriKey(?string $uri): ?ResourceContract
     {
         if (is_null($uri)) {

--- a/src/Traits/Resource/ResourceWithParent.php
+++ b/src/Traits/Resource/ResourceWithParent.php
@@ -4,28 +4,34 @@ declare(strict_types=1);
 
 namespace MoonShine\Traits\Resource;
 
-use MoonShine\Resources\ModelResource;
+use MoonShine\MoonShine;
 
 trait ResourceWithParent
 {
-    protected ?string $parentId = null;
+    protected null|string|int $parentId = null;
 
-    abstract protected function getParentResource(): ModelResource;
+    abstract public function getItemID(): int|string|null;
+
+    abstract protected function getParentResourceClassName(): string;
 
     abstract protected function getParentRelationName(): string;
 
-    protected function getParentId()
+    protected function getParentId(): null|string|int
     {
         if(! is_null($this->parentId)) {
             return $this->parentId;
         }
 
-        $parentResource = $this->getParentResource();
+        $parentResource = Moonshine::getResourceFromClassName($this->getParentResourceClassName());
+
+        if(is_null($parentResource)) {
+            return null;
+        }
 
         $relationName = $this->getParentRelationName();
 
         if(moonshineRequest()->getResourceUri() === $parentResource->uriKey()) {
-            return $this->parentId = request('resourceItem');
+            return $this->parentId = $this->getItemID();
         }
 
         if(request($parentKey = $this->getModel()

--- a/src/Traits/Resource/ResourceWithParent.php
+++ b/src/Traits/Resource/ResourceWithParent.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Traits\Resource;
+
+use MoonShine\Resources\ModelResource;
+
+trait ResourceWithParent
+{
+    protected ?string $parentId = null;
+
+    abstract protected function getParentResource(): ModelResource;
+
+    abstract protected function getParentRelationName(): string;
+
+    protected function getParentId()
+    {
+        if(! is_null($this->parentId)) {
+            return $this->parentId;
+        }
+
+        $parentResource = $this->getParentResource();
+
+        $relationName = $this->getParentRelationName();
+
+        if(moonshineRequest()->getResourceUri() === $parentResource->uriKey()) {
+            return $this->parentId = request('resourceItem');
+        }
+
+        if(request($parentKey = $this->getModel()
+            ?->{$relationName}()
+            ->getForeignKeyName()))
+        {
+            return $this->parentId = request($parentKey);
+        }
+
+        if(is_null($this->getItem())) {
+            return $this->parentId = moonshineRequest()->getParentResourceId();
+        }
+
+        $parentKey = $this->getItem()->{$relationName}()->getOwnerKeyName();
+
+        return $this->parentId = $this->getItem()?->{$relationName}->{$parentKey};
+    }
+}

--- a/tests/Feature/Resources/ResourceWithFileHasManyTest.php
+++ b/tests/Feature/Resources/ResourceWithFileHasManyTest.php
@@ -11,6 +11,7 @@ use MoonShine\Pages\Crud\FormPage;
 use MoonShine\Resources\ModelResource;
 use MoonShine\Tests\Fixtures\Models\Item;
 use MoonShine\Tests\Fixtures\Resources\TestFileResource;
+use MoonShine\Tests\Fixtures\Resources\TestFileResourceWithParent;
 use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
 
 uses()->group('resources-feature');
@@ -56,6 +57,50 @@ it('not delete a has many file after delete item', function () {
     deleteItemWithHasMany($this->resource, $this->item->getKey());
 
     Storage::disk('public')->assertExists($file->hashName());
+});
+
+it('delete a has many file after delete item with parent', function () {
+
+    $fileResource = new TestFileResourceWithParent();
+
+    $resource = TestResourceBuilder::new(Item::class)
+        ->setTestFields([
+            ID::make()->sortable(),
+            Text::make('Name', 'name')->sortable(),
+            HasMany::make('Files', 'itemFiles', resource: $fileResource),
+        ])
+    ;
+
+    $file = UploadedFile::fake()->create('test.csv');
+
+    $data = [
+        'path' => $file,
+        'item_id' => $this->item->id,
+    ];
+
+    asAdmin()->post(
+        $fileResource->route('crud.store', $this->item->getKey()),
+        $data
+    )
+        ->assertRedirect();
+
+    $this->item->refresh();
+
+    $filePath = 'item_files/'.$this->item->id.'/'.$file->hashName();
+
+    expect($this->item->itemFiles)
+        ->not()->toBeNull()
+        ->and($this->item->itemFiles->first()->path)
+        ->toBe($filePath)
+    ;
+
+    Storage::disk('public')->assertExists($filePath);
+
+    $this->resource->setDeleteRelationships();
+
+    deleteItemWithHasMany($resource, $this->item->getKey());
+
+    Storage::disk('public')->assertMissing($filePath);
 });
 
 function addHasManyFile(ModelResource $resource, Model $item)

--- a/tests/Fixtures/Resources/TestFileResourceWithParent.php
+++ b/tests/Fixtures/Resources/TestFileResourceWithParent.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace MoonShine\Tests\Fixtures\Resources;
+
+use Illuminate\Database\Eloquent\Model;
+use MoonShine\Fields\File;
+use MoonShine\Fields\ID;
+use MoonShine\Fields\Relationships\BelongsTo;
+use MoonShine\Resources\ModelResource;
+use MoonShine\Tests\Fixtures\Models\FileModel;
+use MoonShine\Traits\Resource\ResourceWithParent;
+
+class TestFileResourceWithParent extends TestFileResource
+{
+    use ResourceWithParent;
+
+    public function fields(): array
+    {
+        $parentId = $this->getParentId();
+
+        return [
+            ID::make()->sortable(),
+            File::make('File', 'path')->dir('item_files/'.$parentId),
+            BelongsTo::make('Item', resource: new TestItemResource()),
+        ];
+    }
+
+    protected function getParentResourceClassName(): string
+    {
+        return TestItemResource::class;
+    }
+
+    protected function getParentRelationName(): string
+    {
+        return 'item';
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,6 +23,7 @@ use MoonShine\Tests\Fixtures\Resources\TestCategoryResource;
 use MoonShine\Tests\Fixtures\Resources\TestCommentResource;
 use MoonShine\Tests\Fixtures\Resources\TestCoverResource;
 use MoonShine\Tests\Fixtures\Resources\TestFileResource;
+use MoonShine\Tests\Fixtures\Resources\TestFileResourceWithParent;
 use MoonShine\Tests\Fixtures\Resources\TestImageResource;
 use MoonShine\Tests\Fixtures\Resources\TestItemResource;
 use MoonShine\Tests\Fixtures\TestServiceProvider;
@@ -116,6 +117,7 @@ class TestCase extends Orchestra
             new TestCommentResource(),
             new TestImageResource(),
             new TestFileResource(),
+            new TestFileResourceWithParent(),
 
             new MoonShineUserRoleResource(),
         ], newCollection: true);


### PR DESCRIPTION
Now you can connect the parent resource and get the id of its element

```php
class PostImageResource extends ModelResource
{
    use ResourceWithParent;

    public string $model = PostImage::class;

    public string $title = 'PostImage';

    protected function getParentResource(): ModelResource
    {
        return new PostResource();
    }

    protected function getParentRelationName(): string
    {
        return 'post';
    }

    public function fields(): array
    {
        //Get PostResource item id
        $parentId = $this->getParentId();
...
```