### PR TITLE
Fix Tabs fields

### DIFF
--- a/src/Decorations/Tabs.php
+++ b/src/Decorations/Tabs.php
@@ -21,9 +21,12 @@ class Tabs extends Decoration
 
     protected string $justifyAlign = 'start';
 
-    public function __construct(protected array $tabs = [])
+    /**
+     * @param list<Tab> $tabs
+     */
+    public function __construct(array $tabs = [])
     {
-        parent::__construct(uniqid('', true));
+        parent::__construct(uniqid('', true), $tabs);
     }
 
     public function active(string|int $active): self
@@ -71,7 +74,7 @@ class Tabs extends Decoration
     public function tabs(): Fields
     {
         return tap(
-            Fields::make($this->tabs),
+            Fields::make($this->fields),
             static function (Fields $tabs): void {
                 throw_if(
                     $tabs->every(fn ($tab): bool => ! $tab instanceof Tab),


### PR DESCRIPTION
An error occurs when specifying fields for a set of tabs:
```php
$tabs = Tabs::make();
$tabs->fields([ Tab::make( ... ), Tab::make( ... ) ]);
```

There are no other ways to add tabs to a `Tabs` instance.

This fix renames `$tabs->tabs` to the `$tabs->fields` to ensure compatibility with methods for working with child elements (fields).