### PR TITLE
[2.0] active QueryTag by default

### DIFF
--- a/src/Fields/Relationships/HasMany.php
+++ b/src/Fields/Relationships/HasMany.php
@@ -271,7 +271,7 @@ class HasMany extends ModelRelationField implements HasFields
         return TableBuilder::make(items: $this->toValue())
             ->async($asyncUrl)
             ->when(
-                $this->isSearchable() && !empty($this->getResource()->search()),
+                $this->isSearchable() && ! empty($this->getResource()->search()),
                 fn (TableBuilder $table): TableBuilder => $table->searchable()
             )
             ->name($this->getRelationName())

--- a/src/QueryTags/QueryTag.php
+++ b/src/QueryTags/QueryTag.php
@@ -45,7 +45,7 @@ final class QueryTag
 
     public function isActive(): bool
     {
-        return ($this->isDefault && !request()->filled('query-tag')) || request('query-tag') === $this->uri();
+        return ($this->isDefault && ! request()->filled('query-tag')) || request('query-tag') === $this->uri();
     }
 
     public function apply(Builder $builder): Builder

--- a/src/QueryTags/QueryTag.php
+++ b/src/QueryTags/QueryTag.php
@@ -6,6 +6,7 @@ namespace MoonShine\QueryTags;
 
 use Closure;
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use MoonShine\Support\Condition;
 use MoonShine\Traits\HasCanSee;
 use MoonShine\Traits\Makeable;
 use MoonShine\Traits\WithIcon;
@@ -21,6 +22,8 @@ final class QueryTag
     use HasCanSee;
     use WithLabel;
 
+    protected bool $isDefault = false;
+
     public function __construct(
         Closure|string $label,
         protected Closure $builder,
@@ -33,9 +36,16 @@ final class QueryTag
         return str($this->label())->slug()->value();
     }
 
+    public function default(Closure|bool|null $condition = null): self
+    {
+        $this->isDefault = Condition::boolean($condition, true);
+
+        return $this;
+    }
+
     public function isActive(): bool
     {
-        return request('query-tag') === $this->uri();
+        return ($this->isDefault && !request()->filled('query-tag')) || request('query-tag') === $this->uri();
     }
 
     public function apply(Builder $builder): Builder

--- a/src/QueryTags/QueryTag.php
+++ b/src/QueryTags/QueryTag.php
@@ -45,7 +45,11 @@ final class QueryTag
 
     public function isActive(): bool
     {
-        return ($this->isDefault && ! request()->filled('query-tag')) || request('query-tag') === $this->uri();
+        if ($this->isDefault && ! request()->filled('query-tag')) {
+            return true;
+        }
+
+        return request('query-tag') === $this->uri();
     }
 
     public function apply(Builder $builder): Builder

--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -211,19 +211,17 @@ trait ResourceModelQuery
 
     protected function resolveTags(): static
     {
-        if ($tagUri = request('query-tag')) {
-            $tag = collect($this->queryTags())
-                ->first(
-                    fn (QueryTag $tag): bool => $tag->uri() === $tagUri
-                );
+        $tag = collect($this->queryTags())
+            ->first(
+                fn (QueryTag $tag): bool => $tag->isActive()
+            );
 
-            if ($tag) {
-                $this->customBuilder(
-                    $tag->apply(
-                        $this->query()
-                    )
-                );
-            }
+        if ($tag) {
+            $this->customBuilder(
+                $tag->apply(
+                    $this->query()
+                )
+            );
         }
 
         return $this;


### PR DESCRIPTION
Активный пункт по умолчанию ->default(Closure|bool|null $condition = null)
```
public function queryTags(): array
    {
        return [
            QueryTag::make(
                'All posts',
                fn(Builder $query) => $query
            )->default(),

            QueryTag::make(
                'Post with author',
                fn(Builder $query) => $query->whereNotNull('author_id')
            ),

            QueryTag::make(
                'Post without an author',
                fn(Builder $query) => $query->whereNull('author_id')
            )->icon('heroicons.users')->canSee(fn() => auth()->user()->moonshine_user_role_id === 1)
        ];
    }
```