### PR TITLE
SDUI

### DIFF
--- a/src/Buttons/FiltersButton.php
+++ b/src/Buttons/FiltersButton.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Stringable;
 use MoonShine\Components\ActionButtons\ActionButton;
 use MoonShine\Components\FormBuilder;
+use MoonShine\Components\Offcanvas;
 use MoonShine\Forms\FiltersForm;
 use MoonShine\Resources\ModelResource;
 
@@ -17,13 +18,16 @@ final class FiltersButton
     {
         $title = self::title($resource->getFilterParams());
 
+        $filters = call_user_func(new FiltersForm, $resource);
+
         return ActionButton::make($title, '#')
             ->secondary()
             ->icon('heroicons.outline.adjustments-horizontal')
             ->inOffCanvas(
                 fn (): array|string|null => __('moonshine::ui.filters'),
-                fn (): FormBuilder => (new FiltersForm())($resource),
-                name: 'filters-off-canvas'
+                fn (): FormBuilder => $filters,
+                name: 'filters-off-canvas',
+                builder: fn(Offcanvas $offCanvas) => $offCanvas->setComponents([$filters])
             )
             ->showInLine();
     }

--- a/src/Collections/MoonShineRenderElements.php
+++ b/src/Collections/MoonShineRenderElements.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\Conditionable;
 use MoonShine\Contracts\Components\HasComponents;
 use MoonShine\Contracts\Fields\HasFields;
+use MoonShine\Contracts\MoonShineRenderable;
 use MoonShine\Fields\Field;
 use Throwable;
 
@@ -68,12 +69,19 @@ abstract class MoonShineRenderElements extends Collection
                     $element->getFields()->exceptElements($except)->toArray()
                 );
             } elseif ($element instanceof HasComponents) {
-                $element->components(
+                $element->setComponents(
                     $element->getComponents()->exceptElements($except)->toArray()
                 );
             }
 
             return true;
         })->filter()->values();
+    }
+
+    public function toStructure(bool $withStates = true): array
+    {
+        return $this->map(
+            fn(MoonShineRenderable $component) => $component->toStructure($withStates)
+        )->toArray();
     }
 }

--- a/src/Components/AbstractWithComponents.php
+++ b/src/Components/AbstractWithComponents.php
@@ -28,7 +28,7 @@ abstract class AbstractWithComponents extends MoonShineComponent implements
     {
         parent::__construct();
 
-        $this->components($components);
+        $this->setComponents($components);
         $this->fields($this->getComponents()->toArray());
     }
 

--- a/src/Components/CardsBuilder.php
+++ b/src/Components/CardsBuilder.php
@@ -122,7 +122,7 @@ final class CardsBuilder extends IterableComponent
     /**
      * @throws Throwable
      */
-    public function components(): Collection
+    public function getComponents(): Collection
     {
         $fields = $this->getFields();
 
@@ -203,7 +203,7 @@ final class CardsBuilder extends IterableComponent
     protected function viewData(): array
     {
         return [
-            'components' => $this->components(),
+            'components' => $this->getComponents(),
             'name' => $this->getName(),
             'hasPaginator' => $this->hasPaginator(),
             'simplePaginate' => ! $this->getPaginator() instanceof LengthAwarePaginator,

--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\View\ComponentSlot;
 use MoonShine\Components\ActionButtons\ActionButton;
 use MoonShine\Support\Condition;
+use Throwable;
 
 /**
  * @method static static make(Closure|string $title, Closure|View|string $content, Closure|View|ActionButton|string $outer = '', Closure|string|null $asyncUrl = '', iterable $components = [])
@@ -39,6 +40,8 @@ final class Modal extends AbstractWithComponents
         string $name = 'default'
     ) {
         parent::__construct($components);
+
+        $this->name($name);
     }
 
 
@@ -86,6 +89,7 @@ final class Modal extends AbstractWithComponents
 
     /**
      * @return array<string, mixed>
+     * @throws Throwable
      */
     protected function viewData(): array
     {

--- a/src/Components/MoonShineComponent.php
+++ b/src/Components/MoonShineComponent.php
@@ -45,7 +45,6 @@ abstract class MoonShineComponent extends Component implements MoonShineRenderab
     public function data(): array
     {
         return array_merge($this->extractPublicProperties(), [
-            'type' => class_basename($this),
             'attributes' => $this->attributes(),
             'name' => $this->getName(),
         ]);
@@ -54,14 +53,5 @@ abstract class MoonShineComponent extends Component implements MoonShineRenderab
     protected function systemViewData(): array
     {
         return $this->data();
-    }
-
-    public function jsonSerialize(): array
-    {
-        return array_merge(
-            $this->systemViewData(),
-            $this->viewData(),
-            $this->getCustomViewData()
-        );
     }
 }

--- a/src/Components/Offcanvas.php
+++ b/src/Components/Offcanvas.php
@@ -10,9 +10,9 @@ use Illuminate\View\ComponentSlot;
 use MoonShine\Support\Condition;
 
 /**
- * @method static static make(Closure|string $title, Closure|View|string $content, Closure|string $toggler = '', Closure|string|null $asyncUrl = '')
+ * @method static static make(Closure|string $title, Closure|View|string $content, Closure|string $toggler = '', Closure|string|null $asyncUrl = '', iterable $components = [])
  */
-final class Offcanvas extends MoonShineComponent
+final class Offcanvas extends AbstractWithComponents
 {
     protected string $view = 'moonshine::components.offcanvas';
 
@@ -27,10 +27,13 @@ final class Offcanvas extends MoonShineComponent
         protected Closure|View|string $content = '',
         protected Closure|string $toggler = '',
         protected Closure|string|null $asyncUrl = null,
+        iterable $components = [],
         // anonymous component variables
         string $name = 'default'
     ) {
-        parent::__construct($name);
+        parent::__construct($components);
+
+        $this->name($name);
     }
 
     public function open(Closure|bool|null $condition = null): self

--- a/src/Contracts/Components/HasComponents.php
+++ b/src/Contracts/Components/HasComponents.php
@@ -8,7 +8,7 @@ use MoonShine\Collections\MoonShineRenderElements;
 
 interface HasComponents
 {
-    public function components(iterable $components): static;
+    public function setComponents(iterable $components): static;
 
     public function hasComponents(): bool;
 

--- a/src/Contracts/MoonShineRenderable.php
+++ b/src/Contracts/MoonShineRenderable.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace MoonShine\Contracts;
 
+use Closure;
 use Illuminate\Contracts\Support\CanBeEscapedWhenCastToString;
+use Illuminate\Contracts\View\View;
 use JsonSerializable;
 use Stringable;
 
@@ -13,5 +15,9 @@ interface MoonShineRenderable extends
     JsonSerializable,
     CanBeEscapedWhenCastToString
 {
-    public function render();
+    public function render(): View|Closure|string;
+
+    public function toStructure(bool $withStates = true): array;
+
+    public function toArray(): array;
 }

--- a/src/Fields/FormElement.php
+++ b/src/Fields/FormElement.php
@@ -391,22 +391,7 @@ abstract class FormElement extends MoonShineComponent implements HasAssets
     protected function systemViewData(): array
     {
         return [
-            'type' => class_basename($this),
             'attributes' => $this->attributes(),
         ];
-    }
-
-    public function jsonSerialize(): array
-    {
-        return array_merge(
-            $this->systemViewData(),
-            $this->viewData(),
-            $this->getCustomViewData(),
-        );
-    }
-
-    public function toArray(): array
-    {
-        return $this->jsonSerialize();
     }
 }

--- a/src/Fields/Relationships/BelongsTo.php
+++ b/src/Fields/Relationships/BelongsTo.php
@@ -110,7 +110,7 @@ class BelongsTo extends ModelRelationField implements
     {
         return [
             'isSearchable' => $this->isSearchable(),
-            'values' => $this->values(),
+            'values' => $this->getRelation() ? $this->values() : [],
             'isSelected' => fn (string $value): bool => $this->isSelected($value),
             'isNullable' => $this->isNullable(),
             'customProperties' => $this->valuesWithProperties(onlyCustom: true),

--- a/src/Fields/Relationships/BelongsToMany.php
+++ b/src/Fields/Relationships/BelongsToMany.php
@@ -346,7 +346,7 @@ class BelongsToMany extends ModelRelationField implements
         return [
             'component' => $this->resolveValue(),
             'buttons' => $this->getButtons(),
-            'values' => $this->values(),
+            'values' => $this->getRelation() ? $this->values() : [],
             'customProperties' => $this->resolvePropertyAttributes(),
             'selectedKeys' => $this->selectedKeys(),
             'isSearchable' => $this->isSearchable(),

--- a/src/Fields/Relationships/HasMany.php
+++ b/src/Fields/Relationships/HasMany.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use MoonShine\Buttons\HasManyButton;
 use MoonShine\Components\ActionButtons\ActionButton;
+use MoonShine\Components\FlexibleRender;
 use MoonShine\Components\TableBuilder;
 use MoonShine\Contracts\Fields\HasFields;
 use MoonShine\Contracts\Fields\HasUpdateOnPreview;

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -2,16 +2,46 @@
 
 namespace MoonShine\Http\Controllers;
 
-use Illuminate\Contracts\View\View;
 use MoonShine\MoonShineRequest;
+use MoonShine\Pages\Page;
+use MoonShine\Pages\ViewPage;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 class PageController extends MoonShineController
 {
-    public function __invoke(MoonShineRequest $request): View|string
+    public function __invoke(MoonShineRequest $request): Page|JsonResponse
     {
-        return $request
-            ->getPage()
-            ->checkUrl()
-            ->render();
+        $page = $request->getPage()->checkUrl();
+
+        if($request->wantsJson()) {
+            return $this->structureResponse($page, $request);
+        }
+
+        return $page;
+    }
+
+    private function structureResponse(Page $page, MoonShineRequest $request): JsonResponse
+    {
+        $withStates = ! $request->hasHeader('X-MS-Without-States');
+
+        $layout = $page->layout();
+        $emptyPage = ViewPage::make();
+        $layoutComponents = $layout->build($emptyPage);
+
+        if($request->hasHeader('X-MS-Only-Layout')) {
+            return response()->json(
+                $layoutComponents->toStructure($withStates)
+            );
+        }
+
+        if($request->hasHeader('X-MS-Without-Layout')) {
+            return response()->json(
+                $page->getComponents()->toStructure($withStates)
+            );
+        }
+
+        return response()->json(
+            $page->toStructure($withStates)
+        );
     }
 }

--- a/src/MenuManager/MenuElement.php
+++ b/src/MenuManager/MenuElement.php
@@ -56,9 +56,4 @@ abstract class MenuElement implements MoonShineRenderable, HasCanSeeContract
             'top' => $this->isTopMode(),
         ];
     }
-
-    public function jsonSerialize(): array
-    {
-        return $this->systemViewData();
-    }
 }

--- a/src/Pages/Crud/IndexPage.php
+++ b/src/Pages/Crud/IndexPage.php
@@ -21,7 +21,6 @@ use MoonShine\Enums\JsEvent;
 use MoonShine\Enums\PageType;
 use MoonShine\Exceptions\ResourceException;
 use MoonShine\Fields\Fields;
-use MoonShine\Forms\FiltersForm;
 use MoonShine\Pages\Page;
 use MoonShine\Resources\ModelResource;
 use Throwable;
@@ -74,7 +73,6 @@ class IndexPage extends Page
     protected function mainLayer(): array
     {
         return [
-            ...$this->filtersForm(),
             ...$this->actionButtons(),
             ...$this->queryTags(),
             ...$this->table(),
@@ -91,18 +89,6 @@ class IndexPage extends Page
                     'class' => 'flex flex-col gap-y-8 gap-x-6 sm:grid sm:grid-cols-12 lg:gap-y-10 mb-6',
                 ])
             : null;
-    }
-
-    /**
-     * @return list<MoonShineComponent>
-     * @throws Throwable
-     */
-    protected function filtersForm(): array
-    {
-        return [
-            Block::make([(new FiltersForm())($this->getResource())])
-                ->customAttributes(['class' => 'hidden']),
-        ];
     }
 
     /*

--- a/src/Pages/Page.php
+++ b/src/Pages/Page.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\View;
 use MoonShine\Collections\ComponentsCollection;
 use MoonShine\Components\MoonShineComponent;
+use MoonShine\Contracts\Components\HasComponents;
 use MoonShine\Contracts\Fields\HasAssets;
 use MoonShine\Contracts\HasResourceContract;
 use MoonShine\Contracts\MoonShineRenderable;
@@ -33,6 +34,7 @@ use Throwable;
  */
 abstract class Page implements
     Renderable,
+    HasComponents,
     HasResourceContract,
     MenuFiller,
     HasAssets,
@@ -169,6 +171,22 @@ abstract class Page implements
     public function setBreadcrumbs(array $breadcrumbs): static
     {
         $this->breadcrumbs = $breadcrumbs;
+
+        return $this;
+    }
+
+    public function hasComponents(): bool
+    {
+        return $this->getComponents()->isNotEmpty();
+    }
+
+    public function setComponents(iterable $components): static
+    {
+        if(!$components instanceof ComponentsCollection) {
+            $components = ComponentsCollection::make($components);
+        }
+
+        $this->components = $components;
 
         return $this;
     }

--- a/src/Table/TableRow.php
+++ b/src/Table/TableRow.php
@@ -151,13 +151,8 @@ final class TableRow implements MoonShineRenderable
         ];
     }
 
-    public function jsonSerialize(): array
-    {
-        return (array) $this->data;
-    }
-
     public function toArray(): array
     {
-        return $this->jsonSerialize();
+        return (array) $this->data;
     }
 }

--- a/src/Traits/WithComponents.php
+++ b/src/Traits/WithComponents.php
@@ -40,7 +40,7 @@ trait WithComponents
         return $this->getComponents()->isNotEmpty();
     }
 
-    public function components(iterable $components): static
+    public function setComponents(iterable $components): static
     {
         if(app()->runningUnitTests()) {
             $components = collect($components)


### PR DESCRIPTION
A new concept and approach that we will implement in version 3. When requesting a page and expecting a json in the response (header accept: json), we will receive the structure of all components and their states, thereby we can obtain the page layout in advance and cache it, as well as the template and state of the page

This will make it possible to write a front-end part or a mobile application in Moonshine, without having to make a new build of the application if the set or order of components in Moonshine changes

Available headers - X-MS-Without-States, X-MS-Only-Layout, X-MS-Without-Layout