### PR TITLE
feat(export): Export xlsx default

### DIFF
--- a/src/Traits/Resource/ResourceModelActions.php
+++ b/src/Traits/Resource/ResourceModelActions.php
@@ -11,6 +11,8 @@ use MoonShine\Handlers\ImportHandler;
 
 trait ResourceModelActions
 {
+    protected static bool $defaultExportToCsv = false;
+
     /**
      * @return string[]
      */
@@ -27,14 +29,21 @@ trait ResourceModelActions
         return [];
     }
 
+    public static function defaultExportToCsv(): void
+    {
+        self::$defaultExportToCsv = true;
+    }
+
     public function export(): ?ExportHandler
     {
         if (! config('moonshine.model_resources.default_with_export', true)) {
             return null;
         }
 
-        return ExportHandler::make(__('moonshine::ui.export'))
-            ->csv();
+        return ExportHandler::make(__('moonshine::ui.export'))->when(
+            self::$defaultExportToCsv,
+            static fn (ExportHandler $handler): ExportHandler => $handler->csv()
+        );
     }
 
     public function import(): ?ImportHandler

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -112,6 +112,8 @@ class TestCase extends Orchestra
 
     protected function registerTestResource(): static
     {
+        ModelResource::defaultExportToCsv();
+
         moonshine()->resources([
             $this->moonShineUserResource(),
             new MoonShineUserRoleResource(),


### PR DESCRIPTION
Default export is now in xlsx format

If you need to make csv the default everywhere, then you can do it provider

```php
ModelResource::defaultExportToCsv();
```

Co-authored-by: JeRabix