### PR TITLE
fix: path to social icons

### DIFF
--- a/resources/views/ui/social-auth.blade.php
+++ b/resources/views/ui/social-auth.blade.php
@@ -5,7 +5,7 @@
             @foreach(config('moonshine.socialite') as $driver => $src)
                 <a href="{{ route('moonshine.socialite.redirect', $driver) }}" class="social-item">
                     <img class="h-6 w-6"
-                         src="{{ $src }}"
+                         src="{{ asset($src) }}"
                          alt="{{ $driver }}"
                     >
                 </a>


### PR DESCRIPTION
Обернутл путь в хелпер asset, иначе пути строятся не верно.
![image](https://github.com/moonshine-software/moonshine/assets/17690542/f31fe56b-4fef-47ff-aa3d-8a980851a9a0)

