### PR TITLE
Forwarding guard in MoonShine\Http\Middleware\Authenticate

### DIFF
--- a/src/Http/Middleware/Authenticate.php
+++ b/src/Http/Middleware/Authenticate.php
@@ -18,7 +18,7 @@ class Authenticate extends Middleware
         $guard = MoonShineAuth::guard();
 
         if (! $guard->check()) {
-            $this->unauthenticated($request, $guards);
+            $this->unauthenticated($request, [$guard, ...$guards]);
         }
 
         $this->auth->shouldUse(MoonShineAuth::guardName());


### PR DESCRIPTION
Moonshine guard isn't passed to `Authenticate::unauthenticated` method.
This PR fixed that.