### PR TITLE
feat: add methods for export/import

### DIFF
--- a/src/Handlers/ExportHandler.php
+++ b/src/Handlers/ExportHandler.php
@@ -150,10 +150,7 @@ class ExportHandler extends Handler
             foreach ($resource->resolveQuery()->cursor() as $index => $item) {
                 $row = [];
 
-                $fields = $resource
-                    ->getFields()
-                    ->onlyFields()
-                    ->exportFields();
+                $fields = $resource->getExportFields();
 
                 $fields->fill($item->toArray(), $item, $index);
 

--- a/src/Handlers/ImportHandler.php
+++ b/src/Handlers/ImportHandler.php
@@ -147,7 +147,7 @@ class ImportHandler extends Handler
         $result = $fastExcel->import($path, function ($line) use ($resource) {
             $data = collect($line)->mapWithKeys(
                 function ($value, $key) use ($resource): array {
-                    $field = $resource->getFields()->onlyFields()->importFields()->first(
+                    $field = $resource->getImportFields()->first(
                         fn (Field $field): bool => $field->column() === $key || $field->label() === $key
                     );
 

--- a/src/Traits/Resource/ResourceWithFields.php
+++ b/src/Traits/Resource/ResourceWithFields.php
@@ -154,7 +154,8 @@ trait ResourceWithFields
                 ->exportFields();
         }
 
-        return Fields::make($fields);
+        return Fields::make($fields)
+            ->ensure(Field::class);
     }
 
     public function importFields(): array
@@ -179,7 +180,8 @@ trait ResourceWithFields
                 ->importFields();
         }
 
-        return Fields::make($fields);
+        return Fields::make($fields)
+            ->ensure(Field::class);
     }
 
     /**

--- a/src/Traits/Resource/ResourceWithFields.php
+++ b/src/Traits/Resource/ResourceWithFields.php
@@ -132,6 +132,56 @@ trait ResourceWithFields
             ->onlyOutside();
     }
 
+    public function exportFields(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return Collection<int, Field>
+     * @throws Throwable
+     */
+    public function getExportFields(): Fields
+    {
+        $fields = $this->exportFields();
+
+        if ($fields === []) {
+            $fields = $this->fields()
+                ?: $this->indexFields();
+
+            return Fields::make($fields)
+                ->onlyFields()
+                ->exportFields();
+        }
+
+        return Fields::make($fields);
+    }
+
+    public function importFields(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return Collection<int, Field>
+     * @throws Throwable
+     */
+    public function getImportFields(): Fields
+    {
+        $fields = $this->importFields();
+
+        if ($fields === []) {
+            $fields = $this->fields()
+                ?: $this->indexFields();
+
+            return Fields::make($fields)
+                ->onlyFields()
+                ->importFields();
+        }
+
+        return Fields::make($fields);
+    }
+
     /**
      * @return list<MoonShineComponent|Field>
      */

--- a/src/Traits/Resource/ResourceWithFields.php
+++ b/src/Traits/Resource/ResourceWithFields.php
@@ -145,17 +145,17 @@ trait ResourceWithFields
     {
         $fields = $this->exportFields();
 
-        if ($fields === []) {
-            $fields = $this->fields()
-                ?: $this->indexFields();
-
+        if ($fields !== []) {
             return Fields::make($fields)
-                ->onlyFields()
-                ->exportFields();
+                ->ensure(Field::class);
         }
 
+        $fields = $this->fields()
+            ?: $this->indexFields();
+
         return Fields::make($fields)
-            ->ensure(Field::class);
+            ->onlyFields()
+            ->exportFields();
     }
 
     public function importFields(): array
@@ -171,17 +171,17 @@ trait ResourceWithFields
     {
         $fields = $this->importFields();
 
-        if ($fields === []) {
-            $fields = $this->fields()
-                ?: $this->indexFields();
-
+        if ($fields !== []) {
             return Fields::make($fields)
-                ->onlyFields()
-                ->importFields();
+                ->ensure(Field::class);
         }
 
+        $fields = $this->fields()
+            ?: $this->indexFields();
+
         return Fields::make($fields)
-            ->ensure(Field::class);
+            ->onlyFields()
+            ->importFields();
     }
 
     /**


### PR DESCRIPTION
Если в ресурсе использовать метод _indexFields()_, то при экспорте сохранялся пустой файл (ну и при импорте тоже ошибка). Пришлось частично позаимствовать из 3 версии методы _exportFields_ и _importFields_

в ресурсе:
```php
public function exportFields(): array
    {
        return [
            ID::make(),
            Text::make('Title'),
            TinyMce::make('Description'),
            Url::make('Link'),
        ];
    }
```