### PR TITLE
feat: import enum field, can now by string (tryFromString)

### DIFF
--- a/src/Fields/Enum.php
+++ b/src/Fields/Enum.php
@@ -33,6 +33,11 @@ class Enum extends Select implements DefaultCanBeEnum
         return $this;
     }
 
+    public function getAttached(): ?string
+    {
+        return $this->attached;
+    }
+
     protected function resolvePreview(): string
     {
         $value = $this->toFormattedValue();

--- a/src/Handlers/ImportHandler.php
+++ b/src/Handlers/ImportHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MoonShine\Handlers;
 
+use MoonShine\Fields\Enum;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use MoonShine\Contracts\Fields\HasDefaultValue;
@@ -153,6 +154,14 @@ class ImportHandler extends Handler
 
                     if (! $field instanceof Field) {
                         return [];
+                    }
+
+                    if ($field instanceof Enum) {
+                        $caseEnum = rescue(fn () => $field->getAttached()::tryFromString($value), report: false);
+
+                        if ($caseEnum && method_exists($caseEnum, 'tryFromString')) {
+                            $value = $caseEnum::tryFromString($value)->value;
+                        }
                     }
 
                     if (empty($value)) {

--- a/src/Traits/Enum/HasTryFromStringEnumTrait.php
+++ b/src/Traits/Enum/HasTryFromStringEnumTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace MoonShine\Traits\Enum;
+
+use UnitEnum;
+
+/**
+ * @mixin UnitEnum
+ */
+trait HasTryFromStringEnumTrait
+{
+    public static function tryFromString(string $value): ?self
+    {
+        if (method_exists(self::class, 'toString') === false) {
+            return null;
+        }
+
+        $allCases = self::cases();
+
+        $foundCases = array_filter($allCases, fn($case): bool => mb_strtolower($case->toString()) === mb_strtolower($value));
+
+        return $foundCases !== [] ? head($foundCases) : null;
+    }
+}


### PR DESCRIPTION
Представим Enum:

```php
enum UserType: int
{
    use HasTryFromStringEnumTrait;

    case DEFAULT = 1;

    case PRO = 2;

    public function toString(): string
    {
        return match ($this) {
            self::DEFAULT => 'Обычный',
            self::PRO => 'Про',
        };
    }
}
```

Сейчас при экспорте - в XLS файле поля Enum берутся из toString() метода enum'а
если попытаться сразу этот же файл вкинуть в импорт - то получим ошибку, что "обычный" не может в int поле вставиться в БД.

добавил возможность кастить строку к enum'у если разработчик пропишет tryFromString() статик метод у енама.
Также сразу добавил трейт - HasTryFromStringEnumTrait

который автоматически создаёт метод tryFromString из метода toString()