### PR TITLE
Fix: ValueMetric - devision by zero

### DIFF
--- a/src/Metrics/ValueMetric.php
+++ b/src/Metrics/ValueMetric.php
@@ -25,15 +25,22 @@ class ValueMetric extends Metric
         return $this;
     }
 
-    public function valueResult(): string|float
+    public function valueResult(): string|float|int
     {
         if ($this->isProgress()) {
-            return ($this->target <= 0 || $this->value <= 0)
-                ? $this->value
-                : round(($this->value / $this->target) * 100);
+            return $this->progressValueResult();
         }
 
         return $this->simpleValue();
+    }
+
+    public function progressValueResult(): float|int
+    {
+        if ($this->target <= 0 || $this->value <= 0) {
+            return $this->value;
+        }
+
+        return round(($this->value / $this->target) * 100);
     }
 
     public function isProgress(): bool

--- a/src/Metrics/ValueMetric.php
+++ b/src/Metrics/ValueMetric.php
@@ -34,7 +34,7 @@ class ValueMetric extends Metric
         return $this->simpleValue();
     }
 
-    public function progressValueResult(): float|int
+    protected function progressValueResult(): float|int
     {
         if ($this->target <= 0 || $this->value <= 0) {
             return $this->value;

--- a/src/Metrics/ValueMetric.php
+++ b/src/Metrics/ValueMetric.php
@@ -28,7 +28,9 @@ class ValueMetric extends Metric
     public function valueResult(): string|float
     {
         if ($this->isProgress()) {
-            return round(($this->value / $this->target) * 100);
+            return ($this->target <= 0 || $this->value <= 0)
+                ? $this->value
+                : round(($this->value / $this->target) * 100);
         }
 
         return $this->simpleValue();


### PR DESCRIPTION
Если вызвать метод `->progress(0)` с параметром **0**, то при расчёте значения методом `valueResult()` будет ошибка (деление на ноль):

![2024-02-13_16-30-05](https://github.com/moonshine-software/moonshine/assets/11013417/9487ad87-a84c-40ba-959b-fd023f979e33)
