### PR TITLE
feat(import): Import improvements

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -191,6 +191,10 @@ abstract class Field extends FormElement
         return $this->rawValue;
     }
 
+    /**
+     * @param  Closure(mixed $raw, static): mixed  $callback
+     * @return $this
+     */
     public function fromRaw(Closure $callback): static
     {
         $this->fromRaw = $callback;
@@ -219,6 +223,10 @@ abstract class Field extends FormElement
         return !is_null($this->rawValueCallback);
     }
 
+    /**
+     * @param  Closure(mixed $raw, static): mixed  $callback
+     * @return $this
+     */
     public function modifyRawValue(Closure $callback): static
     {
         $this->rawValueCallback = $callback;

--- a/src/Fields/Position.php
+++ b/src/Fields/Position.php
@@ -28,6 +28,10 @@ class Position extends Preview
 
     protected function resolvePreview(): View|string
     {
+        if($this->isRawMode()) {
+            return parent::resolvePreview();
+        }
+
         return $this->render();
     }
 }

--- a/src/Fields/Relationships/BelongsTo.php
+++ b/src/Fields/Relationships/BelongsTo.php
@@ -49,6 +49,10 @@ class BelongsTo extends ModelRelationField implements
      */
     protected function resolvePreview(): string
     {
+        if($this->isRawMode()) {
+            return (string) ($this->toValue()?->getKey() ?? $this->toFormattedValue() ?? '');
+        }
+
         $actions = $this->getResource()->getActiveActions();
 
         if (! in_array('view', $actions, true)

--- a/src/Fields/Relationships/HasMany.php
+++ b/src/Fields/Relationships/HasMany.php
@@ -433,6 +433,10 @@ class HasMany extends ModelRelationField implements HasFields
      */
     protected function resolvePreview(): View|string
     {
+        if($this->isRawMode()) {
+            return '';
+        }
+
         if (is_null($this->toValue())) {
             $casted = $this->getRelatedModel();
 

--- a/src/Fields/Td.php
+++ b/src/Fields/Td.php
@@ -97,6 +97,10 @@ class Td extends Template
 
     protected function resolvePreview(): string|View
     {
+        if($this->isRawMode()) {
+            return parent::resolvePreview();
+        }
+
         $fields = $this->hasConditionalFields()
             ? $this->getConditionalFields()
             : $this->getFields();
@@ -105,7 +109,7 @@ class Td extends Template
             Fields::make($fields)
         )
             ->mapFields(fn (Field $field): Field => $field
-                ->resolveFill($this->toRawValue(), $this->getData())
+                ->resolveFill($this->toRawValue(withoutModify: true), $this->getData())
                 ->beforeRender(fn (): string => $this->hasLabels() ? '' : (string) LineBreak::make())
                 ->withoutWrapper($this->hasLabels())
                 ->forcePreview())

--- a/src/Traits/Fields/ShowOrHide.php
+++ b/src/Traits/Fields/ShowOrHide.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MoonShine\Traits\Fields;
 
+use Closure;
 use MoonShine\Support\Condition;
 
 trait ShowOrHide
@@ -99,9 +100,13 @@ trait ShowOrHide
      *
      * @return $this
      */
-    public function showOnExport(mixed $condition = null): static
+    public function showOnExport(mixed $condition = null, ?Closure $modifyRawValue = null): static
     {
         $this->showOnExport = Condition::boolean($condition, true);
+
+        if(!is_null($modifyRawValue)) {
+            $this->modifyRawValue($modifyRawValue);
+        }
 
         return $this;
     }
@@ -194,9 +199,13 @@ trait ShowOrHide
      *
      * @return $this
      */
-    public function useOnImport(mixed $condition = null): static
+    public function useOnImport(mixed $condition = null, ?Closure $fromRaw = null): static
     {
         $this->useOnImport = Condition::boolean($condition, true);
+
+        if(!is_null($fromRaw)) {
+            $this->fromRaw($fromRaw);
+        }
 
         return $this;
     }

--- a/src/Traits/Resource/ResourceModelEvents.php
+++ b/src/Traits/Resource/ResourceModelEvents.php
@@ -80,4 +80,34 @@ trait ResourceModelEvents
     {
         // Logic here
     }
+
+    /**
+     * @param TModel $item
+     *
+     * @return array
+     */
+    public function beforeImportFilling(array $data): array
+    {
+        return $data;
+    }
+
+    /**
+     * @param TModel $item
+     *
+     * @return TModel
+     */
+    public function beforeImported(Model $item): Model
+    {
+        return $item;
+    }
+
+    /**
+     * @param TModel $item
+     *
+     * @return TModel
+     */
+    public function afterImported(Model $item): Model
+    {
+        return $item;
+    }
 }

--- a/tests/Feature/Fields/Relationships/BelongsToTest.php
+++ b/tests/Feature/Fields/Relationships/BelongsToTest.php
@@ -246,7 +246,7 @@ function belongsToExport(Item $item, int $newId): ?string
 
     expect($file)
         ->toContain('User')
-        ->toContain($item->user->name)
+        ->toContain($item->user->getKey())
     ;
 
     return $file;


### PR DESCRIPTION
This pr provides new functionality that can be used in import and export, thanks to which you can generate what value will be during export and what value will be generated during import. Events for import have also been added, which will allow you to add customization without the need to create a class

## New fields methods

- fromRaw - Callback for getting the value from raw to final, now used in import
- modifyRawValue - Additional callback handler for receiving raw value, currently used in export


### Example useOnImport/fromRaw/modifyRawValue

An example where, as a result of export, our inam field is a string and when importing, we convert it back to inam

```php
Enum::make('Enum')
    ->attach(ColorEnum::class)
    ->fromRaw(fn(string $raw, Enum $ctx) => ColorEnum::tryFrom($raw))
    ->modifyRawValue(fn(ColorEnum $raw, Enum $ctx) => $raw->value))
```

also through sugar right when announcing that fields are available in import and export

```php
Enum::make('Enum')
    ->attach(ColorEnum::class)
    ->useOnImport(fromRaw: static fn(string $raw, Enum $ctx) => ColorEnum::tryFrom($raw))
    ->showOnExport(modifyRawValue: static fn(ColorEnum $raw, Enum $ctx) => $raw->value)
```

### Resource import methods

- beforeImportFilling
- beforeImported
- afterImported

```php
 public function beforeImportFilling(array $data): array
{
    return $data;
}

public function beforeImported(Model $item): Model
{
    return $item;
}

public function afterImported(Model $item): Model
{
    return $item;
}
```

### ImportHandler

```php
$data = $resource->beforeImportFilling($data);

$item->forceFill($data);

$item = $resource->beforeImported($item);

return tap($item->save(), fn() => $resource->afterImported($item));
```