### PR TITLE
chore: add generic types annotations for ModelResource and him traits

### DIFF
--- a/src/Resources/ModelResource.php
+++ b/src/Resources/ModelResource.php
@@ -31,15 +31,22 @@ use MoonShine\Traits\WithIsNowOnRoute;
 use MoonShine\TypeCasts\ModelCast;
 use Throwable;
 
+/**
+ * @template TModel of Model
+ */
 abstract class ModelResource extends Resource
 {
     use ResourceWithFields;
     use ResourceWithButtons;
+    /** @use ResourceModelValidation<TModel> */
     use ResourceModelValidation;
     use ResourceModelActions;
     use ResourceModelPolicy;
+    /** @use ResourceModelQuery<TModel> */
     use ResourceModelQuery;
+    /** @use ResourceModelCrudRouter<TModel> */
     use ResourceModelCrudRouter;
+    /** @use ResourceModelEvents<TModel> */
     use ResourceModelEvents;
     use WithIsNowOnRoute;
 
@@ -99,6 +106,9 @@ abstract class ModelResource extends Resource
         return $this->getPages()->detailPage();
     }
 
+    /**
+     * @return TModel
+     */
     public function getModel(): Model
     {
         return new $this->model();
@@ -206,6 +216,10 @@ abstract class ModelResource extends Resource
     }
 
     /**
+     * @param TModel $item
+     * @param Fields|null $fields
+     *
+     * @return bool
      * @throws Throwable
      */
     public function delete(Model $item, ?Fields $fields = null): bool
@@ -250,7 +264,12 @@ abstract class ModelResource extends Resource
     }
 
     /**
-     * @throws ResourceException|Throwable
+     * @param TModel $item
+     * @param Fields|null $fields
+     *
+     * @return TModel
+     * @throws ResourceException
+     * @throws Throwable
      */
     public function save(Model $item, ?Fields $fields = null): Model
     {

--- a/src/Traits/Resource/ResourceModelCrudRouter.php
+++ b/src/Traits/Resource/ResourceModelCrudRouter.php
@@ -12,6 +12,7 @@ use MoonShine\Enums\PageType;
 use MoonShine\Pages\Page;
 
 /**
+ * @template TModel of Model
  * @mixin ResourceContract
  */
 trait ResourceModelCrudRouter
@@ -28,6 +29,13 @@ trait ResourceModelCrudRouter
         )->value();
     }
 
+    /**
+     * @param string|null $name
+     * @param TModel|int|string|null $key
+     * @param array $query
+     *
+     * @return string
+     */
     public function route(
         string $name = null,
         Model|int|string|null $key = null,
@@ -60,6 +68,13 @@ trait ResourceModelCrudRouter
         return $this->pageUrl($this->indexPage(), params: $params, fragment: $fragment);
     }
 
+    /**
+     * @param TModel|int|string|null $model
+     * @param array $params
+     * @param string|null $fragment
+     *
+     * @return string
+     */
     public function formPageUrl(
         Model|int|string|null $model = null,
         array $params = [],
@@ -75,6 +90,13 @@ trait ResourceModelCrudRouter
         );
     }
 
+    /**
+     * @param TModel|int|string $model
+     * @param array $params
+     * @param string|null $fragment
+     *
+     * @return string
+     */
     public function detailPageUrl(
         Model|int|string $model,
         array $params = [],
@@ -90,6 +112,14 @@ trait ResourceModelCrudRouter
         );
     }
 
+    /**
+     * @param string $fragment
+     * @param Page $page
+     * @param TModel|int|string|null $model
+     * @param array $params
+     *
+     * @return string
+     */
     public function fragmentLoadUrl(
         string $fragment,
         Page $page,

--- a/src/Traits/Resource/ResourceModelEvents.php
+++ b/src/Traits/Resource/ResourceModelEvents.php
@@ -6,33 +6,66 @@ namespace MoonShine\Traits\Resource;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @template TModel of Model
+ */
 trait ResourceModelEvents
 {
+    /**
+     * @param TModel $item
+     *
+     * @return TModel
+     */
     protected function beforeCreating(Model $item): Model
     {
         return $item;
     }
 
+    /**
+     * @param TModel $item
+     *
+     * @return TModel
+     */
     protected function afterCreated(Model $item): Model
     {
         return $item;
     }
 
+    /**
+     * @param TModel $item
+     *
+     * @return TModel
+     */
     protected function beforeUpdating(Model $item): Model
     {
         return $item;
     }
 
+    /**
+     * @param TModel $item
+     *
+     * @return TModel
+     */
     protected function afterUpdated(Model $item): Model
     {
         return $item;
     }
 
+    /**
+     * @param TModel $item
+     *
+     * @return TModel
+     */
     protected function beforeDeleting(Model $item): Model
     {
         return $item;
     }
 
+    /**
+     * @param TModel $item
+     *
+     * @return TModel
+     */
     protected function afterDeleted(Model $item): Model
     {
         return $item;
@@ -48,21 +81,41 @@ trait ResourceModelEvents
         // Logic here
     }
 
+    /**
+     * @param TModel $item
+     *
+     * @return TModel
+     */
     protected function beforeForceDeleting(Model $item): Model
     {
         return $item;
     }
 
+    /**
+     * @param TModel $item
+     *
+     * @return TModel
+     */
     protected function afterForceDeleted(Model $item): Model
     {
         return $item;
     }
 
+    /**
+     * @param TModel $item
+     *
+     * @return TModel
+     */
     protected function beforeRestoring(Model $item): Model
     {
         return $item;
     }
 
+    /**
+     * @param TModel $item
+     *
+     * @return TModel
+     */
     protected function afterRestored(Model $item): Model
     {
         return $item;

--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -19,8 +19,12 @@ use MoonShine\Resources\ModelResource;
 use MoonShine\Support\Attributes;
 use Throwable;
 
+/**
+ * @template TModel of Model
+ */
 trait ResourceModelQuery
 {
+    /** @var TModel|null $item */
     protected ?Model $item = null;
 
     protected array $with = [];
@@ -48,6 +52,11 @@ trait ResourceModelQuery
         return moonshineRequest()->getItemID();
     }
 
+    /**
+     * @param Closure $closure
+     *
+     * @return TModel|null
+     */
     protected function itemOr(Closure $closure): ?Model
     {
         if (! is_null($this->item)) {
@@ -65,6 +74,9 @@ trait ResourceModelQuery
             ->newQuery();
     }
 
+    /**
+     * @return TModel|null
+     */
     public function getItem(): ?Model
     {
         if (! is_null($this->item)) {
@@ -82,6 +94,11 @@ trait ResourceModelQuery
         );
     }
 
+    /**
+     * @param TModel|null $model
+     *
+     * @return $this
+     */
     public function setItem(?Model $model): static
     {
         $this->item = $model;
@@ -89,6 +106,9 @@ trait ResourceModelQuery
         return $this;
     }
 
+    /**
+     * @return TModel
+     */
     public function getItemOrInstance(): Model
     {
         if (! is_null($this->item)) {
@@ -106,6 +126,9 @@ trait ResourceModelQuery
         );
     }
 
+    /**
+     * @return TModel
+     */
     public function getItemOrFail(): Model
     {
         if (! is_null($this->item)) {

--- a/src/Traits/Resource/ResourceModelValidation.php
+++ b/src/Traits/Resource/ResourceModelValidation.php
@@ -9,10 +9,17 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Validator;
 use Throwable;
 
+/**
+ * @template TModel of Model
+ */
 trait ResourceModelValidation
 {
     /**
      * Get an array of validation rules for resource related model
+     *
+     * @param TModel $item
+     *
+     * @return array
      *
      * @see https://laravel.com/docs/validation#available-validation-rules
      */
@@ -29,6 +36,9 @@ trait ResourceModelValidation
     }
 
     /**
+     * @param TModel $item
+     *
+     * @return ValidatorContract
      * @throws Throwable
      */
     public function validate(Model $item): ValidatorContract

--- a/stubs/ModelResourceDefault.stub
+++ b/stubs/ModelResourceDefault.stub
@@ -11,6 +11,9 @@ use MoonShine\Resources\ModelResource;
 use MoonShine\Decorations\Block;
 use MoonShine\Fields\ID;
 
+/**
+ * @extends ModelResource<{model}>
+ */
 class DummyResource extends ModelResource
 {
     protected string $model = {model}::class;

--- a/stubs/ModelResourceSeparate.stub
+++ b/stubs/ModelResourceSeparate.stub
@@ -10,6 +10,9 @@ use {model-namespace};
 use MoonShine\Resources\ModelResource;
 use MoonShine\Fields\ID;
 
+/**
+ * @extends ModelResource<{model}>
+ */
 class DummyResource extends ModelResource
 {
     protected string $model = {model}::class;

--- a/stubs/ModelResourceWithPages.stub
+++ b/stubs/ModelResourceWithPages.stub
@@ -12,6 +12,9 @@ use {detail-page-namespace};
 
 use MoonShine\Resources\ModelResource;
 
+/**
+ * @extends ModelResource<{model}>
+ */
 class DummyResource extends ModelResource
 {
     protected string $model = {model}::class;


### PR DESCRIPTION
С помощью этих аннотаций - теперь указав в ресурсе аннотацию:

```php
/**
 * @extends ModelResource<Article>
 */
class ArticleResource extends ModelResource {}
```

мы будем во всех функциях получать помощь от IDE, таких как
rules, getModel, getItem и тд. IDE будем понимать что там возвращается не просто Model, а конкретная модель какой-то сущности
И таким образом IDE будет автокомплитить переменные модели