### PR TITLE
chore(crud): remove async mode when editing form in modal

### DIFF
--- a/src/Pages/Crud/FormPage.php
+++ b/src/Pages/Crud/FormPage.php
@@ -152,8 +152,12 @@ class FormPage extends Page
             $item?->getKey()
         );
 
-        $isForceAsync = request('_async_form', false);
-        $isAsync = $resource->isAsync() || $isForceAsync;
+        // Reset form problem
+        $isAsync = $resource->isAsync() && $resource->isEditInModal();
+
+        if (request('_async_form', false)) {
+            $isAsync = true;
+        }
 
         return [
             Fragment::make([


### PR DESCRIPTION
Если установить у ресурса `$isAsync = true` и `$editInModal = false;` (значение по умолчанию), то после редактирования остаемся на странице формы и у нее происходит reset на предыдущие значения. На  $redirectAfterSave не переходит.
Данное исправление отключает режим async если `$editInModal = false;`