### PR TITLE
Include .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+* text=auto eol=lf
+
+*.blade.php diff=html
+*.css diff=css
+*.html diff=html
+*.md diff=markdown
+*.php diff=php
+
+/.github export-ignore
+/.tests export-ignore
+/.editorconfig export-ignore
+/.env.example export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/.prettierrc export-ignore
+/.package-lock.json export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit-example.xml.dist export-ignore
+/README.md export-ignore
+/rector.php export-ignore
+/Roadmap.md export-ignore
+/TODO.md export-ignore


### PR DESCRIPTION
При установки как пакет MoonShine тянет за собой слишком много ненужных файлов (эти файлы нужны разработчикам MoonShine, но не пользователям). Этот PR предлагает не включать ненужные файлы в итоговую поставку.

Подробности, что такое файл `.gitattributes` и инструкция `export-ignore`:
- [GitAttributes for PHP Composer Projects](https://php.watch/articles/composer-gitattributes)
- [Use gitattributes to keep your tests out of other people's production](https://madewithlove.com/blog/gitattributes/)