### PR TITLE
feat: Before function for async call

### DIFF
--- a/resources/js/alpine/actionButton.js
+++ b/resources/js/alpine/actionButton.js
@@ -11,6 +11,7 @@ export default () => ({
 
   beforeCallback: null,
   errorCallback: null,
+  beforeFunction: null,
 
   init() {
     this.url = this.$el.href
@@ -19,6 +20,7 @@ export default () => ({
     this.method = this.$el?.dataset?.asyncMethod
     this.events = this.$el?.dataset?.asyncEvents
     this.callback = this.$el?.dataset?.asyncCallback
+    this.beforeFunction = this.$el?.dataset?.asyncBeforeFunction
     this.loading = false
     const el = this.$el
     const btnText = this.btnText

--- a/resources/js/alpine/asyncFunctions.js
+++ b/resources/js/alpine/asyncFunctions.js
@@ -10,6 +10,16 @@ export function responseCallback(callback, response, element, events, component)
   fn(response, element, events, component)
 }
 
+export function beforeCallback(callback, element, component) {
+  const fn = MoonShine.callbacks[callback]
+
+  if (typeof fn !== 'function') {
+    throw new Error(callback + ' is not a function!')
+  }
+
+  fn(element, component)
+}
+
 export function dispatchEvents(events, type, component, extraAttributes = {}) {
   if (events !== '' && type !== 'error') {
     const allEvents = events.split(',')
@@ -38,6 +48,10 @@ export function dispatchEvents(events, type, component, extraAttributes = {}) {
 export function moonShineRequest(t, url, method = 'get', body = {}, headers = {}) {
   if (!url) {
     return
+  }
+
+  if(t.beforeFunction !== undefined && t.beforeFunction) {
+    beforeCallback(t.beforeFunction, t.$el, t)
   }
 
   axios({

--- a/resources/js/alpine/formBuilder.js
+++ b/resources/js/alpine/formBuilder.js
@@ -17,6 +17,7 @@ export default (name = '', reactive = {}) => ({
   callback: null,
   afterCallback: null,
   afterErrorCallback: null,
+  beforeFunction: null,
 
   init(initData = {}) {
     const t = this
@@ -141,7 +142,7 @@ export default (name = '', reactive = {}) => ({
     return false
   },
 
-  async(events = '', callbackFunction = '') {
+  async(events = '', callbackFunction = '', beforeFunction = '') {
     const form = this.$el
     submitState(form, true)
     const t = this
@@ -157,6 +158,7 @@ export default (name = '', reactive = {}) => ({
       action = action + '?' + new URLSearchParams(formData).toString()
     }
 
+    t.beforeFunction = beforeFunction
     t.callback = callbackFunction
     t.events = events
 

--- a/src/ActionButtons/ActionButton.php
+++ b/src/ActionButtons/ActionButton.php
@@ -10,6 +10,7 @@ use MoonShine\Contracts\Actions\ActionButtonContract;
 use MoonShine\Contracts\Resources\ResourceContract;
 use MoonShine\Pages\Page;
 use MoonShine\Support\AlpineJs;
+use MoonShine\Support\AsyncCallback;
 use MoonShine\Support\Condition;
 use MoonShine\Traits\InDropdownOrLine;
 use MoonShine\Traits\WithIcon;
@@ -152,9 +153,9 @@ class ActionButton extends MoonShineComponent implements ActionButtonContract
         ?string $message = null,
         ?string $selector = null,
         array $events = [],
-        ?string $callback = null,
+        string|AsyncCallback|null $callback = null,
         ?Page $page = null,
-        ?ResourceContract $resource = null,
+        ?ResourceContract $resource = null
     ): self {
         $this->asyncMethod = $method;
 
@@ -192,7 +193,7 @@ class ActionButton extends MoonShineComponent implements ActionButtonContract
         string $method = 'GET',
         ?string $selector = null,
         array $events = [],
-        ?string $callback = null
+        string|AsyncCallback|null $callback = null
     ): self {
         $this->isAsync = true;
 

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -14,6 +14,7 @@ use MoonShine\Fields\Fields;
 use MoonShine\Fields\Hidden;
 use MoonShine\Pages\Page;
 use MoonShine\Support\AlpineJs;
+use MoonShine\Support\AsyncCallback;
 use MoonShine\Traits\Fields\WithAdditionalFields;
 use MoonShine\Traits\HasAsync;
 use Throwable;
@@ -104,7 +105,7 @@ final class FormBuilder extends RowComponent
         string $method,
         ?string $message = null,
         array $events = [],
-        ?string $callback = null,
+        string|AsyncCallback|null $callback = null,
         ?Page $page = null,
         ?ResourceContract $resource = null,
     ): self {
@@ -321,7 +322,7 @@ final class FormBuilder extends RowComponent
         if ($this->isAsync()) {
             $this->customAttributes([
                 'x-on:submit.prevent' => 'async(`' . $this->asyncEvents(
-                ) . '`, `' . $this->asyncCallback() . '`)',
+                ) . '`, `' . $this->asyncCallback() . '`, `' . $this->asyncBeforeCallback() . '`)',
                 AlpineJs::eventBlade(JsEvent::FORM_RESET, $this->getName()) => 'formReset',
             ]);
         }

--- a/src/Fields/FormElement.php
+++ b/src/Fields/FormElement.php
@@ -16,6 +16,7 @@ use MoonShine\Contracts\MoonShineRenderable;
 use MoonShine\Contracts\Resources\ResourceContract;
 use MoonShine\Pages\Page;
 use MoonShine\Support\AlpineJs;
+use MoonShine\Support\AsyncCallback;
 use MoonShine\Support\Condition;
 use MoonShine\Traits\Fields\WithFormElementAttributes;
 use MoonShine\Traits\HasCanSee;
@@ -247,7 +248,7 @@ abstract class FormElement implements MoonShineRenderable, HasAssets, CanBeEscap
         ?string $message = null,
         ?string $selector = null,
         array $events = [],
-        ?string $callback = null,
+        string|AsyncCallback|null $callback = null,
         ?Page $page = null,
         ?ResourceContract $resource = null,
     ): static {
@@ -272,7 +273,7 @@ abstract class FormElement implements MoonShineRenderable, HasAssets, CanBeEscap
         string $method = 'PUT',
         array $events = [],
         ?string $selector = null,
-        ?string $callback = null,
+        string|AsyncCallback|null $callback = null,
     ): static {
         $this->onChangeUrl = $url;
 
@@ -288,7 +289,7 @@ abstract class FormElement implements MoonShineRenderable, HasAssets, CanBeEscap
         string $method = 'GET',
         array $events = [],
         ?string $selector = null,
-        ?string $callback = null
+        string|AsyncCallback|null $callback = null
     ): static {
         return $this->customAttributes(
             AlpineJs::asyncUrlDataAttributes(

--- a/src/Support/AlpineJs.php
+++ b/src/Support/AlpineJs.php
@@ -53,12 +53,14 @@ final class AlpineJs
         string $method = 'GET',
         string|array $events = [],
         ?string $selector = null,
-        ?string $callback = null,
+        string|AsyncCallback|null $callback = null
     ): array {
         return array_filter([
             'data-async-events' => self::prepareEvents($events),
             'data-async-selector' => $selector,
-            'data-async-callback' => $callback,
+            //TODO remove $callback string type in future version
+            'data-async-callback' => $callback instanceof AsyncCallback ? $callback->success() : $callback,
+            'data-async-before-function' => $callback instanceof AsyncCallback ? $callback->before() : null,
             'data-async-method' => $method,
         ]);
     }

--- a/src/Support/AsyncCallback.php
+++ b/src/Support/AsyncCallback.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Support;
+
+final class AsyncCallback
+{
+    public function __construct(
+        private readonly ?string $success,
+        private readonly ?string $before,
+    ) {
+
+    }
+
+    public static function with(?string $success = null, ?string $before = null): AsyncCallback
+    {
+        return new AsyncCallback($success, $before);
+    }
+
+    public function before(): ?string
+    {
+        return $this->before;
+    }
+
+    public function success(): ?string
+    {
+        return $this->success;
+    }
+}

--- a/src/Traits/HasAsync.php
+++ b/src/Traits/HasAsync.php
@@ -7,6 +7,7 @@ namespace MoonShine\Traits;
 use Closure;
 use Illuminate\Support\Arr;
 use MoonShine\Support\AlpineJs;
+use MoonShine\Support\AsyncCallback;
 
 trait HasAsync
 {
@@ -15,6 +16,8 @@ trait HasAsync
     protected string|array|null $asyncEvents = null;
 
     protected ?string $asyncCallback = null;
+
+    protected ?string $asyncBeforeCallback = null;
 
     public function isAsync(): bool
     {
@@ -57,11 +60,18 @@ trait HasAsync
     public function async(
         Closure|string|null $asyncUrl = null,
         string|array|null $asyncEvents = null,
-        string $asyncCallback = null
+        string|AsyncCallback|null $asyncCallback = null,
     ): static {
         $this->asyncUrl = $this->prepareAsyncUrl($asyncUrl);
         $this->asyncEvents = $asyncEvents;
-        $this->asyncCallback = $asyncCallback;
+
+        //TODO remove $callback string type in future version
+        if($asyncCallback instanceof AsyncCallback) {
+            $this->asyncCallback = $asyncCallback->success();
+            $this->asyncBeforeCallback = $asyncCallback->before();
+        } else {
+            $this->asyncCallback = $asyncCallback;
+        }
 
         return $this;
     }
@@ -83,5 +93,10 @@ trait HasAsync
     public function asyncCallback(): ?string
     {
         return $this->asyncCallback;
+    }
+
+    public function asyncBeforeCallback(): ?string
+    {
+        return $this->asyncBeforeCallback;
     }
 }


### PR DESCRIPTION
Now you can pass an AsyncCallback object to the callback parameter, in which you can set the call of the necessary functions during the execution of an async request:
```php
ActionButton::make('AsyncWithBefore', route('url'))->async(callback: AsyncCallback::with('mySuccess')
```
Now you can set a before function inside js, which will be executed before the async request:

```php
FormBuilder::make(route('alert.post')
    ->async(asyncCallback: AsyncCallback::with(before: 'myBefore'))

ActionButton::make('AsyncWithBefore', route('url'))
    ->async(callback: AsyncCallback::with('mySuccess', 'myBefore'))
```
```js
document.addEventListener("moonshine:init", () => {
    MoonShine.onCallback('myBefore', function (element, component) {
        console.log('myBefore')
        console.log(element)
        console.log(component)
    })

    MoonShine.onCallback('mySuccess', function (response, element, events, component) {
            console.log('mySuccess')
            console.log(response)
            console.log(element)
            console.log(events)
            console.log(component)
        }
    )
})
```

