### PR TITLE
feat: optimize method for getting values

### DIFF
--- a/src/Traits/Fields/WithRelatedValues.php
+++ b/src/Traits/Fields/WithRelatedValues.php
@@ -107,8 +107,13 @@ trait WithRelatedValues
             ]
         );
 
+        if ($values->isNotEmpty()) {
+            return $values->toArray();
+        }
+
         $value = $this->toValue();
 
+        // if the values are empty then we add the selected one
         if ($value instanceof Model && $value->exists && $values->isEmpty()) {
             $values->put(
                 $value->getKey(),


### PR DESCRIPTION
The condition checking for virtual fields was removed (which caused the problem).
The condition for MongoDB has also been removed
This solution gets the entire set of fields from the table and maps them to optimize the query and get a specific set of fields, you need to use the _valuesQuery method_:
```php
BelongsTo::make(
    __('moonshine::ui.resource.role'),
    'moonshineUserRole',
    formatted: static fn (MoonshineUserRole $model) => $model->name,
    resource: MoonShineUserRoleResource::class,
)
    ->valuesQuery(fn(Builder $q) => $q->select(['id', 'name']))
```