### PR TITLE
Changing the retrieval of field objects

### DIFF
--- a/src/Buttons/HasMany/HasManyEditButton.php
+++ b/src/Buttons/HasMany/HasManyEditButton.php
@@ -32,7 +32,7 @@ final class HasManyEditButton
 
         $isAsync = $resource->isAsync() || $field->isAsync();
 
-        $getFieldsFunction = function () use ($resource, $field, $isAsync, $parent) {
+        $getFields = function () use ($resource, $field, $isAsync, $parent) {
             $fields = $resource->getFormFields();
 
             $fields->onlyFields()
@@ -76,7 +76,7 @@ final class HasManyEditButton
                         $resource->getModelCast()
                     )
                     ->submit(__('moonshine::ui.save'), ['class' => 'btn-primary btn-lg'])
-                    ->fields($getFieldsFunction)
+                    ->fields($getFields)
                     ->redirect(
                         $isAsync ? null : to_page(
                             moonshineRequest()->getResource()

--- a/src/Components/RowComponent.php
+++ b/src/Components/RowComponent.php
@@ -48,14 +48,16 @@ abstract class RowComponent extends MoonshineComponent implements HasFields
 
     public function preparedFields(): Fields
     {
-        $this->getFields()->fill(
+        $fields = $this->getFields();
+
+        $fields->fill(
             $this->unCastData($this->getValues()),
             $this->castData($this->getValues())
         );
 
-        $this->getFields()->prepareAttributes();
+        $fields->prepareAttributes();
 
-        return $this->getFields();
+        return $fields;
     }
 
     public function getButtons(): ActionButtons

--- a/src/Components/TableBuilder.php
+++ b/src/Components/TableBuilder.php
@@ -67,6 +67,7 @@ final class TableBuilder extends IterableComponent implements TableContract
             $raw = $this->unCastData($data);
 
             $fields = $this->getFields();
+            $fields->fill($raw, $casted, $index);
 
             if (! is_null($this->getName())) {
                 $fields->onlyFields()->each(
@@ -76,7 +77,7 @@ final class TableBuilder extends IterableComponent implements TableContract
 
             return TableRow::make(
                 $casted,
-                $fields->fillCloned($raw, $casted, $index),
+                $fields,
                 $this->getButtons($casted),
                 $this->trAttributes,
                 $this->tdAttributes

--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -18,22 +18,11 @@ final class Fields extends FormElements
     /**
      * @throws Throwable
      */
-    public function fillCloned(array $raw = [], mixed $casted = null, int $index = 0): self
-    {
-        return $this->onlyFields()->map(
-            fn (Field $field): Field => (clone $field)
-                ->resolveFill($raw, $casted, $index)
-        );
-    }
-
-    /**
-     * @throws Throwable
-     */
-    public function fill(array $raw = [], mixed $casted = null): void
+    public function fill(array $raw = [], mixed $casted = null, int $index = 0): void
     {
         $this->onlyFields()->map(
             fn (Field $field): Field => $field
-                ->resolveFill($raw, $casted)
+                ->resolveFill($raw, $casted, $index)
         );
     }
 

--- a/src/Fields/Relationships/HasMany.php
+++ b/src/Fields/Relationships/HasMany.php
@@ -204,7 +204,7 @@ class HasMany extends ModelRelationField implements HasFields
         $resource = $this->getResource();
 
         return TableBuilder::make(items: $items)
-            ->fields($this->preparedFields())
+            ->fields(fn() => $this->getResource()->getIndexFields()->toArray())
             ->cast($resource->getModelCast())
             ->preview()
             ->simple()

--- a/src/Fields/Relationships/HasMany.php
+++ b/src/Fields/Relationships/HasMany.php
@@ -240,25 +240,30 @@ class HasMany extends ModelRelationField implements HasFields
             relation: $this->getRelationName()
         );
 
-        $fields = $this->preparedFields();
+        $getFields = function () {
+            $fields = $this->getResource()->getIndexFields();
 
-        $fields->each(function (Field $field): void {
-            if (
-                $field instanceof HasUpdateOnPreview
-                && $field->isUpdateOnPreview()
-                && is_null($field->getUrl())
-            ) {
-                $field->setUpdateOnPreviewUrl(
-                    updateRelationColumnRoute(
-                        $field->getResourceUriForUpdate(),
-                        $field->getPageUriForUpdate(),
-                        $this->getRelationName(),
-                    )
-                );
-            }
-        });
+            $fields->each(function (Field $field): void {
+                if (
+                    $field instanceof HasUpdateOnPreview
+                    && $field->isUpdateOnPreview()
+                    && is_null($field->getUrl())
+                ) {
+                    $field->setUpdateOnPreviewUrl(
+                        updateRelationColumnRoute(
+                            $field->getResourceUriForUpdate(),
+                            $field->getPageUriForUpdate(),
+                            $this->getRelationName(),
+                        )
+                    );
+                }
+            });
 
-        $fields->onlyFields()->each(fn (Field $field): Field => $field->setParent($this));
+            $fields->onlyFields()->each(fn (Field $field): Field => $field->setParent($this));
+
+            return $fields->toArray();
+        };
+
 
         $parentId = $this->getRelatedModel()?->getKey();
 
@@ -275,7 +280,7 @@ class HasMany extends ModelRelationField implements HasFields
                 fn (TableBuilder $table): TableBuilder => $table->searchable()
             )
             ->name($this->getRelationName())
-            ->fields($fields)
+            ->fields($getFields)
             ->cast($resource->getModelCast())
             ->when(
                 $this->isNowOnForm(),

--- a/src/Handlers/ExportHandler.php
+++ b/src/Handlers/ExportHandler.php
@@ -123,8 +123,9 @@ class ExportHandler extends Handler
 
             $fields = $resource
                 ->getIndexFields()
-                ->exportFields()
-                ->fillCloned($item->toArray(), $item, $index);
+                ->exportFields();
+
+            $fields->fill($item->toArray(), $item, $index);
 
             foreach ($fields as $field) {
                 $row[$field->label()] = $field

--- a/src/Pages/Crud/IndexPage.php
+++ b/src/Pages/Crud/IndexPage.php
@@ -155,7 +155,7 @@ class IndexPage extends Page
         return [
             Fragment::make([
                 TableBuilder::make(items: $this->getResource()->paginate())
-                    ->fields($this->getResource()->getIndexFields())
+                    ->fields(fn() => $this->getResource()->getIndexFields()->toArray())
                     ->cast($this->getResource()->getModelCast())
                     ->withNotFound()
                     ->when(

--- a/src/Traits/WithFields.php
+++ b/src/Traits/WithFields.php
@@ -31,6 +31,9 @@ trait WithFields
      */
     public function getFields(mixed $data = null): Fields
     {
+        /**
+         * If this method is called from within a loop, it is important to use fieldsClosure
+         */
         if(! is_null($this->fieldsClosure)) {
             $this->fields = value($this->fieldsClosure, $data, $this);
         }

--- a/tests/Feature/Fields/DateRangeFieldTest.php
+++ b/tests/Feature/Fields/DateRangeFieldTest.php
@@ -6,6 +6,7 @@ use MoonShine\Applies\Filters\DateRangeModelApply;
 use MoonShine\Fields\DateRange;
 use MoonShine\Handlers\ExportHandler;
 use MoonShine\Handlers\ImportHandler;
+use MoonShine\Pages\Crud\DetailPage;
 use MoonShine\Pages\Crud\FormPage;
 use MoonShine\Pages\Crud\IndexPage;
 use MoonShine\Tests\Fixtures\Models\Item;
@@ -26,10 +27,9 @@ it('show field on pages', function () {
     $from = now();
     $to = now()->addMonth();
 
-    $item = Item::factory()->create([
-        'start_date' => $from,
-        'end_date' => $to,
-    ]);
+    $this->item->start_date = $from->format('Y-m-d');
+    $this->item->end_date = $to->format('Y-m-d');
+    $this->item->save();
 
     asAdmin()->get(
         to_page(page: IndexPage::class, resource: $resource)
@@ -39,18 +39,16 @@ it('show field on pages', function () {
         ->assertSee($from->format('d.m.Y') . ' - ' . $to->format('d.m.Y'))
     ;
 
-    /*
-     * TODO range empty value just in tests
-     * asAdmin()->get(
-        to_page(page: DetailPage::class, resource: $resource, params: ['resourceItem' => $item->getKey()])
+    asAdmin()->get(
+        to_page(page: DetailPage::class, resource: $resource, params: ['resourceItem' => $this->item->getKey()])
     )
         ->assertOk()
         ->assertSee('Range')
         ->assertSee($from->format('d.m.Y') . ' - ' . $to->format('d.m.Y'))
-    ;*/
+    ;
 
     asAdmin()->get(
-        to_page(page: FormPage::class, resource: $resource, params: ['resourceItem' => $item->getKey()])
+        to_page(page: FormPage::class, resource: $resource, params: ['resourceItem' => $this->item->getKey()])
     )
         ->assertOk()
         ->assertSee('range')

--- a/tests/Feature/Fields/Relationships/HasManyFieldTest.php
+++ b/tests/Feature/Fields/Relationships/HasManyFieldTest.php
@@ -98,7 +98,7 @@ it('onlyLink preview condition', function () {
         ->get(to_page(page: IndexPage::class, resource: $resource))
         ->assertOk()
         ->assertSee('Comments title')
-        ->assertSee($item->comments[0]->content)
+        ->assertSee($item->comments->first()->content)
         ->assertDontSee('(6)')
     ;
 });


### PR DESCRIPTION
Now working with fields inside a loop, each element has its own field object, without using clone