### PR TITLE
[3.x] Spa

### DIFF
--- a/src/Laravel/Layouts/AppLayout.php
+++ b/src/Laravel/Layouts/AppLayout.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace MoonShine\Laravel\Layouts;
 
 use MoonShine\Laravel\Components\Layout\{Flash, Locales, Notifications, Profile, Search};
+use MoonShine\Laravel\Components\Fragment;
 use MoonShine\Laravel\Resources\MoonShineUserResource;
 use MoonShine\Laravel\Resources\MoonShineUserRoleResource;
 use MoonShine\MenuManager\MenuGroup;
 use MoonShine\MenuManager\MenuItem;
-use MoonShine\UI\Components\{Breadcrumbs,
+use MoonShine\UI\Components\{ActionButton,
+    Breadcrumbs,
     Components,
     Layout\Block,
     Layout\Body,
@@ -27,6 +29,8 @@ use MoonShine\UI\Components\{Breadcrumbs,
     Layout\Wrapper,
     Title,
     When};
+use MoonShine\Support\AlpineJs;
+use MoonShine\Support\Enums\JsEvent;
 use MoonShine\UI\MoonShineLayout;
 
 class AppLayout extends MoonShineLayout
@@ -38,11 +42,11 @@ class AppLayout extends MoonShineLayout
                 MenuItem::make(
                     static fn () => __('moonshine::ui.resource.admins_title'),
                     moonshine()->getContainer(MoonShineUserResource::class)
-                ),
+                )->spa(),
                 MenuItem::make(
                     static fn () => __('moonshine::ui.resource.role_title'),
                     moonshine()->getContainer(MoonShineUserRoleResource::class)
-                ),
+                )->spa(),
             ]),
         ];
     }
@@ -91,28 +95,30 @@ class AppLayout extends MoonShineLayout
                         ])->collapsed(),
 
                         Block::make([
-                            Flash::make(),
-                            Header::make([
-                                Breadcrumbs::make($this->getPage()->getBreadcrumbs())
-                                    ->prepend(moonshineRouter()->getEndpoints()->home(), icon: 'home'),
+                            Fragment::make([
+                                Flash::make(),
+                                Header::make([
+                                    Breadcrumbs::make($this->getPage()->getBreadcrumbs())
+                                        ->prepend(moonshineRouter()->getEndpoints()->home(), icon: 'home'),
 
-                                Search::make(),
+                                    Search::make(),
 
-                                When::make(
-                                    static fn (): bool => moonshineConfig()->isAuthEnabled() && moonshineConfig()->isUseNotifications(),
-                                    static fn (): array => [Notifications::make()]
-                                ),
+                                    When::make(
+                                        static fn (): bool => moonshineConfig()->isAuthEnabled() && moonshineConfig()->isUseNotifications(),
+                                        static fn (): array => [Notifications::make()]
+                                    ),
 
-                                Locales::make(),
-                            ]),
+                                    Locales::make(),
+                                ]),
 
-                            Content::make([
-                                Title::make($this->getPage()->getTitle())->class('mb-6'),
+                                Content::make([
+                                    Title::make($this->getPage()->getTitle())->class('mb-6'),
 
-                                Components::make(
-                                    $this->getPage()->getComponents()
-                                ),
-                            ]),
+                                    Components::make(
+                                        $this->getPage()->getComponents()
+                                    ),
+                                ]),
+                            ])->name('_content')->customAttributes(['id' => 'content']),
 
                             Footer::make()
                                 ->copyright(static fn (): string => sprintf(

--- a/src/Laravel/Layouts/CompactLayout.php
+++ b/src/Laravel/Layouts/CompactLayout.php
@@ -25,6 +25,7 @@ use MoonShine\UI\Components\{Breadcrumbs,
     Layout\TopBar,
     Layout\Wrapper,
     When};
+use MoonShine\Laravel\Components\Fragment;
 
 class CompactLayout extends AppLayout
 {
@@ -158,23 +159,25 @@ class CompactLayout extends AppLayout
                             ]),
                         ])->collapsed(),
                         Block::make([
-                            Flash::make(),
-                            Header::make([
-                                Breadcrumbs::make($this->getPage()->getBreadcrumbs())
-                                    ->prepend(moonshineRouter()->getEndpoints()->home(), icon: 'home'),
+                            Fragment::make([
+                                Flash::make(),
+                                Header::make([
+                                    Breadcrumbs::make($this->getPage()->getBreadcrumbs())
+                                        ->prepend(moonshineRouter()->getEndpoints()->home(), icon: 'home'),
 
-                                Search::make(),
+                                    Search::make(),
 
-                                Notifications::make(),
+                                    Notifications::make(),
 
-                                Locales::make(),
-                            ]),
+                                    Locales::make(),
+                                ]),
 
-                            Content::make([
-                                Components::make(
-                                    $this->getPage()->getComponents()
-                                ),
-                            ]),
+                                Content::make([
+                                    Components::make(
+                                        $this->getPage()->getComponents()
+                                    ),
+                                ]),
+                            ])->name('_content')->customAttributes(['id' => 'content']),
 
                             Footer::make()
                                 ->copyright(static fn (): string => sprintf(

--- a/src/Laravel/Providers/MoonShineServiceProvider.php
+++ b/src/Laravel/Providers/MoonShineServiceProvider.php
@@ -52,11 +52,14 @@ use MoonShine\Laravel\Models\MoonshineUser;
 use MoonShine\Laravel\MoonShineConfigurator;
 use MoonShine\Laravel\MoonShineRequest;
 use MoonShine\Laravel\Resources\ModelResource;
+use MoonShine\Laravel\Resources\MoonShineUserRoleResource;
 use MoonShine\Laravel\Storage\LaravelStorage;
+use MoonShine\MenuManager\MenuItem;
 use MoonShine\MenuManager\MenuManager;
 use MoonShine\MoonShine;
 use MoonShine\Support\Enums\Env;
 use MoonShine\UI\Applies\AppliesRegister;
+use MoonShine\UI\Components\ActionButton;
 use MoonShine\UI\Contracts\Collections\FieldsCollection;
 use MoonShine\UI\Fields\Checkbox;
 use MoonShine\UI\Fields\Date;
@@ -180,6 +183,17 @@ class MoonShineServiceProvider extends ServiceProvider
             file: static fn (string $key) => request()->file($key, request()->input($key, false)),
             old: static fn (string $key, mixed $default) => session()->getOldInput($key, $default)
         ));
+
+        MenuItem::macro('spa', function () {
+            /** @var ModelResource $filler */
+            $filler = value($this->getFiller());
+
+            return $this->setUrl(
+                fn() => $filler->getFragmentLoadUrl('_content')
+            )->changeButton(
+                static fn(ActionButton $btn) => $btn->async(selector: '#content')
+            );
+        });
 
         return $this;
     }

--- a/src/Laravel/Traits/Resource/ResourceModelCrudRouter.php
+++ b/src/Laravel/Traits/Resource/ResourceModelCrudRouter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\Laravel\Traits\Resource;
 
 use Illuminate\Database\Eloquent\Model;
+use MoonShine\Core\Contracts\PageContract;
 use MoonShine\Core\Contracts\ResourceContract;
 use MoonShine\Laravel\Pages\Page;
 use MoonShine\Support\Enums\PageType;
@@ -77,10 +78,14 @@ trait ResourceModelCrudRouter
 
     public function getFragmentLoadUrl(
         string $fragment,
-        Page $page,
-        Model|int|string|null $model,
+        ?PageContract $page = null,
+        Model|int|string|null $model = null,
         array $params = []
     ): string {
+        if(is_null($page)) {
+            $page = $this->getIndexPage();
+        }
+
         return $this->getPageUrl(
             $page,
             params: array_filter([

--- a/src/MenuManager/MenuElement.php
+++ b/src/MenuManager/MenuElement.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\MenuManager;
 
 use Closure;
+use Illuminate\Support\Traits\Macroable;
 use MoonShine\Support\Components\MoonShineComponentAttributeBag;
 use MoonShine\Support\Traits\HasCanSee;
 use MoonShine\Support\Traits\Makeable;
@@ -17,6 +18,7 @@ use MoonShine\UI\Traits\WithViewRenderer;
 
 abstract class MenuElement implements MoonShineRenderable, HasCanSeeContract
 {
+    use Macroable;
     use Makeable;
     use WithComponentAttributes;
     use WithIcon;


### PR DESCRIPTION
Works via macro

```php
MenuItem::macro('spa', function () {
    /** @var ModelResource $filler */
    $filler = value($this->getFiller());

    return $this->setUrl(
        fn() => $filler->getFragmentLoadUrl('_content')
    )->changeButton(
        static fn(ActionButton $btn) => $btn->async(selector: '#content')
    );
});
```

Next, we simply add the spa method to the menu

```php
MenuItem::make(
    static fn () => __('moonshine::ui.resource.admins_title'),
    moonshine()->getContainer(MoonShineUserResource::class)
)->spa(),
```

### TODO
- [ ] Push state (browser history)
- [ ] Set current menu item (mb events)
- [ ] Fix the footer to the bottom
- [ ] Сlick on the active menu again to exclude