### PR TITLE
feat: Menu closure

### DIFF
--- a/src/Menu/MenuManager.php
+++ b/src/Menu/MenuManager.php
@@ -4,20 +4,21 @@ declare(strict_types=1);
 
 namespace MoonShine\Menu;
 
+use Closure;
 use Illuminate\Support\Collection;
 
 class MenuManager
 {
-    protected static ?Collection $menu = null;
+    protected static Closure|Collection|array|null $menu = null;
 
-    public static function register(Collection $data): void
+    public static function register(Closure|array|Collection $data): void
     {
         self::$menu = $data;
     }
 
     public static function all(): ?Collection
     {
-        return self::$menu?->filter(function (MenuElement $item): bool {
+        return collect(value(self::$menu, moonshineRequest()))?->filter(function (MenuElement $item): bool {
             if ($item instanceof MenuGroup) {
                 $item->setItems(
                     $item->items()->filter(

--- a/src/MoonShine.php
+++ b/src/MoonShine.php
@@ -155,21 +155,23 @@ class MoonShine
     /**
      * Register Menu with resources and pages in the system
      *
-     * @param  array<MenuElement>  $data
-     * @throws Throwable
+     * @param  Closure|array<MenuElement>  $data
      */
-    public static function menu(array $data, bool $newCollection = false): void
+    public static function init(array|Closure $data, bool $newCollection = false): void
     {
-        self::$menu = $newCollection ? collect() : self::getMenu();
         self::$pages = self::getPages();
         self::$resources = self::getResources();
 
-        collect($data)->merge(self::getVendorsMenu())->each(
-            function (MenuElement $item): void {
-                self::$menu->add($item);
-                self::resolveMenuItem($item);
-            }
-        );
+        if(!is_closure($data)) {
+            self::$menu = $newCollection ? collect() : self::getMenu();
+
+            collect($data)->merge(self::getVendorsMenu())->each(
+                function (MenuElement $item): void {
+                    self::$menu->add($item);
+                    self::resolveMenuItem($item);
+                }
+            );
+        }
 
         self::$resources->add(new MoonShineProfileResource());
 

--- a/src/Providers/MoonShineApplicationServiceProvider.php
+++ b/src/Providers/MoonShineApplicationServiceProvider.php
@@ -24,13 +24,17 @@ class MoonShineApplicationServiceProvider extends ServiceProvider
     {
         MoonShine::resources($this->resources());
         MoonShine::pages($this->pages());
-        MoonShine::menu($this->menu());
 
-        MenuManager::register(MoonShine::getMenu());
+        $menu = $this->menu();
+
+        MoonShine::init($menu);
+        MenuManager::register($menu);
 
         MoonShine::resolveRoutes();
 
-        $theme = is_closure($this->theme()) ? $this->theme() : fn (): array|Closure => $this->theme();
+        $theme = is_closure($this->theme())
+            ? $this->theme()
+            : fn (): array|Closure => $this->theme();
 
         moonshineColors()->lazyAssign($theme);
         moonshineAssets()->lazyAssign($theme);
@@ -61,9 +65,9 @@ class MoonShineApplicationServiceProvider extends ServiceProvider
     }
 
     /**
-     * @return array<MenuElement>
+     * @return Closure|array<MenuElement>
      */
-    protected function menu(): array
+    protected function menu(): Closure|array
     {
         return [];
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -122,7 +122,7 @@ class TestCase extends Orchestra
             new MoonShineUserRoleResource(),
         ], newCollection: true);
 
-        MoonShine::menu([
+        MoonShine::init([
             MenuItem::make('Admins', $this->moonShineUserResource()),
         ], newCollection: true);
 

--- a/tests/Unit/MoonShineTest.php
+++ b/tests/Unit/MoonShineTest.php
@@ -18,7 +18,7 @@ it('find resource by uri key', function (): void {
 });
 
 it('menu', function (): void {
-    MoonShine::menu([
+    MoonShine::init([
         MenuItem::make('Resource', $this->resource),
     ]);
 


### PR DESCRIPTION
Lazy load with request instance

```php
protected function menu(): Closure|array
{
    return static function (MoonShineRequest $request) {
        return [
        ];
    };
}
```

### But with this approach you must add resources and pages to the provider methods

```php
 protected function resources(): array
{
    return [
        new CommentResource(),
        new CategoryResource(),
        new UserResource(),
        new ArticleResource(),
    ];
}

protected function pages(): array
{
    return [
        new CustomPage(),
    ];
}
```