### PR TITLE
fix floating point for DonutCartMetric

### DIFF
--- a/resources/views/components/metrics/donut.blade.php
+++ b/resources/views/components/metrics/donut.blade.php
@@ -3,52 +3,53 @@
     'values' => [],
     'labels' => [],
     'colors' => [],
+    'decimal' => 3,
 ])
 
 <div
     {{ $attributes->merge(['class' => 'chart']) }}
     x-data="charts({
-                series: {{ json_encode($values) }},
-                colors: {{ json_encode($colors) }},
-                tooltip: {
-                    y: {
-                        formatter: function (val) {
-                            return `${val}`
-                        },
-                        title: {
-                            formatter: function (seriesName) {
-                                return `${seriesName}:`
-                            },
-                        },
+        series: {{ json_encode($values) }},
+        colors: {{ json_encode($colors) }},
+        tooltip: {
+            y: {
+                formatter: function (val) {
+                    return `${val}`
+                },
+                title: {
+                    formatter: function (seriesName) {
+                        return `${seriesName}:`
                     },
                 },
-                labels: {{ json_encode($labels) }},
-                chart: {
-                    height: 350,
-                    type: 'donut',
-                },
-                stroke: {
-                    colors: ['transparent'],
-                },
-                plotOptions: {
-                    pie: {
-                        expandOnClick: false,
-                        donut: {
-                            labels: {
-                                show: true,
-                                total: {
-                                    label: '{{ $title }}',
-                                    showAlways: false,
-                                    show: true,
-                                    formatter: function (w) {
-                                    return w.globals.seriesTotals.reduce((a, b) => {
-                                      return Number((a + b).toFixed(10))
-                                    }, 0)
-                                  }
-                                }
-                            }
+            },
+        },
+        labels: {{ json_encode($labels) }},
+        chart: {
+            height: 350,
+            type: 'donut',
+        },
+        stroke: {
+            colors: ['transparent'],
+        },
+        plotOptions: {
+            pie: {
+                expandOnClick: false,
+                donut: {
+                    labels: {
+                        show: true,
+                        total: {
+                            label: '{{ $title }}',
+                            showAlways: false,
+                            show: true,
+                            formatter: function (w) {
+                            return Number(w.globals.seriesTotals.reduce((a, b) => {
+                              return a + b
+                            }, 0).toFixed({{ $decimal }}))
+                          }
                         }
-                    },
-                },
-            })"
+                    }
+                }
+            },
+        },
+    })"
 ></div>

--- a/resources/views/components/metrics/donut.blade.php
+++ b/resources/views/components/metrics/donut.blade.php
@@ -3,7 +3,7 @@
     'values' => [],
     'labels' => [],
     'colors' => [],
-    'decimal' => 3,
+    'decimals' => 3,
 ])
 
 <div
@@ -44,7 +44,7 @@
                             formatter: function (w) {
                             return Number(w.globals.seriesTotals.reduce((a, b) => {
                               return a + b
-                            }, 0).toFixed({{ $decimal }}))
+                            }, 0).toFixed({{ $decimals }}))
                           }
                         }
                     }

--- a/resources/views/components/metrics/donut.blade.php
+++ b/resources/views/components/metrics/donut.blade.php
@@ -39,7 +39,12 @@
                                 total: {
                                     label: '{{ $title }}',
                                     showAlways: false,
-                                    show: true
+                                    show: true,
+                                    formatter: function (w) {
+                                    return w.globals.seriesTotals.reduce((a, b) => {
+                                      return Number((a + b).toFixed(10))
+                                    }, 0)
+                                  }
                                 }
                             }
                         }

--- a/resources/views/metrics/donut-chart.blade.php
+++ b/resources/views/metrics/donut-chart.blade.php
@@ -7,7 +7,7 @@
             :attributes="$attributes->merge(['id' => $element->id()])"
             :values="$element->getValues()"
             :colors="$element->getColors()"
-            :decimal="$element->getDecimal()"
+            :decimals="$element->getDecimals()"
             :labels="$element->labels()"
             :title="$element->label()"
         />

--- a/resources/views/metrics/donut-chart.blade.php
+++ b/resources/views/metrics/donut-chart.blade.php
@@ -7,6 +7,7 @@
             :attributes="$attributes->merge(['id' => $element->id()])"
             :values="$element->getValues()"
             :colors="$element->getColors()"
+            :decimal="$element->getDecimal()"
             :labels="$element->labels()"
             :title="$element->label()"
         />

--- a/src/Metrics/DonutChartMetric.php
+++ b/src/Metrics/DonutChartMetric.php
@@ -14,6 +14,8 @@ class DonutChartMetric extends Metric
 
     protected array $colors = [];
 
+    protected int $decimal = 3;
+
     protected array $assets = [
         'vendor/moonshine/libs/apexcharts/apexcharts.min.js',
         'vendor/moonshine/libs/apexcharts/apexcharts-config.js',
@@ -55,6 +57,26 @@ class DonutChartMetric extends Metric
         $this->colors = is_closure($colors)
             ? $colors()
             : $colors;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDecimal(): int
+    {
+        return $this->decimal;
+    }
+
+    /**
+     * @param int $decimal
+     */
+    public function decimal(int $decimal): self
+    {
+        if (in_array($decimal, range(0, 100))) {
+            $this->decimal = $decimal;
+        }
 
         return $this;
     }

--- a/src/Metrics/DonutChartMetric.php
+++ b/src/Metrics/DonutChartMetric.php
@@ -14,7 +14,7 @@ class DonutChartMetric extends Metric
 
     protected array $colors = [];
 
-    protected int $decimal = 3;
+    protected int $decimals = 3;
 
     protected array $assets = [
         'vendor/moonshine/libs/apexcharts/apexcharts.min.js',
@@ -61,21 +61,15 @@ class DonutChartMetric extends Metric
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getDecimal(): int
+    public function getDecimals(): int
     {
-        return $this->decimal;
+        return $this->decimals;
     }
 
-    /**
-     * @param int $decimal
-     */
-    public function decimal(int $decimal): self
+    public function decimals(int $decimals): self
     {
-        if (in_array($decimal, range(0, 100))) {
-            $this->decimal = $decimal;
+        if (in_array($decimals, range(0, 100), true)) {
+            $this->decimals = $decimals;
         }
 
         return $this;


### PR DESCRIPTION
```
DonutChartMetric::make('Subscribers') 
    ->values(['CutCode' => 10000.03, 'Apple' => 9999.02])
```
before:
<img width="297" alt="Снимок экрана 2024-06-01 в 15 05 39" src="https://github.com/moonshine-software/moonshine/assets/12373059/6392cc74-e7ff-4530-9950-5c404ca3b2a9">

after:
<img width="309" alt="Снимок экрана 2024-06-01 в 15 04 34" src="https://github.com/moonshine-software/moonshine/assets/12373059/4cb7ced1-228c-4724-a640-768b95fe40e2">

Added decimals method

```
DonutChartMetric::make('Subscribers') 
    ->values(['CutCode' => 10000.03, 'Apple' => 9999.02])
    ->decimals(5)
```

default: decimals = 3

