### PR TITLE
feat(modal): Modal autoClose mode

### DIFF
--- a/resources/js/alpine/formBuilder.js
+++ b/resources/js/alpine/formBuilder.js
@@ -104,7 +104,7 @@ export default () => ({
 
         let isFormReset = false
 
-        if (type !== 'error' && t.inModal) {
+        if (type !== 'error' && t.inModal && t.autoClose) {
           t.toggleModal()
         }
 

--- a/resources/js/alpine/modal.js
+++ b/resources/js/alpine/modal.js
@@ -1,11 +1,12 @@
 /* Modal */
 
-export default (open = false, asyncUrl = '') => ({
+export default (open = false, asyncUrl = '', autoClose = true) => ({
   open: open,
   id: '',
   asyncUrl: asyncUrl,
   inModal: true,
   asyncLoaded: false,
+  autoClose: autoClose,
 
   init() {
     this.id = this.$id('modal-content')

--- a/resources/views/actions/default.blade.php
+++ b/resources/views/actions/default.blade.php
@@ -20,7 +20,6 @@
         :auto="$action->modal()->isAuto()"
         :autoClose="$action->modal()->isAutoClose()"
         :wide="$action->modal()->isWide()"
-        :wide="$action->modal()->isWide()"
         :attributes="$action->modal()->attributes()"
         :closeOutside="$action->modal()->isCloseOutside()"
         :asyncUrl="$action->modal()->isAsync() ? $action->url() : ''"

--- a/resources/views/actions/default.blade.php
+++ b/resources/views/actions/default.blade.php
@@ -18,6 +18,8 @@
     <x-moonshine::modal
         :async="$action->modal()->isAsync()"
         :auto="$action->modal()->isAuto()"
+        :autoClose="$action->modal()->isAutoClose()"
+        :wide="$action->modal()->isWide()"
         :wide="$action->modal()->isWide()"
         :attributes="$action->modal()->attributes()"
         :closeOutside="$action->modal()->isCloseOutside()"

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -6,11 +6,12 @@
     'wide' => $isWide ?? false,
     'open' => $isOpen ?? false,
     'auto' => $isAuto ?? false,
+    'autoClose' => $isAutoClose ?? false,
     'closeOutside' => $isCloseOutside ?? true,
     'title' => '',
     'outerHtml' => null
 ])
-<div x-data="modal(`{{ $open }}`, `{{ $async ? str_replace('&amp;', '&', $asyncUrl) : ''}}`)">
+<div x-data="modal(`{{ $open }}`, `{{ $async ? str_replace('&amp;', '&', $asyncUrl) : ''}}`, `{{ $autoClose }}`)">
     <template x-teleport="body">
     <div class="modal-template" @modal-toggled-{{ $eventName ?? $name }}.window="toggleModal">
         <div

--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -25,6 +25,8 @@ final class Modal extends MoonShineComponent
 
     protected bool $auto = false;
 
+    protected bool $autoClose = true;
+
     protected array $outerAttributes = [];
 
     public function __construct(
@@ -63,6 +65,13 @@ final class Modal extends MoonShineComponent
         return $this;
     }
 
+    public function autoClose(Closure|bool|null $autoClose = null): self
+    {
+        $this->autoClose = is_null($autoClose) || Condition::boolean($autoClose, false);
+
+        return $this;
+    }
+
     public function outerAttributes(array $attributes): self
     {
         $this->outerAttributes = $attributes;
@@ -76,6 +85,7 @@ final class Modal extends MoonShineComponent
             'isWide' => $this->wide,
             'isOpen' => $this->open,
             'isAuto' => $this->auto,
+            'isAutoClose' => $this->autoClose,
             'isCloseOutside' => $this->closeOutside,
             'async' => ! empty($this->asyncUrl),
             'asyncUrl' => value($this->asyncUrl, $this) ?? '',

--- a/src/Traits/WithModal.php
+++ b/src/Traits/WithModal.php
@@ -43,10 +43,12 @@ trait WithModal
         bool $auto = false,
         bool $closeOutside = false,
         array $attributes = [],
+        bool $autoClose = true,
     ): static {
         $this->modal = Modal::make($title, $content, $async)
             ->auto($auto)
             ->wide($wide)
+            ->autoClose($autoClose)
             ->closeOutside($closeOutside)
             ->buttons($buttons)
         ;

--- a/src/UI/Modal.php
+++ b/src/UI/Modal.php
@@ -26,6 +26,8 @@ class Modal
 
     protected bool $isCloseOutside = false;
 
+    protected bool $isAutoClose = true;
+
     public function __construct(
         protected string|Closure|null $title,
         protected string|Closure|null $content,
@@ -39,6 +41,13 @@ class Modal
     public function wide(mixed $condition = null): self
     {
         $this->isWide = Condition::boolean($condition, true);
+
+        return $this;
+    }
+
+    public function autoClose(mixed $condition = null): self
+    {
+        $this->isAutoClose = Condition::boolean($condition, true);
 
         return $this;
     }
@@ -58,6 +67,11 @@ class Modal
     public function isAuto(): bool
     {
         return $this->isAuto;
+    }
+
+    public function isAutoClose(): bool
+    {
+        return $this->isAutoClose;
     }
 
     public function closeOutside(mixed $condition = null): self


### PR DESCRIPTION
You can now control the closing of modal windows when submitting a async form

Option 1
```php
Modal::make(
    'Demo modal',
    static fn() => FormBuilder::make(route('alert.post'))
        ->fields([
            Text::make('Text'),
        ])
        ->submit('Send', ['class' => 'btn-primary'])
        ->async(),
)
    ->name('demo-modal')
    ->autoClose(false), //Modal window don't close when form is submitted

ActionButton::make('Open modal', '#')
    ->onClick(fn() => "\$dispatch('modal-toggled-demo-modal')", 'prevent')
```
Option 2
```php
ActionButton::make('AsyncTest', '#')
    ->inModal(fn (): string => 'Go test',
        fn (): string => (string) FormBuilder::make(route('alert.post'), method: 'GET')
            ->fields([
                Text::make('Text'),
            ])
            ->submit('Отправить', ['class' => 'btn-primary'])
            ->async(),
            autoClose: false //Modal window don't close when form is submitted
    ),
```