### PR TITLE
fix: применил type="module" для поддержки ESM

### DIFF
--- a/src/Theme/AssetManager.php
+++ b/src/Theme/AssetManager.php
@@ -77,7 +77,7 @@ class AssetManager
                 fn ($asset): int|bool => str_contains((string) $asset, '.js')
             )
             ->map(
-                fn ($asset): string => "<script defer src='" . asset(
+                fn ($asset): string => "<script defer type='module' src='" . asset(
                     $asset
                 ) . (str_contains((string) $asset, '?') ? '&' : '?') . "v={$this->getVersion()}'></script>"
             )->implode(PHP_EOL);


### PR DESCRIPTION
При попытке импорта dayJs в alpineJs столкнулся с ошибкой: "Uncaught SyntaxError: Cannot use import statement outside a module".

Обнаружил что moonshine указывает js ассеты не как ECMAScript.

Указал type="module" и проблема решилась.

```
<script type="module" src="app.js"></script>
```
