### PR TITLE
feat: Components in a modal

### DIFF
--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -108,7 +108,7 @@ final class Modal extends MoonShineComponent implements HasFields
      */
     public function hasFields(): bool
     {
-        return $this->components?->onlyFields()->isNotEmpty();
+        return ! is_null($this->components);
     }
 
     /**
@@ -116,12 +116,12 @@ final class Modal extends MoonShineComponent implements HasFields
      */
     public function getFields(): Fields
     {
-        return $this->components->onlyFields();
+        return Fields::make($this->components?->toArray() ?? []);
     }
 
     public function preparedFields(): Fields
     {
-        return $this->hasFields() ? $this->getFields() : new Fields();
+        return $this->getFields();
     }
 
     public function fields(array|Fields|Closure $fields): static

--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -8,12 +8,16 @@ use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\ComponentSlot;
 use MoonShine\ActionButtons\ActionButton;
+use MoonShine\Collections\MoonShineRenderElements;
+use MoonShine\Contracts\Fields\HasFields;
+use MoonShine\Fields\Fields;
 use MoonShine\Support\Condition;
+use Throwable;
 
 /**
  * @method static static make(Closure|string $title, Closure|View|string $content, Closure|View|ActionButton|string $outer = '', Closure|string|null $asyncUrl = '')
  */
-final class Modal extends MoonShineComponent
+final class Modal extends MoonShineComponent implements HasFields
 {
     protected string $view = 'moonshine::components.modal';
 
@@ -34,6 +38,7 @@ final class Modal extends MoonShineComponent
         protected Closure|View|string $content = '',
         protected Closure|View|ActionButton|string $outer = '',
         protected Closure|string|null $asyncUrl = null,
+        protected ?MoonShineRenderElements $components = null
     ) {
     }
 
@@ -81,6 +86,9 @@ final class Modal extends MoonShineComponent
 
     protected function viewData(): array
     {
+        $componentsHtml = $this->components?->isNotEmpty() ?
+            Components::make($this->components) : '' ;
+
         return [
             'isWide' => $this->wide,
             'isOpen' => $this->open,
@@ -90,8 +98,34 @@ final class Modal extends MoonShineComponent
             'async' => ! empty($this->asyncUrl),
             'asyncUrl' => value($this->asyncUrl, $this) ?? '',
             'title' => value($this->title, $this),
-            'slot' => new ComponentSlot(value($this->content, $this)),
+            'slot' => new ComponentSlot(value($this->content, $this).$componentsHtml),
             'outerHtml' => new ComponentSlot(value($this->outer, $this), $this->outerAttributes),
         ];
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function hasFields(): bool
+    {
+        return $this->components?->onlyFields()->isNotEmpty();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function getFields(): Fields
+    {
+        return $this->components->onlyFields();
+    }
+
+    public function preparedFields(): Fields
+    {
+        return $this->hasFields() ? $this->getFields() : new Fields();
+    }
+
+    public function fields(array|Fields|Closure $fields): static
+    {
+        return $this;
     }
 }

--- a/tests/Unit/Pages/PageComponentsTest.php
+++ b/tests/Unit/Pages/PageComponentsTest.php
@@ -1,8 +1,10 @@
 <?php
 
 use MoonShine\Components\FormBuilder;
+use MoonShine\Components\Modal;
 use MoonShine\Components\TableBuilder;
 use MoonShine\Decorations\Block;
+use MoonShine\Decorations\Fragment;
 use MoonShine\Decorations\LineBreak;
 use MoonShine\Decorations\Tab;
 use MoonShine\Decorations\Tabs;
@@ -44,6 +46,17 @@ beforeEach(function (): void {
 
         TableBuilder::make()
             ->name('parent-table'),
+
+        Modal::make(
+            'Test Modal',
+            components: PageComponents::make([
+                FormBuilder::make()->fields([
+                    Fragment::make([
+                        HasOne::make('HasModal', 'has_modal', resource: new TestResource())
+                    ]),
+                ])->name('form-in-modal')
+            ])
+        ),
     ])->name('block');
 
     $this->collection = PageComponents::make([
@@ -60,7 +73,7 @@ it('find table', function () {
 
 it('only forms', function () {
     expect($this->collection->onlyForms())
-        ->toHaveCount(2)
+        ->toHaveCount(3)
         ->each->toBeInstanceOf(FormBuilder::class);
 });
 
@@ -72,7 +85,7 @@ it('only tables', function () {
 
 it('only fields', function () {
     expect($this->collection->onlyFields())
-        ->toHaveCount(4)
+        ->toHaveCount(5)
         ->each->toBeInstanceOf(Field::class);
 });
 
@@ -97,6 +110,23 @@ it('find by name', function () {
         ->toBe('line-break');
 });
 
+it('find component in modal', function () {
+    expect($this->collection->findByName('form-in-modal'))
+        ->toBeInstanceOf(FormBuilder::class)
+        ->getName()
+        ->toBe('form-in-modal');
+});
+
+it('find has field in modal', function () {
+    expect($this->collection
+        ->onlyFields()
+        ->onlyHasFields()
+        ->findByColumn('has_modal')
+    )
+        ->not()
+        ->toBeNull();
+});
+
 it('form fields without outside', function () {
     expect($this->collection->onlyFields()->formFields(withOutside: false)->onlyFields())
         ->toHaveCount(2)
@@ -105,19 +135,19 @@ it('form fields without outside', function () {
 
 it('form fields with outside', function () {
     expect($this->collection->onlyFields()->formFields()->onlyFields())
-        ->toHaveCount(3)
+        ->toHaveCount(4)
         ->each->toBeInstanceOf(Field::class);
 });
 
 it('fields only outside', function () {
     expect($this->collection->onlyFields()->onlyOutside())
-        ->toHaveCount(1)
+        ->toHaveCount(2)
         ->each->toBeInstanceOf(HasOne::class);
 });
 
 it('form fields only outside', function () {
     expect($this->collection->onlyFields()->formFields()->onlyOutside())
-        ->toHaveCount(1)
+        ->toHaveCount(2)
         ->each->toBeInstanceOf(HasOne::class);
 });
 


### PR DESCRIPTION
Now you can pass a collection of components to a modal window. In this case, asyncSearch in the BelongsTo field will work.

```php
$modal = Modal::make(
    'Image Modal',
    components: PageComponents::make([$image])
)
    ->name('image-modal');
```