### PR TITLE
feat: Remove buttons improvements

### DIFF
--- a/resources/views/components/form/file-item.blade.php
+++ b/resources/views/components/form/file-item.blade.php
@@ -3,6 +3,7 @@
     'raw' => null,
     'download' => false,
     'removable' => true,
+    'removableAttributes' => null,
     'imageable' => true
 ])
 <div
@@ -28,9 +29,11 @@
 
     @if($removable)
         <button
-            class="dropzone-remove"
-            type="button"
-            @click.prevent="$event.target.closest('.x-removeable').remove()"
+            {{ $removableAttributes?->merge([
+                '@click.prevent' => '$event.target.closest(".x-removeable").remove()',
+                'type' => 'button',
+                'class' => 'dropzone-remove',
+            ]) }}
         >
             <x-moonshine::icon
                 icon="heroicons.x-mark"

--- a/resources/views/components/form/file.blade.php
+++ b/resources/views/components/form/file.blade.php
@@ -3,6 +3,7 @@
     'raw' => [],
     'download' => false,
     'removable' => true,
+    'removableAttributes' => null,
     'imageable' => true
 ])
 <div class="form-group form-group-dropzone">
@@ -24,6 +25,7 @@
                         :file="$file"
                         :download="$download"
                         :removable="$removable"
+                        :removableAttributes="$removableAttributes"
                         :imageable="$imageable"
                     />
                 @endforeach

--- a/resources/views/fields/file.blade.php
+++ b/resources/views/fields/file.blade.php
@@ -6,6 +6,7 @@
     :files="$element->getFullPathValues()"
     :raw="is_iterable($element->value()) ? $element->value() : [$element->value()]"
     :removable="$element->isRemovable()"
+    :removableAttributes="$element->getRemovableAttributes()"
     :imageable="false"
     :download="$element->canDownload()"
 />

--- a/resources/views/fields/image.blade.php
+++ b/resources/views/fields/image.blade.php
@@ -6,5 +6,6 @@
     :files="$element->getFullPathValues()"
     :raw="is_iterable($element->value()) ? $element->value() : [$element->value()]"
     :removable="$element->isRemovable()"
+    :removableAttributes="$element->getRemovableAttributes()"
     :imageable="true"
 />

--- a/src/Contracts/Fields/RemovableContract.php
+++ b/src/Contracts/Fields/RemovableContract.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace MoonShine\Contracts\Fields;
 
+use Closure;
+
 interface RemovableContract
 {
-    public function removable(): static;
+    public function removable(
+        Closure|bool|null $condition = null,
+        array $attributes = [],
+    ): static;
 
     public function isRemovable(): bool;
 }

--- a/src/Fields/Json.php
+++ b/src/Fields/Json.php
@@ -234,7 +234,7 @@ class Json extends Field implements
             $buttons[] = ActionButton::make('', '#')
                 ->icon('heroicons.outline.trash')
                 ->onClick(fn ($action): string => 'remove', 'prevent')
-                ->customAttributes(['class' => 'btn-secondary'])
+                ->customAttributes($this->removableAttributes ?: ['class' => 'btn-secondary'])
                 ->showInLine();
         }
 

--- a/src/Traits/Removable.php
+++ b/src/Traits/Removable.php
@@ -5,17 +5,29 @@ declare(strict_types=1);
 namespace MoonShine\Traits;
 
 use Closure;
+use Illuminate\View\ComponentAttributeBag;
 use MoonShine\Support\Condition;
 
 trait Removable
 {
     protected bool $removable = false;
 
-    public function removable(Closure|bool|null $condition = null): static
+    protected array $removableAttributes = [];
+
+    public function removable(
+        Closure|bool|null $condition = null,
+        array $attributes = []
+    ): static
     {
         $this->removable = Condition::boolean($condition, true);
+        $this->removableAttributes = $attributes;
 
         return $this;
+    }
+
+    public function getRemovableAttributes(): ComponentAttributeBag
+    {
+        return new ComponentAttributeBag($this->removableAttributes);
     }
 
     public function isRemovable(): bool


### PR DESCRIPTION
The remove method now also accepts attributes with which you can add

```php
 Image::make('Thumbnail')
    ->removable(attributes: ['@click.prevent' => '$event.target.closest(`.x-removeable`).remove()'])
```

```php
 File::make('File')
    ->removable(attributes: ['@click.prevent' => 'alert()', 'class' => 'my-class'])
```

```php
Json::make('Data', 'data.content')->fields([
    Text::make('Title'),
    Image::make('Image'),
    Text::make('Value'),
])
    ->removable(attributes: ['@click.prevent' => 'customAsyncRemove'])
    ->creatable(),
```