### PR TITLE
fix: Json

### DIFF
--- a/src/Fields/Json.php
+++ b/src/Fields/Json.php
@@ -365,11 +365,12 @@ class Json extends Field implements
             }
 
             $preparedValues = $this->prepareOnApply($applyValues);
+            $values = $this->isKeyValue() ? $preparedValues : array_values($preparedValues);
 
             return data_set(
                 $item,
-                $this->column(),
-                $this->isKeyValue() ? $preparedValues : array_values($preparedValues)
+                str_replace('.', '->', $this->column()),
+                $values
             );
         };
     }


### PR DESCRIPTION
We can receive values through a dot, but if we are talking about a JSON field, then we can also save it, and the remaining keys will not be overwritten in the JSON

```json
{"info": [{"title": "Info title", "value": "Info value"}], "content": [{"title": "Content title", "value": "Content value"}]}
```

```php
Json::make('Data', 'data.content')->fields([
      Text::make('Title'),
      Text::make('Value'),
  ])->removable(),
```