### PR TITLE
feat: QueryTags with fixed alias

### DIFF
--- a/src/QueryTags/QueryTag.php
+++ b/src/QueryTags/QueryTag.php
@@ -24,6 +24,8 @@ final class QueryTag
 
     protected bool $isDefault = false;
 
+    protected ?string $alias = null;
+
     public function __construct(
         Closure|string $label,
         protected Closure $builder,
@@ -31,8 +33,19 @@ final class QueryTag
         $this->setLabel($label);
     }
 
+    public function alias(string $alias): self
+    {
+        $this->alias = $alias;
+
+        return $this;
+    }
+
     public function uri(): string
     {
+        if(!is_null($this->alias)) {
+            return $this->alias;
+        }
+
         return str($this->label())->slug()->value();
     }
 


### PR DESCRIPTION
Issue #915

```php
QueryTag::make('Label', fn($builder) => $builder)->alias('alias')
```