### PR TITLE
feat: remove ui-avatars.com dependency, and render name initials with html/css

### DIFF
--- a/resources/views/components/layout/profile.blade.php
+++ b/resources/views/components/layout/profile.blade.php
@@ -19,10 +19,18 @@
                class="menu-profile-main"
             >
                 <div class="menu-profile-photo">
-                    <img class="h-full w-full object-cover"
-                         src="{{ $avatar }}"
-                         alt="{{ $nameOfUser }}"
-                    />
+                    @if($avatar)
+                        <img class="h-full w-full object-cover"
+                             src="{{ $avatar }}"
+                             alt="{{ $nameOfUser }}"
+                        />
+                    @else
+                        <div class="h-full w-full object-cover flex items-center justify-center font-semibold text-xl"
+                             style="background-color: #dddddd; color: #222222;"
+                        >
+                            {{ \MoonShine\Utils::nameToInitials($nameOfUser) }}
+                        </div>
+                    @endif
                 </div>
                 <div class="menu-profile-info">
                     <h5 class="name">{{ $nameOfUser }}</h5>

--- a/src/Components/Layout/Profile.php
+++ b/src/Components/Layout/Profile.php
@@ -44,7 +44,7 @@ final class Profile extends MoonShineComponent
         $avatar = $avatar
             ? Storage::disk(config('moonshine.disk', 'public'))
                 ->url($avatar)
-            : "https://ui-avatars.com/api/?name=$nameOfUser";
+            : null;
 
         return [
             'route' => $this->route ?? to_page(config('moonshine.pages.profile', ProfilePage::class)),

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MoonShine;
+
+use Illuminate\Support\Str;
+
+class Utils
+{
+    /**
+     * return initials from name in UPPERCASE
+     */
+    public static function nameToInitials(string $name): string
+    {
+        $nameParts = explode(' ', $name);
+
+        if (count($nameParts) === 1) {
+            return mb_strtoupper(Str::charAt($name, 0) . (Str::charAt($name, 1) ?? ''));
+        }
+
+        return mb_strtoupper(Str::charAt($nameParts[0], 0) . Str::charAt(last($nameParts), 0));
+    }
+}

--- a/tests/Unit/UtilsTest.php
+++ b/tests/Unit/UtilsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+it('name to initials, one word', function (): void {
+    expect(\MoonShine\Utils::nameToInitials('moonshine'))
+        ->toBe('MO');
+});
+
+it('name to initials, two words', function (): void {
+    expect(\MoonShine\Utils::nameToInitials('beautiful moonshine'))
+        ->toBe('BM');
+});
+
+it('name to initials, three words', function (): void {
+    expect(\MoonShine\Utils::nameToInitials('moonshine is beautiful'))
+        ->toBe('MB');
+});


### PR DESCRIPTION
Когда у пользователя нет аватарки - она рендериться с помощью внешнего сервиса ui-avatars.com

убрал эту зависимость и теперь инициалы рендеряться с помощью CSS/HTML