### PR TITLE
feat: FormBuilder apply

### DIFF
--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -35,7 +35,6 @@ final class FormBuilder extends RowComponent
         '_force_redirect',
         '_redirect',
         '_method',
-        '_token',
         '_component_name',
         '_async_field'
     ];

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -195,10 +195,11 @@ final class FormBuilder extends RowComponent
         }
 
         try {
-            $fields = $this->preparedFields()->onlyFields();
-
-            $fields->exceptElements(
-                fn (Field $element): bool => ! in_array($element->column(), $this->getExcludedFields(), true)
+            $fields = $this
+                ->preparedFields()
+                ->onlyFields()
+                ->exceptElements(
+                fn (Field $element): bool => in_array($element->column(), $this->getExcludedFields(), true)
             );
 
             $values = is_null($before) ? $values : $before($values);

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -31,6 +31,15 @@ final class FormBuilder extends RowComponent
         'submitLabel',
     ];
 
+    protected array $excludeFields = [
+        '_force_redirect',
+        '_redirect',
+        '_method',
+        '_token',
+        '_component_name',
+        '_async_field'
+    ];
+
     protected bool $isPrecognitive = false;
 
     protected ?string $submitLabel = null;
@@ -138,6 +147,18 @@ final class FormBuilder extends RowComponent
         return $isAsync ? $this->async(asyncEvents: $asyncEvents) : $this->precognitive();
     }
 
+    public function getExcludedFields(): array
+    {
+        return $this->excludeFields;
+    }
+
+    public function excludeFields(array $excludeFields): self
+    {
+        $this->excludeFields = array_merge($this->excludeFields, $excludeFields);
+
+        return $this;
+    }
+
     public function onBeforeFieldsRender(Closure $closure): self
     {
         $this->onBeforeFieldsRender = $closure;
@@ -175,6 +196,10 @@ final class FormBuilder extends RowComponent
 
         try {
             $fields = $this->preparedFields()->onlyFields();
+
+            $fields->exceptElements(
+                fn (Field $element): bool => ! in_array($element->column(), $this->getExcludedFields(), true)
+            );
 
             $values = is_null($before) ? $values : $before($values);
 


### PR DESCRIPTION
Form instance

```php
$form = FormBuilder::make()
            ->fields($fields)
            ->fillCast($item, $this->getModelCast());
```

Use in controller

```php
$form->apply(fn(Model $item) => $item->save());
```


A difficult example with all the features from the ModelResource

```php
$form->apply(
                static fn(Model $item) => $item->save(),
                default: fn(Field $field) => $this->onSave($field),
                before: function (Model $item) {
                    if (! $item->exists) {
                        $item = $this->beforeCreating($item);
                    }

                    if ($item->exists) {
                        $item = $this->beforeUpdating($item);
                    }

                    return $item;
                },
                after: function (Model $item) {
                    $wasRecentlyCreated = $item->wasRecentlyCreated;

                    $item->save();

                    if ($wasRecentlyCreated) {
                        $item = $this->afterCreated($item);
                    }

                    if (! $wasRecentlyCreated) {
                        $item = $this->afterUpdated($item);
                    }

                    return $item;
                },
                throw: true
            );
```