### PR TITLE
Profile to layout builder

### DIFF
--- a/resources/views/components/layout/profile.blade.php
+++ b/resources/views/components/layout/profile.blade.php
@@ -11,7 +11,7 @@
 @if($withBorder) <div {{ $attributes->merge(['class' => 'mt-2 border-t border-dark-200']) }}> @endif
     {{ $before ?? '' }}
 
-    @if($slot->isNotEmpty())
+    @if(isset($slot) && $slot->isNotEmpty())
         {{ $slot }}
     @else
         <div class="menu-profile">

--- a/resources/views/components/layout/sidebar.blade.php
+++ b/resources/views/components/layout/sidebar.blade.php
@@ -36,12 +36,6 @@
 
         {{ $slot ?? '' }}
 
-        @if($profile ?? false)
-            {{ $profile }}
-        @elseif(config('moonshine.auth.enable', true))
-            <x-moonshine::layout.profile :with-border="true" />
-        @endif
-
         <!-- Bottom menu -->
         <div
             @if(($profile ?? false) || config('moonshine.auth.enable', true))

--- a/resources/views/components/layout/top-bar.blade.php
+++ b/resources/views/components/layout/top-bar.blade.php
@@ -25,11 +25,9 @@
     </nav>
 
     <div class="menu-actions">
-        @if($profile ?? false)
-            {{ $profile }}
-        @elseif(config('moonshine.auth.enable', true))
-            <x-moonshine::layout.profile />
-        @endif
+        <x-moonshine::components
+            :components="$actions"
+        />
 
         <div class="menu-inner-divider"></div>
 

--- a/src/Components/Layout/TopBar.php
+++ b/src/Components/Layout/TopBar.php
@@ -10,4 +10,18 @@ namespace MoonShine\Components\Layout;
 class TopBar extends WithComponents
 {
     protected string $view = 'moonshine::components.layout.top-bar';
+
+    protected array $actions = [];
+
+    public function actions(array $actions): self
+    {
+        $this->actions = $actions;
+
+        return $this;
+    }
+
+    protected function viewData(): array
+    {
+        return parent::viewData() + ['actions' => $this->actions];
+    }
 }

--- a/src/MoonShineLayout.php
+++ b/src/MoonShineLayout.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace MoonShine;
 
-use MoonShine\Components\Layout\{Content, Flash, Footer, Header, LayoutBlock, LayoutBuilder, Menu, Sidebar};
+use MoonShine\Components\Layout\{Content, Flash, Footer, Header, LayoutBlock, LayoutBuilder, Menu, Profile, Sidebar};
+use MoonShine\Components\When;
 use MoonShine\Contracts\MoonShineLayoutContract;
 
 final class MoonShineLayout implements MoonShineLayoutContract
@@ -14,6 +15,10 @@ final class MoonShineLayout implements MoonShineLayoutContract
         return LayoutBuilder::make([
             Sidebar::make([
                 Menu::make()->customAttributes(['class' => 'mt-2']),
+                When::make(
+                    static fn() => config('moonshine.auth.enable', true),
+                    static fn() => [Profile::make()]
+                ),
             ]),
             LayoutBlock::make([
                 Flash::make(),

--- a/src/MoonShineLayout.php
+++ b/src/MoonShineLayout.php
@@ -17,7 +17,7 @@ final class MoonShineLayout implements MoonShineLayoutContract
                 Menu::make()->customAttributes(['class' => 'mt-2']),
                 When::make(
                     static fn() => config('moonshine.auth.enable', true),
-                    static fn() => [Profile::make()]
+                    static fn() => [Profile::make(withBorder: true)]
                 ),
             ]),
             LayoutBlock::make([

--- a/stubs/Layout.stub
+++ b/stubs/Layout.stub
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace {namespace};
 
-use MoonShine\Components\Layout\{Content, Flash, Footer, Header, LayoutBlock, LayoutBuilder, Menu, Sidebar};
+use MoonShine\Components\Layout\{Content, Flash, Footer, Header, LayoutBlock, LayoutBuilder, Menu, Sidebar, Profile};
+use MoonShine\Components\When;
 use MoonShine\Contracts\MoonShineLayoutContract;
 
 final class MoonShineLayout implements MoonShineLayoutContract
@@ -14,6 +15,10 @@ final class MoonShineLayout implements MoonShineLayoutContract
         return LayoutBuilder::make([
             Sidebar::make([
                 Menu::make()->customAttributes(['class' => 'mt-2']),
+                When::make(
+                    static fn() => config('moonshine.auth.enable', true),
+                    static fn() => [Profile::make()]
+                ),
             ]),
             LayoutBlock::make([
                 Flash::make(),

--- a/stubs/Layout.stub
+++ b/stubs/Layout.stub
@@ -17,7 +17,7 @@ final class MoonShineLayout implements MoonShineLayoutContract
                 Menu::make()->customAttributes(['class' => 'mt-2']),
                 When::make(
                     static fn() => config('moonshine.auth.enable', true),
-                    static fn() => [Profile::make()]
+                    static fn() => [Profile::make(withBorder: true)]
                 ),
             ]),
             LayoutBlock::make([


### PR DESCRIPTION
Now you can configure profile component in LayoutBuilder

```php
Sidebar::make([
    Menu::make()->customAttributes(['class' => 'mt-2']),
    When::make(
        static fn() => config('moonshine.auth.enable', true),
        static fn() => [Profile::make(withBorder: true)]
    ),
]),
```

```php
TopBar::make([
    Menu::make()->top(),
])->actions([
    When::make(
        static fn() => config('moonshine.auth.enable', true),
        static fn() => [Profile::make()]
    )
]),
```