### PR TITLE
fix: ExportHandler, use getFields instead of getIndexFields for export

### DIFF
--- a/src/Handlers/ExportHandler.php
+++ b/src/Handlers/ExportHandler.php
@@ -122,7 +122,7 @@ class ExportHandler extends Handler
             $row = [];
 
             $fields = $resource
-                ->getIndexFields()
+                ->getFields()
                 ->exportFields();
 
             $fields->fill($item->toArray(), $item, $index);

--- a/src/Handlers/ExportHandler.php
+++ b/src/Handlers/ExportHandler.php
@@ -123,6 +123,7 @@ class ExportHandler extends Handler
 
             $fields = $resource
                 ->getFields()
+                ->onlyFields()
                 ->exportFields();
 
             $fields->fill($item->toArray(), $item, $index);


### PR DESCRIPTION
# Features
На данный момент в экспорте учавствуют только те поля, которые есть в index таблице, что не очень логично.