### PR TITLE
fix: ActionButton bulk fix

### DIFF
--- a/resources/js/alpine/tableBuilder.js
+++ b/resources/js/alpine/tableBuilder.js
@@ -138,7 +138,9 @@ export default (
     let ids = document.querySelectorAll(
       '.hidden-ids[data-for-component=' + this.table.getAttribute('data-name') + ']',
     )
-    let bulkButtons = this.$root.querySelectorAll('[data-button-type=bulk-button]')
+    let bulkButtons = document.querySelectorAll(
+        '[data-button-type=bulk-button][data-for-component=' + this.table.getAttribute('data-name') + ']'
+    )
 
     //TODO Delete this block after updating the HiddenIds component
     if (ids.length === 0) {

--- a/src/ActionButtons/ActionButton.php
+++ b/src/ActionButtons/ActionButton.php
@@ -84,6 +84,7 @@ class ActionButton extends MoonShineComponent implements ActionButtonContract
         if(is_null($this->modal)) {
             $this->customAttributes([
                 'data-button-type' => 'bulk-button',
+                'data-for-component' => $forComponent,
             ]);
         }
 


### PR DESCRIPTION
Now ActionButton bulk() and method() work correctly inside the actions() resource