### PR TITLE
Allow aggregating related resources through withCount attribute

### DIFF
--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -25,6 +25,8 @@ trait ResourceModelQuery
 
     protected array $with = [];
 
+    protected array $withCount = [];
+
     protected string $sortColumn = '';
 
     protected string $sortDirection = 'DESC';
@@ -189,6 +191,10 @@ trait ResourceModelQuery
 
         if ($this->hasWith()) {
             $this->query->with($this->getWith());
+        }
+
+        if ($this->hasWithCount()) {
+            $this->query->withCount($this->getWithCount());
         }
 
         return $this->query;
@@ -443,6 +449,16 @@ trait ResourceModelQuery
     public function getWith(): array
     {
         return $this->with;
+    }
+
+    public function hasWithCount(): bool
+    {
+        return $this->withCount !== [];
+    }
+
+    public function getWithCount(): array
+    {
+        return $this->withCount;
     }
 
     public function sortColumn(): string


### PR DESCRIPTION
This little change allow to count related models and use the result number in fields, like we can use it in common eloquent queries: https://laravel.com/docs/10.x/eloquent-relationships#counting-related-models

```php

class MyResource extends ModelResource
{
    protected array $withCount = ['values'];
...

    public function indexFields(): array
    {
        return [
...
            Number::make('Counter', 'values_count')->sortable(),
        ];
    }

}


```