### PR TITLE
fix: Add click event to tag A from DIV

### DIFF
--- a/resources/views/actions/default.blade.php
+++ b/resources/views/actions/default.blade.php
@@ -37,7 +37,9 @@
 
         <x-slot name="outerHtml">
             <x-moonshine::link-button
-                :attributes="$attributes"
+                :attributes="$attributes?->merge([
+                    '@click.prevent' => 'toggleModal',
+                ])"
                 :icon="$action->iconValue()"
                 :href="$action->url()"
             >
@@ -58,7 +60,9 @@
         </x-moonshine::link-native>
     @else
         <x-moonshine::link-button
-            :attributes="$attributes"
+            :attributes="$attributes?->merge([
+                '@click.prevent' => 'toggleModal',
+            ])"
             @class(['p-2' => $action->inDropdown()])
             :href="$action->url()"
             :icon="$action->iconValue()"

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -64,9 +64,7 @@
     </template>
 
     @if($outerHtml?->isNotEmpty())
-        <div {{ $outerHtml->attributes?->merge([
-            '@click.prevent' => 'toggleModal',
-        ]) }}>
+        <div {{ $outerHtml->attributes }}>
             {{ $outerHtml ?? '' }}
         </div>
     @endif


### PR DESCRIPTION
If div is full-width, then the Alpine event is valid for the entire area

From pull request https://github.com/moonshine-software/moonshine/pull/784