### PR TITLE
chore(fields): remove content_css from reserved names the TinyMce field

### DIFF
--- a/src/Fields/TinyMce.php
+++ b/src/Fields/TinyMce.php
@@ -90,7 +90,6 @@ final class TinyMce extends Textarea
             'relative_urls',
             'branding',
             'skin',
-            'content_css',
             'file_picker_callback',
             'language',
             'plugins',


### PR DESCRIPTION
content_css property is editable

```
TinyMce::make('Content')
    ->addConfig('content_css', Vite::asset('resources/scss/app.scss'))
```