### PR TITLE
refactor: ColorManager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": "^8.1|^8.2",
+    "php": "^8.1|^8.2|^8.3",
     "ext-curl": "*",
     "ext-json": "*",
     "rap2hpoutre/fast-excel": "^5.0",

--- a/resources/views/layouts/shared/assets.blade.php
+++ b/resources/views/layouts/shared/assets.blade.php
@@ -12,12 +12,12 @@
 
 <style>
     :root {
-    @foreach (moonshineAssets()->getColors() as $name => $value)
+    @foreach (moonshineColors()->all() as $name => $value)
     --{{ $name }}:{{ $value }};
     @endforeach
     }
     :root.dark {
-    @foreach (moonshineAssets()->getColors(dark: true) as $name => $value)
+    @foreach (moonshineColors()->all(dark: true) as $name => $value)
         --{{ $name }}:{{ $value }};
     @endforeach
     }

--- a/resources/views/layouts/shared/favicon.blade.php
+++ b/resources/views/layouts/shared/favicon.blade.php
@@ -1,0 +1,9 @@
+<link rel="apple-touch-icon" sizes="180x180" href="{{ asset('vendor/moonshine/apple-touch-icon.png') }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ asset('vendor/moonshine/favicon-32x32.png') }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ asset('vendor/moonshine/favicon-16x16.png') }}">
+
+<link rel="manifest" href="{{ asset('vendor/moonshine/site.webmanifest') }}">
+<link rel="mask-icon"
+      href="{{ asset('vendor/moonshine/safari-pinned-tab.svg') }}"
+      color="{{ moonshineColors()->get('body') }}"
+>

--- a/resources/views/layouts/shared/head.blade.php
+++ b/resources/views/layouts/shared/head.blade.php
@@ -12,15 +12,7 @@
 
 <meta name="csrf-token" content="{{ csrf_token() }}">
 
-<link rel="apple-touch-icon" sizes="180x180" href="{{ asset('vendor/moonshine/apple-touch-icon.png') }}">
-<link rel="icon" type="image/png" sizes="32x32" href="{{ asset('vendor/moonshine/favicon-32x32.png') }}">
-<link rel="icon" type="image/png" sizes="16x16" href="{{ asset('vendor/moonshine/favicon-16x16.png') }}">
+@include('moonshine::layouts.shared.favicon')
 
-<link rel="manifest" href="{{ asset('vendor/moonshine/site.webmanifest') }}">
-<link rel="mask-icon"
-      href="{{ asset('vendor/moonshine/safari-pinned-tab.svg') }}"
-      color="{{ moonshineAssets()->getColor('body') }}"
->
-
-<meta name="msapplication-TileColor" content="{{ moonshineAssets()->getColor('body') }}">
-<meta name="theme-color" content="{{ moonshineAssets()->getColor('body') }}">
+<meta name="msapplication-TileColor" content="{{ moonshineColors()->get('body') }}">
+<meta name="theme-color" content="{{ moonshineColors()->get('body') }}">

--- a/src/Providers/MoonShineApplicationServiceProvider.php
+++ b/src/Providers/MoonShineApplicationServiceProvider.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace MoonShine\Providers;
 
+use Closure;
 use Illuminate\Support\ServiceProvider;
-use MoonShine\AssetManager;
 use MoonShine\Contracts\Resources\ResourceContract;
 use MoonShine\Menu\MenuElement;
 use MoonShine\Menu\MenuManager;
@@ -30,18 +30,10 @@ class MoonShineApplicationServiceProvider extends ServiceProvider
 
         MoonShine::resolveRoutes();
 
-        $theme = $this->theme();
+        $theme = is_closure($this->theme()) ? $this->theme() : fn() => $this->theme();
 
-        moonshineAssets()->when(
-            isset($theme['css']) && $theme['css'] !== '',
-            static fn (AssetManager $assets): AssetManager => $assets->mainCss($theme['css'])
-        )->when(
-            isset($theme['colors']) && $theme['colors'] !== [],
-            static fn (AssetManager $assets): AssetManager => $assets->colors($theme['colors'])
-        )->when(
-            isset($theme['darkColors']) && $theme['darkColors'] !== [],
-            static fn (AssetManager $assets): AssetManager => $assets->darkColors($theme['darkColors'])
-        );
+        moonshineColors()->lazyAssign($theme);
+        moonshineAssets()->lazyAssign($theme);
     }
 
     /**
@@ -77,9 +69,9 @@ class MoonShineApplicationServiceProvider extends ServiceProvider
     }
 
     /**
-     * @return array{css: string, colors: array, darkColors: array}
+     * @return Closure|array{css: string, colors: array, darkColors: array}
      */
-    protected function theme(): array
+    protected function theme(): Closure|array
     {
         return [];
     }

--- a/src/Providers/MoonShineServiceProvider.php
+++ b/src/Providers/MoonShineServiceProvider.php
@@ -14,7 +14,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
-use MoonShine\AssetManager;
 use MoonShine\Commands\InstallCommand;
 use MoonShine\Commands\MakeApplyCommand;
 use MoonShine\Commands\MakeComponentCommand;
@@ -32,6 +31,8 @@ use MoonShine\Menu\MenuManager;
 use MoonShine\MoonShine;
 use MoonShine\MoonShineRegister;
 use MoonShine\MoonShineRequest;
+use MoonShine\Theme\AssetManager;
+use MoonShine\Theme\ColorManager;
 
 class MoonShineServiceProvider extends ServiceProvider
 {
@@ -148,6 +149,7 @@ class MoonShineServiceProvider extends ServiceProvider
         $this->app->singleton(MoonShine::class);
         $this->app->singleton(MenuManager::class);
         $this->app->singleton(AssetManager::class);
+        $this->app->singleton(ColorManager::class);
         $this->app->singleton(MoonShineRegister::class);
 
         $this->loadAuthConfig();

--- a/src/Theme/AssetManager.php
+++ b/src/Theme/AssetManager.php
@@ -49,14 +49,18 @@ class AssetManager
         return $this->mainJs;
     }
 
-    public function add(string|array $assets): void
+    public function add(string|array|Closure $assets): void
     {
-        $this->assets = array_unique(
-            array_merge(
-                $this->assets,
-                is_array($assets) ? $assets : [$assets]
-            )
-        );
+        if (is_closure($assets)) {
+            $this->lazyAssign($assets);
+        } else {
+            $this->assets = array_unique(
+                array_merge(
+                    $this->assets,
+                    is_array($assets) ? $assets : [$assets]
+                )
+            );
+        }
     }
 
     public function getAssets(): array
@@ -73,8 +77,8 @@ class AssetManager
             )
             ->map(
                 fn ($asset): string => "<script defer src='" . asset(
-                    $asset
-                ) . (str_contains((string) $asset, '?') ? '&' : '?') . "v={$this->getVersion()}'></script>"
+                        $asset
+                    ) . (str_contains((string) $asset, '?') ? '&' : '?') . "v={$this->getVersion()}'></script>"
             )->implode(PHP_EOL);
     }
 
@@ -87,8 +91,8 @@ class AssetManager
             )
             ->map(
                 fn ($asset): string => "<link href='" . asset(
-                    $asset
-                ) . (str_contains((string) $asset, '?') ? '&' : '?') . "v={$this->getVersion()}' rel='stylesheet'>"
+                        $asset
+                    ) . (str_contains((string) $asset, '?') ? '&' : '?') . "v={$this->getVersion()}' rel='stylesheet'>"
             )->implode(PHP_EOL);
     }
 

--- a/src/Theme/AssetManager.php
+++ b/src/Theme/AssetManager.php
@@ -2,66 +2,35 @@
 
 declare(strict_types=1);
 
-namespace MoonShine;
+namespace MoonShine\Theme;
 
+use Closure;
 use Composer\InstalledVersions;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\Traits\Conditionable;
-use MoonShine\Support\Colors;
+use MoonShine\MoonShine;
 
-/**
- * @todo pull theme options into a separate class
- */
 class AssetManager
 {
     use Conditionable;
 
     private array $assets = [];
 
-    private array $colors = [
-        'primary' => '120, 67, 233',
-        'secondary' => '236, 65, 118',
-        'body' => '27, 37, 59',
-        'dark' => [
-            'DEFAULT' => '30, 31, 67',
-            50 => '83, 103, 132',
-            100 => '74, 90, 121',
-            200 => '65, 81, 114',
-            300 => '53, 69, 103',
-            400 => '48, 61, 93',
-            500 => '41, 53, 82',
-            600 => '40, 51, 78',
-            700 => '39, 45, 69',
-            800 => '27, 37, 59',
-            900 => '15, 23, 42',
-        ],
-
-        'success-bg' => '0, 170, 0',
-        'success-text' => '255, 255, 255',
-        'warning-bg' => '255, 220, 42',
-        'warning-text' => '139, 116, 0',
-        'error-bg' => '224, 45, 45',
-        'error-text' => '255, 255, 255',
-        'info-bg' => '0, 121, 255',
-        'info-text' => '255, 255, 255',
-    ];
-
-    private array $darkColors = [
-        'body' => '27, 37, 59',
-        'success-bg' => '17, 157, 17',
-        'success-text' => '178, 255, 178',
-        'warning-bg' => '225, 169, 0',
-        'warning-text' => '255, 255, 199',
-        'error-bg' => '190, 10, 10',
-        'error-text' => '255, 197, 197',
-        'info-bg' => '38, 93, 205',
-        'info-text' => '179, 220, 255',
-    ];
-
     private string $mainJs = '/vendor/moonshine/assets/app.js';
 
     private string $mainCss = '/vendor/moonshine/assets/main.css';
+
+    private ?Closure $lazy = null;
+
+    private bool $extracted = false;
+
+    public function lazyAssign(Closure $closure): self
+    {
+        $this->lazy = $closure;
+
+        return $this;
+    }
 
     public function mainCss(string $path): self
     {
@@ -123,8 +92,29 @@ class AssetManager
             )->implode(PHP_EOL);
     }
 
+    private function lazyExtract(): void
+    {
+        if (! $this->extracted) {
+            $this->when(
+                value($this->lazy, moonshineRequest()),
+                fn (self $class, array $data) => $class
+                    ->when(
+                        isset($data['css']) && $data['css'] !== '',
+                        static fn (AssetManager $assets): AssetManager => $assets->mainCss($data['css'])
+                    )->when(
+                        isset($data['assets']) && $data['assets'] !== [],
+                        static fn (AssetManager $assets) => $assets->add($data['assets'])
+                    )
+            );
+        }
+
+        $this->extracted = true;
+    }
+
     public function toHtml(): string
     {
+        $this->lazyExtract();
+
         if ($this->isRunningHot()) {
             $vendorAssets = Vite::useBuildDirectory('vendor/moonshine')
                 ->useHotFile($this->hotFile())
@@ -143,53 +133,6 @@ class AssetManager
     private function hotFile(): string
     {
         return MoonShine::path('/public') . '/hot';
-    }
-
-    public function colors(array $colors): static
-    {
-        foreach ($colors as $name => $color) {
-            $this->colors[$name] = $color;
-        }
-
-        return $this;
-    }
-
-    public function darkColors(array $colors): static
-    {
-        foreach ($colors as $name => $color) {
-            $this->darkColors[$name] = $color;
-        }
-
-        return $this;
-    }
-
-    public function getColor(string $name, ?int $shade = null, bool $dark = false, bool $hex = true): string
-    {
-        $data = $dark ? $this->darkColors : $this->colors;
-        $value = $data[$name];
-        $value = is_null($shade)
-            ? $value
-            : $value[$shade];
-
-        return $hex ? Colors::toHEX($value) : $value;
-    }
-
-    public function getColors(bool $dark = false): array
-    {
-        $colors = [];
-        $data = $dark ? $this->darkColors : $this->colors;
-
-        foreach ($data as $name => $shades) {
-            if (! is_array($shades)) {
-                $colors[$name] = Colors::toRGB($shades);
-            } else {
-                foreach ($shades as $shade => $color) {
-                    $colors["$name-$shade"] = Colors::toRGB($color);
-                }
-            }
-        }
-
-        return $colors;
     }
 
     public function getVersion(): string

--- a/src/Theme/ColorManager.php
+++ b/src/Theme/ColorManager.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Theme;
+
+use Closure;
+use Illuminate\Support\Traits\Conditionable;
+use MoonShine\Support\Colors;
+
+final class ColorManager
+{
+    use Conditionable;
+
+    public const TEXT = '255, 255, 255';
+
+    public const BG = '27, 37, 59';
+
+    public const DEFAULT = [
+        'primary' => '120, 67, 233',
+        'secondary' => '236, 65, 118',
+        'body' => self::BG,
+        'dark' => [
+            'DEFAULT' => '30, 31, 67',
+            50 => '83, 103, 132', // search, toasts, progress bars
+            100 => '74, 90, 121', // dividers
+            200 => '65, 81, 114', // dividers
+            300 => '53, 69, 103', // borders
+            400 => '48, 61, 93', // dropdowns, buttons, pagination
+            500 => '41, 53, 82', // buttons default bg
+            600 => '40, 51, 78', // table row
+            700 => '39, 45, 69', // background content
+            800 => self::BG, // background sidebar
+            900 => '15, 23, 42', // background
+        ],
+
+        'success-bg' => '0, 170, 0',
+        'success-text' => self::TEXT,
+        'warning-bg' => '255, 220, 42',
+        'warning-text' => '139, 116, 0',
+        'error-bg' => '224, 45, 45',
+        'error-text' => self::TEXT,
+        'info-bg' => '0, 121, 255',
+        'info-text' => self::TEXT,
+    ];
+
+    public const DARK = [
+        'body' => self::BG,
+        'success-bg' => '17, 157, 17',
+        'success-text' => '178, 255, 178',
+        'warning-bg' => '225, 169, 0',
+        'warning-text' => '255, 255, 199',
+        'error-bg' => '190, 10, 10',
+        'error-text' => '255, 197, 197',
+        'info-bg' => '38, 93, 205',
+        'info-text' => '179, 220, 255',
+    ];
+
+    private array $colors = self::DEFAULT;
+
+    private array $darkColors = self::DARK;
+
+    private ?Closure $lazy = null;
+
+    private bool $extracted = false;
+
+    public function background(string $value): self
+    {
+        return $this
+            ->set('body', $value)
+            ->set('dark.800', $value)
+            ->set('body', $value, dark: true)
+        ;
+    }
+
+    public function tableRow(string $value): self
+    {
+        return $this
+            ->set('dark.600', $value)
+        ;
+    }
+
+    public function borders(string $value): self
+    {
+        return $this
+            ->set('dark.300', $value)
+        ;
+    }
+
+    public function dropdowns(string $value): self
+    {
+        return $this
+            ->set('dark.400', $value)
+        ;
+    }
+
+    public function buttons(string $value): self
+    {
+        return $this
+            ->set('dark.50', $value)
+            ->set('dark.500', $value)
+            ->dropdowns($value)
+        ;
+    }
+
+    public function dividers(string $value): self
+    {
+        return $this
+            ->set('dark.100', $value)
+            ->set('dark.200', $value)
+        ;
+    }
+
+    public function content(string $value): self
+    {
+        return $this
+            ->set('dark.700', $value)
+            ->set('dark.900', $value)
+        ;
+    }
+
+    public function set(string $name, string|array $value, bool $dark = false): self
+    {
+        data_set($this->{$dark ? 'darkColors' : 'colors'}, $name, $value);
+
+        return $this;
+    }
+
+    public function bulkAssign(array $colors, bool $dark = false): self
+    {
+        foreach ($colors as $name => $color) {
+            $this->set($name, $color, $dark);
+        }
+
+        return $this;
+    }
+
+    public function lazyAssign(Closure $closure): self
+    {
+        $this->lazy = $closure;
+
+        return $this;
+    }
+
+    private function lazyExtract(): void
+    {
+        if (! $this->extracted) {
+            $this->when(
+                value($this->lazy, moonshineRequest()),
+                fn (self $class, array $data) => $class
+                    ->bulkAssign(data_get($data, 'colors', []))
+                    ->bulkAssign(data_get($data, 'darkColors', []), dark: true)
+            );
+        }
+
+        $this->extracted = true;
+    }
+
+    public function get(string $name, ?int $shade = null, bool $dark = false, bool $hex = true): string
+    {
+        $this->lazyExtract();
+
+        $data = $dark ? $this->darkColors : $this->colors;
+        $value = $data[$name];
+        $value = is_null($shade)
+            ? $value
+            : $value[$shade];
+
+        $hexValue = is_array($value) ? $value['DEFAULT'] : $value;
+
+        return $hex ?
+            Colors::toHEX($hexValue)
+            : $value;
+    }
+
+    public function all(bool $dark = false): array
+    {
+        $this->lazyExtract();
+
+        $colors = [];
+        $data = $dark ? $this->darkColors : $this->colors;
+
+        foreach ($data as $name => $shades) {
+            if (! is_array($shades)) {
+                $colors[$name] = Colors::toRGB($shades);
+            } else {
+                foreach ($shades as $shade => $color) {
+                    $colors["$name-$shade"] = Colors::toRGB($color);
+                }
+            }
+        }
+
+        return $colors;
+    }
+
+    public function __call(string $name, array $arguments): self
+    {
+        $this->set($name, $arguments[0] ?? '', dark: $arguments[1] ?? false);
+
+        return $this;
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -8,7 +8,6 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\ViewErrorBag;
 use MoonShine\ActionButtons\ActionButton;
-use MoonShine\AssetManager;
 use MoonShine\Components\FormBuilder;
 use MoonShine\Components\TableBuilder;
 use MoonShine\Contracts\ApplyContract;
@@ -24,6 +23,8 @@ use MoonShine\MoonShineRequest;
 use MoonShine\MoonShineRouter;
 use MoonShine\Pages\Page;
 use MoonShine\Support\SelectOptions;
+use MoonShine\Theme\AssetManager;
+use MoonShine\Theme\ColorManager;
 
 if (! function_exists('moonshine')) {
     function moonshine(): MoonShine
@@ -50,6 +51,13 @@ if (! function_exists('moonshineAssets')) {
     function moonshineAssets(): AssetManager
     {
         return app(AssetManager::class);
+    }
+}
+
+if (! function_exists('moonshineColors')) {
+    function moonshineColors(): ColorManager
+    {
+        return app(ColorManager::class);
     }
 }
 


### PR DESCRIPTION
colors improvements
```php
public function boot(): void
{
  parent::boot();
  
  moonshineColors()
      ->background('#A3C3D9')
      ->content('#A3C3D9')
      ->tableRow('#AE76A6')
      ->dividers('#AE76A6')
      ->borders('#AE76A6')
      ->buttons('#AE76A6')
      ->primary('#CCD6EB')
      ->secondary('#AE76A6')
  ;
}
```

theme closure

```php
protected function theme(): Closure|array
{
    return static function (MoonShineRequest $request) {
        return [];
    }
}

```

BREAKING CHANGE: assets.blade changed, head.blade changed