### PR TITLE
feat: Async callback

### DIFF
--- a/resources/js/alpine/formBuilder.js
+++ b/resources/js/alpine/formBuilder.js
@@ -52,7 +52,7 @@ export default () => ({
     return false
   },
 
-  async(form, events = '', successFunction = '') {
+  async(form, events = '', callbackFunction = '') {
     submitState(form, true)
     const t = this
     const method = form.getAttribute('method')
@@ -73,8 +73,8 @@ export default () => ({
       },
     })
       .then(function (response) {
-        if(successFunction) {
-          t.applySuccessFunction(successFunction, response, form, events, t)
+        if(callbackFunction) {
+          t.applyCallbackFunction(callbackFunction, response, form, events, t)
           return
         }
 
@@ -110,8 +110,8 @@ export default () => ({
         }
       })
       .catch(errorResponse => {
-        if(successFunction) {
-          t.applySuccessFunction(successFunction, errorResponse.response, form, events, t)
+        if(callbackFunction) {
+          t.applyCallbackFunction(callbackFunction, errorResponse.response, form, events, t)
           return
         }
 
@@ -159,14 +159,14 @@ export default () => ({
 
   getInputs,
 
-  applySuccessFunction(successFunction, errorResponse, form, events, component)
+  applyCallbackFunction(callbackFunction, errorResponse, form, events, component)
   {
-    const fn = window[successFunction];
+    const fn = window[callbackFunction];
 
     if (typeof fn !== "function") {
       component.$dispatch('toast', {type: 'error', text: 'Error'})
       submitState(form, false)
-      throw new Error(successFunction + ' is not a function!');
+      throw new Error(callbackFunction + ' is not a function!');
     }
 
     fn.apply(null, [errorResponse, form, events, component]);

--- a/resources/js/alpine/formBuilder.js
+++ b/resources/js/alpine/formBuilder.js
@@ -52,7 +52,7 @@ export default () => ({
     return false
   },
 
-  async(form, events = '') {
+  async(form, events = '', successFunction = '') {
     submitState(form, true)
     const t = this
     const method = form.getAttribute('method')
@@ -73,6 +73,16 @@ export default () => ({
       },
     })
       .then(function (response) {
+        if(successFunction) {
+          const fn = window[successFunction];
+
+          if (typeof fn === "function") {
+            fn.apply(null, [response, form, events, t]);
+          }
+
+          return
+        }
+
         const data = response.data
 
         if (data.redirect) {
@@ -90,13 +100,8 @@ export default () => ({
 
         let isFormReset = false
 
-        if (type !== 'error') {
-          const modalParent = t.$el.closest('.modal')
-
-          if (modalParent !== null) {
-            modalParent.querySelector('.btn-close').click()
-            isFormReset = true
-          }
+        if (type !== 'error' && t.inModal) {
+          t.toggleModal()
         }
 
         submitState(form, false, isFormReset)

--- a/resources/js/alpine/modal.js
+++ b/resources/js/alpine/modal.js
@@ -3,6 +3,7 @@
 export default (open = false) => ({
   open: open,
   id: '',
+  inModal: true,
 
   init() {
     this.id = this.$id('modal-content')

--- a/resources/views/actions/default.blade.php
+++ b/resources/views/actions/default.blade.php
@@ -19,6 +19,7 @@
         :async="$action->modal()->isAsync()"
         :auto="$action->modal()->isAuto()"
         :wide="$action->modal()->isWide()"
+        :attributes="$action->modal()->attributes()"
         :closeOutside="$action->modal()->isCloseOutside()"
         :asyncUrl="$action->url()"
         title="{{ $action->modal()->title($action->getItem()) }}"

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -19,9 +19,9 @@
             x-transition:leave="transition ease-in duration-150"
             x-transition:leave-start="opacity-100 translate-y-0"
             x-transition:leave-end="opacity-0 -translate-y-10"
-            class="modal"
             aria-modal="true"
             role="dialog"
+            {{ $attributes->merge(['class' => 'modal']) }}
             @if($closeOutside) @click.self="open=false" @endif
         >
             <div class="modal-dialog

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -260,7 +260,7 @@ final class FormBuilder extends RowComponent
 
         if ($this->isAsync()) {
             $this->customAttributes([
-                'x-on:submit.prevent' => 'async($event.target, `' . $this->asyncEvents() . '`)',
+                'x-on:submit.prevent' => 'async($event.target, `' . $this->asyncEvents() . '`, `' . $this->asyncCallback() . '`)',
                 '@form-reset-' . ($this->getName() ?? 'default') . '.window' => 'formReset',
             ]);
         }

--- a/src/Traits/HasAsync.php
+++ b/src/Traits/HasAsync.php
@@ -10,6 +10,8 @@ trait HasAsync
 
     protected string|array|null $asyncEvents = null;
 
+    protected ?string $asyncCallback = null;
+
     public function isAsync(): bool
     {
         return ! is_null($this->asyncUrl);
@@ -20,10 +22,11 @@ trait HasAsync
         return $asyncUrl;
     }
 
-    public function async(?string $asyncUrl = null, string|array|null $asyncEvents = null): static
+    public function async(?string $asyncUrl = null, string|array|null $asyncEvents = null, string $asyncCallback = null): static
     {
         $this->asyncUrl = $this->prepareAsyncUrl($asyncUrl);
         $this->asyncEvents = $asyncEvents;
+        $this->asyncCallback = $asyncCallback;
 
         return $this;
     }
@@ -47,5 +50,10 @@ trait HasAsync
         }
 
         return $this->asyncEvents;
+    }
+
+    public function asyncCallback(): ?string
+    {
+        return $this->asyncCallback;
     }
 }

--- a/src/Traits/WithModal.php
+++ b/src/Traits/WithModal.php
@@ -42,12 +42,18 @@ trait WithModal
         bool $wide = false,
         bool $auto = false,
         bool $closeOutside = false,
+        array $attributes = [],
     ): static {
         $this->modal = Modal::make($title, $content, $async)
             ->auto($auto)
             ->wide($wide)
             ->closeOutside($closeOutside)
-            ->buttons($buttons);
+            ->buttons($buttons)
+        ;
+
+        if(! empty($attributes)) {
+            $this->modal->customAttributes($attributes);
+        }
 
         return $this;
     }

--- a/src/UI/Modal.php
+++ b/src/UI/Modal.php
@@ -3,6 +3,7 @@
 namespace MoonShine\UI;
 
 use Closure;
+use Illuminate\View\ComponentAttributeBag;
 use MoonShine\ActionButtons\ActionButtons;
 use MoonShine\Support\Condition;
 use MoonShine\Traits\HasAsync;
@@ -24,6 +25,8 @@ class Modal
 
     protected bool $isCloseOutside = false;
 
+    protected ComponentAttributeBag $attributes;
+
     public function __construct(
         protected string|Closure|null $title,
         protected string|Closure|null $content,
@@ -32,6 +35,8 @@ class Modal
         if ($async) {
             $this->async('#');
         }
+
+        $this->attributes = new ComponentAttributeBag();
     }
 
     public function wide(mixed $condition = null): self
@@ -83,6 +88,18 @@ class Modal
     public function buttons(array $buttons): self
     {
         $this->buttons = $buttons;
+
+        return $this;
+    }
+
+    public function attributes(): ComponentAttributeBag
+    {
+        return $this->attributes;
+    }
+
+    public function customAttributes(array $attributes): static
+    {
+        $this->attributes = $this->attributes->merge($attributes);
 
         return $this;
     }


### PR DESCRIPTION
 Now you can specify a function that will be executed after calling the async method on the form. Added attributes to the modal window

```php
return ActionButton::make('Test async form', '#')
    ->icon('heroicons.outline.plus')
    ->inModal(
        fn (): string => 'Go test',
        fn (): string => (string) FormBuilder::make(route('alert.post'), method: 'GET')
            ->fields([
                Text::make('Text'),
            ])
            ->submit('Отправить', ['class' => 'btn-primary'])
            ->async(asyncEvents: 'toggle-my-modal', asyncCallback: 'successAsync')
        ,
        attributes: [
            '@toggle-my-modal.window' => 'toggleModal'
        ]
    )
    ->showInLine();
```

In your js file:

```js
window.successAsync = function(response, element, events, component)
{
    console.log(response)
    console.log(element)
    console.log(events)
    console.log(component)

    events = events.split(',')
    events.forEach(function (event) {
        component.$dispatch(event.replaceAll(/\s/g, ''))
    })

    element.querySelector('.form_submit_button_loader').style.display = 'none'
    element.querySelector('.form_submit_button').removeAttribute('disabled')
    element.reset()
}
```