### PR TITLE
feat: Add method persist for Collapse

### DIFF
--- a/resources/views/components/collapse.blade.php
+++ b/resources/views/components/collapse.blade.php
@@ -1,15 +1,15 @@
 @props([
     'persist' => false,
-    'show' => false,
+    'open' => false,
     'title'
 ])
 <div
     {{ $attributes->class(['accordion']) }}
     x-data="{
         @if($persist)
-            open: $persist({{ $show ? 'true' : 'false' }}).as($id('collapse')),
+            open: $persist({{ $open ? 'true' : 'false' }}).as($id('collapse')),
         @else
-            open: {{ $show ? 'true' : 'false' }},
+            open: {{ $open ? 'true' : 'false' }},
         @endif
         toggle() {
             this.open = !this.open

--- a/resources/views/components/collapse.blade.php
+++ b/resources/views/components/collapse.blade.php
@@ -13,7 +13,7 @@
         @endif
         toggle() {
             this.open = !this.open
-        },
+        }
     }"
 >
     <div
@@ -33,7 +33,7 @@
                 </svg>
             </button>
         </h2>
-        <div x-show="open" class="accordion-body">
+        <div x-cloak x-show="open" class="accordion-body">
             <div class="accordion-content">
                 {{ $slot }}
             </div>

--- a/resources/views/decorations/collapse.blade.php
+++ b/resources/views/decorations/collapse.blade.php
@@ -1,6 +1,6 @@
 <x-moonshine::collapse :show="$element->isShow()"
                        :title="$element->label()"
-                       :persist="true"
+                       :persist="$element->isPersist()"
                        :attributes="$attributes"
 >
     <x-moonshine::fields-group

--- a/resources/views/decorations/collapse.blade.php
+++ b/resources/views/decorations/collapse.blade.php
@@ -1,4 +1,4 @@
-<x-moonshine::collapse :show="$element->isShow()"
+<x-moonshine::collapse :open="$element->isOpen()"
                        :title="$element->label()"
                        :persist="$element->isPersist()"
                        :attributes="$attributes"

--- a/src/Decorations/Collapse.php
+++ b/src/Decorations/Collapse.php
@@ -10,6 +10,8 @@ class Collapse extends Decoration
 
     protected bool $show = false;
 
+    protected bool $persist = false;
+
     public function show(bool $show = true): self
     {
         $this->show = $show;
@@ -20,5 +22,17 @@ class Collapse extends Decoration
     public function isShow(): bool
     {
         return $this->show;
+    }
+
+    public function persist(bool $persist = true): self
+    {
+        $this->persist = $persist;
+
+        return $this;
+    }
+
+    public function isPersist(): bool
+    {
+        return $this->persist;
     }
 }

--- a/src/Decorations/Collapse.php
+++ b/src/Decorations/Collapse.php
@@ -4,29 +4,51 @@ declare(strict_types=1);
 
 namespace MoonShine\Decorations;
 
+use Closure;
+use MoonShine\Support\Condition;
+
 class Collapse extends Decoration
 {
     protected string $view = 'moonshine::decorations.collapse';
 
-    protected bool $show = false;
+    protected bool $open = false;
 
-    protected bool $persist = false;
+    protected bool $persist = true;
 
-    public function show(bool $show = true): self
+    /**
+     * @deprecated will be removed in 3.0 (use method open())
+     * @param bool $show
+     * @return $this
+     */
+    public function show(Closure|bool|null $condition = null): self
     {
-        $this->show = $show;
+        return $this->open($condition);
+    }
+
+    /**
+     * @deprecated will be removed in 3.0 (use method isOpen())
+     * @return bool
+     */
+    public function isShow(): bool
+    {
+        return $this->isOpen();
+    }
+
+    public function open(Closure|bool|null $condition = null): self
+    {
+        $this->open = Condition::boolean($condition, true);
 
         return $this;
     }
 
-    public function isShow(): bool
+    public function isOpen(): bool
     {
-        return $this->show;
+        return $this->open;
     }
 
-    public function persist(bool $persist = true): self
+    public function persist(Closure|bool|null $condition = null): self
     {
-        $this->persist = $persist;
+        $this->persist = Condition::boolean($condition, true);
 
         return $this;
     }


### PR DESCRIPTION
По умолчанию у декорации _Collapse_ свойство _persist_ имеет значение **true**.

![image](https://github.com/moonshine-software/moonshine/assets/11013417/eb18e8a9-b80d-4760-a86b-0efdfb58ec5f)

Было добавлено новое свойство и 2 метода, а также поправлены вьюхи