### PR TITLE
feat: AsyncEvents

### DIFF
--- a/resources/views/components/table/builder.blade.php
+++ b/resources/views/components/table/builder.blade.php
@@ -24,8 +24,8 @@
     {{ (int) $async }},
     '{{ $asyncUrl }}'
 )"
-    @add-table-row.window="add(true)"
     data-pushstate="{{ $attributes->get('data-pushstate', false)}}"
+    @add-table-row.window="add(true)"
     @if($async) @table-updated-{{ $name }}.window="asyncRequest" @endif
 >
     @if($async && $searchable)

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -77,12 +77,9 @@ final class FormBuilder extends RowComponent
         return $this->isPrecognitive;
     }
 
-    public function async(?string $asyncUrl = null, ?string $asyncEvents = null): self
+    protected function prepareAsyncUrl(?string $asyncUrl = null): ?string
     {
-        $this->asyncUrl = $asyncUrl ?? $this->getAction();
-        $this->asyncEvents = $asyncEvents;
-
-        return $this;
+        return $asyncUrl ?? $this->getAction();
     }
 
     public function method(string $method): self
@@ -128,7 +125,7 @@ final class FormBuilder extends RowComponent
         return $this->submitLabel ?? __('moonshine::ui.save');
     }
 
-    public function switchFormMode(bool $isAsync, string $asyncEvents = ''): self
+    public function switchFormMode(bool $isAsync, string|array|null $asyncEvents = ''): self
     {
         return $isAsync ? $this->async(asyncEvents: $asyncEvents) : $this->precognitive();
     }

--- a/src/Components/TableBuilder.php
+++ b/src/Components/TableBuilder.php
@@ -122,12 +122,9 @@ final class TableBuilder extends IterableComponent implements TableContract
         return $this;
     }
 
-    public function async(?string $asyncUrl = null, ?string $asyncEvents = null): self
+    protected function prepareAsyncUrl(?string $asyncUrl = null): ?string
     {
-        $this->asyncUrl = $asyncUrl ?? tableAsyncRoute($this->getName());
-        $this->asyncEvents = $asyncEvents;
-
-        return $this;
+        return $asyncUrl ?? tableAsyncRoute($this->getName());
     }
 
     protected function prepareAsyncUrlFromPaginator(): string

--- a/src/Traits/HasAsync.php
+++ b/src/Traits/HasAsync.php
@@ -8,16 +8,21 @@ trait HasAsync
 {
     protected ?string $asyncUrl = null;
 
-    protected ?string $asyncEvents = null;
+    protected string|array|null $asyncEvents = null;
 
     public function isAsync(): bool
     {
         return ! is_null($this->asyncUrl);
     }
 
-    public function async(?string $asyncUrl = null, ?string $asyncEvents = null): static
+    protected function prepareAsyncUrl(?string $asyncUrl = null): ?string
     {
-        $this->asyncUrl = $asyncUrl;
+        return $asyncUrl;
+    }
+
+    public function async(?string $asyncUrl = null, string|array|null $asyncEvents = null): static
+    {
+        $this->asyncUrl = $this->prepareAsyncUrl($asyncUrl);
         $this->asyncEvents = $asyncEvents;
 
         return $this;
@@ -28,8 +33,13 @@ trait HasAsync
         return $this->asyncUrl;
     }
 
-    public function asyncEvents(): ?string
+    public function asyncEvents(): string|array|null
     {
-        return $this->asyncEvents;
+        return is_array($this->asyncEvents)
+            ? collect($this->asyncEvents)
+                ->map(fn($value) => (string) str($value)->squish())
+                ->filter()
+                ->implode(',')
+            : $this->asyncEvents;
     }
 }


### PR DESCRIPTION
Now you can pass events in an array type, and the approach to implementing an async trait has been improved

**Examples**

```php
FormBuilder::make(route('endpoint'))
                    ->name('main-form')
                    ->async(asyncEvents: ['table-updated-main-table','form-reset-main-form'])
```

```php
TableBuilder::make()
                ->name('main-table')
                ->async()
```

**Available events**
`table-updated-{{TableBuilder->name}}`, `form-reset-{{FormBuilder->name}}`

**Important**
The async method must be after the name method