### PR TITLE
feat: AsyncSearch

### DIFF
--- a/src/Http/Controllers/RelationModelFieldController.php
+++ b/src/Http/Controllers/RelationModelFieldController.php
@@ -58,17 +58,18 @@ class RelationModelFieldController extends MoonShineController
         }
 
         $query = $model->newModelQuery();
+        $term = $request->input('query');
 
         if (is_closure($field->asyncSearchQuery())) {
             $query = value(
                 $field->asyncSearchQuery(),
                 $query,
                 $request,
-                $field
+                $field,
+                $term
             );
         }
 
-        $term = $request->input('query');
         $values = $request->input($field->column(), '') ?? '';
 
         $except = is_array($values)
@@ -78,7 +79,7 @@ class RelationModelFieldController extends MoonShineController
         $offset = $request->input('offset', 0);
 
         $query->when(
-            $term,
+            (is_null($field->asyncSearchQuery()) || $field->isAsyncSearchReplaceQuery() === false) && $term,
             fn (Builder $q) => $q->where(
                 $searchColumn,
                 DBOperators::byModel($q->getModel())->like(),

--- a/src/Traits/Fields/WithAsyncSearch.php
+++ b/src/Traits/Fields/WithAsyncSearch.php
@@ -24,6 +24,8 @@ trait WithAsyncSearch
 
     protected ?Closure $asyncSearchQuery = null;
 
+    protected bool $asyncSearchReplaceQuery = false;
+
     protected ?Closure $asyncSearchValueCallback = null;
 
     protected array $withImage = [];
@@ -111,6 +113,11 @@ trait WithAsyncSearch
         return $this->asyncSearchQuery;
     }
 
+    public function isAsyncSearchReplaceQuery(): bool
+    {
+        return $this->asyncSearchReplaceQuery;
+    }
+
     public function asyncSearchValueCallback(): ?Closure
     {
         return $this->asyncSearchValueCallback;
@@ -169,6 +176,7 @@ trait WithAsyncSearch
         ?Closure $asyncSearchValueCallback = null,
         ?string $associatedWith = null,
         ?string $url = null,
+        bool $replaceQuery = false,
     ): static {
         $this->asyncSearch = true;
         $this->searchable = true;
@@ -178,6 +186,7 @@ trait WithAsyncSearch
         $this->asyncSearchValueCallback = $asyncSearchValueCallback ?? $this->formattedValueCallback();
         $this->associatedWith = $associatedWith;
         $this->asyncUrl = $url;
+        $this->asyncSearchReplaceQuery = $replaceQuery;
 
         if ($this->associatedWith) {
             $this->customAttributes([
@@ -199,13 +208,14 @@ trait WithAsyncSearch
     /**
      * @param  ?Closure(Builder $query, mixed $value, self $field): Builder  $asyncSearchQuery
      */
-    public function associatedWith(string $column, ?Closure $asyncSearchQuery = null): static
+    public function associatedWith(string $column, ?Closure $asyncSearchQuery = null, bool $replaceQuery = false,): static
     {
         $searchQuery = static fn (Builder $query, Request $request) => $query->where($column, $request->input($column));
 
         return $this->asyncSearch(
             asyncSearchQuery: is_null($asyncSearchQuery) ? $searchQuery : $asyncSearchQuery,
-            associatedWith: $column
+            associatedWith: $column,
+            replaceQuery: $replaceQuery
         );
     }
 }


### PR DESCRIPTION
If you use async search and at the same time change the builder, then the initial state of the builder will remain and will be relevant in some cases, but if you need to completely replace the builder with your own, then use the replaceQuery flag

```php
asyncSearch(asyncSearchQuery: fn($q) => $q->where(..., ...), replaceQuery: true)
```