### PR TITLE
feat: MoonShine global scope in js

### DIFF
--- a/resources/js/alpine/asyncFunctions.js
+++ b/resources/js/alpine/asyncFunctions.js
@@ -1,5 +1,5 @@
 export function responseCallback(callback, response, element, events, component) {
-  const fn = MoonShine.successAsyncFunctions[callback]
+  const fn = MoonShine.callbacks[callback]
 
   if (typeof fn !== 'function') {
     component.$dispatch('toast', {type: 'error', text: 'Error'})

--- a/resources/js/alpine/asyncFunctions.js
+++ b/resources/js/alpine/asyncFunctions.js
@@ -1,5 +1,5 @@
 export function responseCallback(callback, response, element, events, component) {
-  const fn = window[callback]
+  const fn = MoonShine.successAsyncFunctions[callback]
 
   if (typeof fn !== 'function') {
     component.$dispatch('toast', {type: 'error', text: 'Error'})

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -2,6 +2,7 @@ import './bootstrap'
 import './layout'
 
 import AlpineMS from 'alpinejs'
+import {MoonShine} from './moonshine.js'
 import persist from '@alpinejs/persist'
 import mask from '@alpinejs/mask'
 
@@ -31,6 +32,9 @@ import asyncLink from './alpine/asyncLink'
 import numberUpDown from './alpine/numberUpDown'
 import fragment from './alpine/fragment'
 import globalSearch from './alpine/globalSearch'
+
+window.MoonShine = new MoonShine();
+document.dispatchEvent(new CustomEvent('moonshine:init'))
 
 const alpineExists = !!window.Alpine
 

--- a/resources/js/moonshine.js
+++ b/resources/js/moonshine.js
@@ -1,11 +1,11 @@
 export class MoonShine {
     constructor() {
-        this.successAsyncFunctions = {}
+        this.callbacks = {}
     }
 
-    successAsyncFor(name, successFunction) {
-        if(typeof successFunction === 'function') {
-            this.successAsyncFunctions[name] = successFunction
+    onCallback(name, callback) {
+        if(typeof callback === 'function') {
+            this.callbacks[name] = callback
         }
     }
 }

--- a/resources/js/moonshine.js
+++ b/resources/js/moonshine.js
@@ -1,0 +1,11 @@
+export class MoonShine {
+    constructor() {
+        this.successAsyncFunctions = {}
+    }
+
+    successAsyncFor(name, successFunction) {
+        if(typeof successFunction === 'function') {
+            this.successAsyncFunctions[name] = successFunction
+        }
+    }
+}


### PR DESCRIPTION
BREAKING-CHANGE: now the function for "asyncCallback" is set differently

PHP:
```php
ActionButton::make('Test async form', '#')
    ->icon('heroicons.outline.plus')
    ->inModal(
        fn (): string => 'Go test',
        fn (): string => (string) FormBuilder::make(route('alert.post'))
            ->fields([
                Text::make('Text'),
            ])
            ->submit('Отправить', ['class' => 'btn-primary'])
            ->async(asyncEvents: 'toggle-my-modal', asyncCallback: 'mySuccess')
        ,
        attributes: [
            '@toggle-my-modal.window' => 'toggleModal'
        ]
    )
    ->showInLine()
```

Old js script for asyncCallback: 'mySuccess'
```js
window.mySuccess= function(response, element, events, component)
{
    console.log(response)
    console.log(element)
    console.log(events)
    console.log(component)
    //...
}
```
New
```js
document.addEventListener("moonshine:init", () => {
    MoonShine.onCallback('mySuccess', function(response, element, events, component) {
            console.log(response)
            console.log(element)
            console.log(events)
            console.log(component)
            //...
        }
    )
})
