### PR TITLE
feat(components): Async Mode for Table and Form refactoring

### DIFF
--- a/resources/js/alpine/formBuilder.js
+++ b/resources/js/alpine/formBuilder.js
@@ -74,10 +74,12 @@ export default () => ({
 
         const type = data.messageType ? data.messageType : 'success'
 
-        t.$dispatch('toast', {
-          type: type,
-          text: data.message,
-        })
+        if(data.message) {
+          t.$dispatch('toast', {
+            type: type,
+            text: data.message,
+          })
+        }
 
         let isFormReset = false
 
@@ -131,6 +133,10 @@ export default () => ({
       event.target.getAttribute('name'),
       event.target.closest('form').getAttribute('id'),
     )
+  },
+
+  formReset() {
+    this.$el.reset()
   },
 
   showWhenChange,

--- a/routes/moonshine.php
+++ b/routes/moonshine.php
@@ -64,7 +64,7 @@ Route::prefix(config('moonshine.route.prefix', ''))
                     Route::get('/{notification}', 'read')->name('read');
                 });
 
-            Route::get('/async/{pageUri}/{resourceUri}', [AsyncController::class, 'table'])->name('async.table');
+            Route::get('/async/{pageUri}/{resourceUri?}', [AsyncController::class, 'table'])->name('async.table');
         });
 
         if (config('moonshine.auth.enable', true)) {

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -164,6 +164,7 @@ final class FormBuilder extends RowComponent
         if ($this->isAsync()) {
             $this->customAttributes([
                 'x-on:submit.prevent' => 'async($event.target, `' . $this->asyncEvents() . '`)',
+                '@form-reset-' . $this->getName() ?? 'default' . '.window' => 'formReset',
             ]);
         }
 

--- a/src/Components/TableBuilder.php
+++ b/src/Components/TableBuilder.php
@@ -105,6 +105,14 @@ final class TableBuilder extends IterableComponent implements TableContract
         return $this;
     }
 
+    public function async(?string $asyncUrl = null, ?string $asyncEvents = null): self
+    {
+        $this->asyncUrl = $asyncUrl ?? tableAsyncRoute($this->getName());
+        $this->asyncEvents = $asyncEvents;
+
+        return $this;
+    }
+
     protected function prepareAsyncUrlFromPaginator(): string
     {
         $withoutQuery = strtok($this->asyncUrl(), '?');

--- a/src/Traits/Fields/UpdateOnPreview.php
+++ b/src/Traits/Fields/UpdateOnPreview.php
@@ -60,6 +60,10 @@ trait UpdateOnPreview
         }
 
         if (! is_null($resource)) {
+            if (is_null($resource->formPage())) {
+                throw new FieldException('To use the updateOnPreview method, you must set FormPage to the Resource');
+            }
+
             $this->updateColumnResourceUri = $resource->uriKey();
             $this->updateColumnPageUri = $resource->formPage()->uriKey();
         }


### PR DESCRIPTION
Now the resource is not required for async table retrieval. The tableAsyncRoute helper is automatically applied to the table in the async method if the url is not specified. New form-reset event to reset the form

```php
Block::make([
    FormBuilder::make('/admin/page/form-demo', 'GET')
        ->fields([
            Text::make('Title')
        ])
        ->name('main-form')
        ->async(asyncEvents: 'table-updated-main-table,form-reset-main-form')
]),

TableBuilder::make()
    ->fields([
        Text::make('Title'),
        Textarea::make('Body')
    ])
    ->items($this->fetch())
    ->name('main-table')
    ->async()
```