### PR TITLE
fix: Unknown column if appends

### DIFF
--- a/src/Traits/Fields/WithRelatedValues.php
+++ b/src/Traits/Fields/WithRelatedValues.php
@@ -116,7 +116,12 @@ trait WithRelatedValues
         } else {
             $table = DB::getTablePrefix() . $related->getTable();
             $key = "$table.{$related->getKeyName()}";
-            $column = "$table.{$this->getResourceColumn()}";
+
+            $column = $key;
+            $resourceColumn = $this->getResourceColumn();
+            if (! $related->hasAppended($resourceColumn)) {
+                $column = "$table.$resourceColumn";
+            }
 
             $values = $this->memoizeValues
                 ?? $this->resolveRelatedQuery(


### PR DESCRIPTION
### Проблема:
Если у ресурса в свойство `$column` добавить поле из свойства модели `$appends`
```
// Model
protected $appends = [
    'name_formatted',
];

protected function nameFormatted(): Attribute
{
    return Attribute::make(
        get: fn () => "$this->name от " . $this->from_at?->format('d.m.Y'),
    );
}

// Resource
protected string $column = 'name_formatted';
```
то выдаёт ошибку:
`SQLSTATE[42S22]: Column not found: 1054 Unknown column 'table.name_formatted' in 'field list'`