### PR TITLE
feat: Add heading gradation

### DIFF
--- a/resources/css/base/common.css
+++ b/resources/css/base/common.css
@@ -80,6 +80,24 @@ body {
   min-width: 320px;
 }
 
+/* Heading */
+h1, h2, h3, h4,
+.h1, .h2, .h3, .h4 {
+  @apply font-medium truncate mb-6;
+}
+h1, .h1 {
+  @apply text-md;
+}
+h2, .h2 {
+  @apply text-sm;
+}
+h3, .h3 {
+  @apply text-xs;
+}
+h4, .h4 {
+  @apply text-2xs;
+}
+
 a {
   @apply inline-block transition-all hover:text-primary dark:hover:text-white;
 }

--- a/resources/css/base/common.css
+++ b/resources/css/base/common.css
@@ -81,21 +81,25 @@ body {
 }
 
 /* Heading */
-h1, h2, h3, h4,
-.h1, .h2, .h3, .h4 {
-  @apply font-medium truncate mb-6;
-}
-h1, .h1 {
-  @apply text-md;
-}
-h2, .h2 {
-  @apply text-sm;
-}
-h3, .h3 {
-  @apply text-xs;
-}
-h4, .h4 {
-  @apply text-2xs;
+.heading {
+  @apply mb-4;
+
+  h1, h2, h3, h4,
+  .h1, .h2, .h3, .h4 {
+    @apply font-medium truncate mb-6;
+  }
+  h1, .h1 {
+    @apply text-md;
+  }
+  h2, .h2 {
+    @apply text-sm;
+  }
+  h3, .h3 {
+    @apply text-xs;
+  }
+  h4, .h4 {
+    @apply text-2xs;
+  }
 }
 
 a {

--- a/resources/views/decorations/heading.blade.php
+++ b/resources/views/decorations/heading.blade.php
@@ -1,7 +1,7 @@
-<div {{ $attributes
+<{{ $element->getTag() }} {{ $attributes
         ->class([
             'mb-4',
         ])
-}}>
+    }}>
     {{ $element->label() }}
-</div>
+</{{ $element->getTag() }}>

--- a/resources/views/decorations/heading.blade.php
+++ b/resources/views/decorations/heading.blade.php
@@ -1,7 +1,5 @@
-<{{ $element->getTag() }} {{ $attributes
-        ->class([
-            'mb-4',
-        ])
-    }}>
-    {{ $element->label() }}
-</{{ $element->getTag() }}>
+<div class="heading">
+    <{{ $element->getTag() }} {{ $attributes }}>
+        {{ $element->label() }}
+    </{{ $element->getTag() }}>
+</div>

--- a/src/Decorations/Heading.php
+++ b/src/Decorations/Heading.php
@@ -6,14 +6,14 @@ namespace MoonShine\Decorations;
 
 use Closure;
 use MoonShine\Traits\WithHeadingGradation;
-use MoonShine\Traits\WithTag;
+use MoonShine\Traits\HasDifferentHtmlTag;
 
 /**
  * @method static static make(Closure|string $label)
  */
 class Heading extends Decoration
 {
-    use WithTag;
+    use HasDifferentHtmlTag;
     use WithHeadingGradation;
 
     protected string $view = 'moonshine::decorations.heading';

--- a/src/Decorations/Heading.php
+++ b/src/Decorations/Heading.php
@@ -5,11 +5,16 @@ declare(strict_types=1);
 namespace MoonShine\Decorations;
 
 use Closure;
+use MoonShine\Traits\WithHeadingGradation;
+use MoonShine\Traits\WithTag;
 
 /**
  * @method static static make(Closure|string $label)
  */
 class Heading extends Decoration
 {
+    use WithTag;
+    use WithHeadingGradation;
+
     protected string $view = 'moonshine::decorations.heading';
 }

--- a/src/Traits/HasDifferentHtmlTag.php
+++ b/src/Traits/HasDifferentHtmlTag.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MoonShine\Traits;
 
-trait WithTag
+trait HasDifferentHtmlTag
 {
     protected string $tag = 'div';
 

--- a/src/Traits/WithHeadingGradation.php
+++ b/src/Traits/WithHeadingGradation.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MoonShine\Traits;
 
+use InvalidArgumentException;
+
 trait WithHeadingGradation
 {
     protected int $gradation = 3;
@@ -15,6 +17,12 @@ trait WithHeadingGradation
 
     public function h(int $gradation = 3, $asClass = true): static
     {
+        if ($gradation < 1 || $gradation > 6) {
+            throw new InvalidArgumentException(
+                'gradation must be between 1 and 6'
+            );
+        }
+
         $this->gradation = $gradation;
 
         if ($asClass) {

--- a/src/Traits/WithHeadingGradation.php
+++ b/src/Traits/WithHeadingGradation.php
@@ -6,16 +6,16 @@ namespace MoonShine\Traits;
 
 trait WithHeadingGradation
 {
-    protected string $gradation = '3';
+    protected int $gradation = 3;
 
     public function getH(): string
     {
         return "h$this->gradation";
     }
 
-    public function h(string|int $gradation = '3', $asClass = true): static
+    public function h(int $gradation = 3, $asClass = true): static
     {
-        $this->gradation = preg_replace('/[^0-9]/','', (string) $gradation);
+        $this->gradation = $gradation;
 
         if ($asClass) {
             $this->withAttributes(['class' => $this->getH()]);

--- a/src/Traits/WithHeadingGradation.php
+++ b/src/Traits/WithHeadingGradation.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Traits;
+
+trait WithHeadingGradation
+{
+    protected string $gradation = '3';
+
+    public function getH(): string
+    {
+        return "h$this->gradation";
+    }
+
+    public function h(string|int $gradation = '3', $asClass = true): static
+    {
+        $this->gradation = preg_replace('/[^0-9]/','', (string) $gradation);
+
+        if ($asClass) {
+            $this->withAttributes(['class' => $this->getH()]);
+        }
+        else {
+            $this->tag($this->getH());
+        }
+
+        return $this;
+    }
+}

--- a/src/Traits/WithTag.php
+++ b/src/Traits/WithTag.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Traits;
+
+trait WithTag
+{
+    protected string $tag = 'div';
+
+    public function getTag(): string
+    {
+        return $this->tag;
+    }
+
+    public function tag(string $tag): static
+    {
+        $this->tag = $tag;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Сейчас декорация `Heading::make()` "обёрнута" в тег _div_ и чтобы сделать нормальный заголовок нужно использовать метод `customAttributes()`. Да и смысл заголовка в том, чтобы он немного выделялся, поэтому добавил немного "сахара".

### Несколько примеров использования
#### Как сейчас
`Heading::make('Dashboard')`

#### Варианты с тегом _h1 - h4_
```
Heading::make('Dashboard')->h('1')
Heading::make('MoonShine')->h('2')
Heading::make('Demo version')->h(3)
Heading::make('Heading')->h('h4')
```

#### Варианты с тегом _div_ и классом _h1 - h4_
```
Heading::make('Dashboard')->h('1', false)
Heading::make('MoonShine')->h('2', false)
Heading::make('Demo version')->h(3, false)
Heading::make('Heading')->h('h4', false)
```

#### Варианты с тегом _p_ и классом _h1 - h4_
```
Heading::make('Dashboard')->tag('p')->h('1')
Heading::make('MoonShine')->tag('p')->h('2')
Heading::make('Demo version')->tag('p')->h(3)
Heading::make('Heading')->tag('p')->h('h4')
```