### PR TITLE
feat: Template field

### DIFF
--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -188,7 +188,6 @@ final class FormBuilder extends RowComponent
         try {
             $fields = $this
                 ->preparedFields()
-                ->onlyFields()
                 ->exceptElements(
                     fn (Field $element): bool => in_array($element->column(), $this->getExcludedFields(), true)
                 );

--- a/src/Components/TableBuilder.php
+++ b/src/Components/TableBuilder.php
@@ -62,7 +62,7 @@ final class TableBuilder extends IterableComponent implements TableContract
      */
     public function rows(): Collection
     {
-        $tableFields = $this->getFields()->onlyFields();
+        $tableFields = $this->getFields();
 
         return $this->getItems()->filter()->map(function (mixed $data, int $index) use ($tableFields): TableRow {
             $casted = $this->castData($data);

--- a/src/Fields/Relationships/BelongsToMany.php
+++ b/src/Fields/Relationships/BelongsToMany.php
@@ -260,7 +260,6 @@ class BelongsToMany extends ModelRelationField implements
             ->iterableAttributes();
 
         $fields = $this->preparedFields()
-            ->onlyFields()
             ->prepend(
                 Preview::make($this->getResourceColumnLabel(), $titleColumn, $this->formattedValueCallback())
                     ->customAttributes(['class' => 'pivotTitle'])
@@ -367,7 +366,6 @@ class BelongsToMany extends ModelRelationField implements
         }
 
         $fields = $this->preparedFields()
-            ->onlyFields()
             ->prepend(Text::make($this->getResourceColumnLabel(), $column, $this->formattedValueCallback()))
             ->prepend(ID::make());
 

--- a/src/Fields/Template.php
+++ b/src/Fields/Template.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Fields;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+
+final class Template extends Field
+{
+    protected ?Closure $renderCallback = null;
+
+    protected function resolvePreview(): string
+    {
+        return '';
+    }
+
+    protected function prepareFill(array $raw = [], mixed $casted = null): mixed
+    {
+        if($this->isFillChanged()) {
+            return value(
+                $this->fillCallback,
+                $casted ?? $raw,
+                $this
+            );
+        }
+
+        return '';
+    }
+
+    public function changeRender(Closure $closure): self
+    {
+        $this->renderCallback = $closure;
+
+        return $this;
+    }
+
+    public function render(): View|string
+    {
+        return value($this->renderCallback, $this->toValue(), $this) ?? '';
+    }
+
+    protected function resolveOnApply(): ?Closure
+    {
+        return static fn ($item) => $item;
+    }
+}


### PR DESCRIPTION
Dummy field for dynamic implementation

```php
Template::make('Comment')
    ->changeFill(fn (Article $data) => $data->comment)
    ->changePreview(fn($data) => $data?->id ?? '-')
    ->changeRender(function (Comment $data) {
        $fields = (new CommentResource())
            ->getFormFields()
            ->wrapNames('comment');

        $fields->fill($data->toArray(), $data);

        return view('moonshine::components.fields-group', [
            'components' => $fields
        ]);
    })
    ->onAfterApply(function (Article $item, array $value) {
        $item->comment()->updateOrCreate([
            'id' => $value['id']
        ], $value);

        return $item;
    })
```