### PR TITLE
fix: Add class inline-block for div

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -64,7 +64,7 @@
     </template>
 
     @if($outerHtml?->isNotEmpty())
-        <div {{ $outerHtml->attributes?->merge([
+        <div class="inline-block" {{ $outerHtml->attributes?->merge([
             '@click.prevent' => 'toggleModal',
         ]) }}>
             {{ $outerHtml ?? '' }}


### PR DESCRIPTION
If div is full-width, then the Alpine event is valid for the entire area

![image](https://github.com/moonshine-software/moonshine/assets/11013417/15aa68f2-c2d0-4643-ac8f-839a59312308)
