### PR TITLE
feat(BelongsToMany): add ability to set custom color for badge in inLine format

### DIFF
--- a/src/Fields/Relationships/BelongsToMany.php
+++ b/src/Fields/Relationships/BelongsToMany.php
@@ -417,9 +417,9 @@ class BelongsToMany extends ModelRelationField implements
                         );
                 }
 
-                $badgeValue = value($this->inLineBadge, $item, (string) $value, $this);
+                $badgeValue = value($this->inLineBadge, $item, $value, $this);
 
-                if ($badgeValue) {
+                if ($badgeValue !== false) {
                     $badge = $badgeValue instanceof Badge
                         ? $badgeValue
                         : Badge::make((string) $value, 'primary');

--- a/src/Fields/Relationships/BelongsToMany.php
+++ b/src/Fields/Relationships/BelongsToMany.php
@@ -420,12 +420,11 @@ class BelongsToMany extends ModelRelationField implements
                 $badgeValue = value($this->inLineBadge, $item, (string) $value, $this);
 
                 if ($badgeValue) {
-                    return $badgeValue instanceof Badge ?
-                        $badgeValue->customAttributes(['class' => 'm-1'])->render() :
-                        (is_bool($badgeValue) ?
-                            Badge::make((string) $value, 'primary')->customAttributes(['class' => 'm-1'])->render() :
-                            $value
-                        );
+                    $badge = $badgeValue instanceof Badge
+                        ? $badgeValue
+                        : Badge::make((string) $value, 'primary');
+
+                    return $badge->customAttributes(['class' => 'm-1'])->render();
                 }
 
                 return $value;

--- a/src/Fields/Relationships/BelongsToMany.php
+++ b/src/Fields/Relationships/BelongsToMany.php
@@ -100,12 +100,13 @@ class BelongsToMany extends ModelRelationField implements
         return $this;
     }
 
-    public function inLine(string $separator = '', bool $badge = false, ?Closure $link = null): static
+    public function inLine(string $separator = '', bool $badge = false, ?Closure $link = null, string $badgeColor = 'primary'): static
     {
         $this->inLine = true;
         $this->inLineSeparator = $separator;
         $this->inLineBadge = $badge;
         $this->inLineLink = $link;
+        $this->badgeColor = $badgeColor;
 
         return $this;
     }
@@ -418,7 +419,7 @@ class BelongsToMany extends ModelRelationField implements
                 }
 
                 if ($this->inLineBadge) {
-                    return Badge::make((string) $value, 'primary')
+                    return Badge::make((string) $value, $this->badgeColor)
                         ->customAttributes(['class' => 'm-1'])
                         ->render();
                 }

--- a/src/Fields/Relationships/BelongsToMany.php
+++ b/src/Fields/Relationships/BelongsToMany.php
@@ -417,14 +417,15 @@ class BelongsToMany extends ModelRelationField implements
                         );
                 }
 
-                if ($this->inLineBadge) {
-                    $badgeValue = value($this->inLineBadge, $item, (string) $value, $this);
+                $badgeValue = value($this->inLineBadge, $item, (string) $value, $this);
 
-                    $badge = $badgeValue instanceof Badge
-                        ? $badgeValue
-                        : Badge::make((string) $value, 'primary');
-
-                    return $badge->customAttributes(['class' => 'm-1'])->render();
+                if ($badgeValue) {
+                    return $badgeValue instanceof Badge ?
+                        $badgeValue->customAttributes(['class' => 'm-1'])->render() :
+                        (is_bool($badgeValue) ?
+                            Badge::make((string) $value, 'primary')->customAttributes(['class' => 'm-1'])->render() :
+                            $value
+                        );
                 }
 
                 return $value;

--- a/src/Fields/Relationships/BelongsToMany.php
+++ b/src/Fields/Relationships/BelongsToMany.php
@@ -70,7 +70,7 @@ class BelongsToMany extends ModelRelationField implements
 
     protected string $inLineSeparator = '';
 
-    protected Closure|bool|null $badgeCallback = null;
+    protected Closure|bool $inLineBadge = false;
 
     protected bool $selectMode = false;
 
@@ -100,11 +100,11 @@ class BelongsToMany extends ModelRelationField implements
         return $this;
     }
 
-    public function inLine(string $separator = '', Closure|bool $badge = null, ?Closure $link = null): static
+    public function inLine(string $separator = '', Closure|bool $badge = false, ?Closure $link = null): static
     {
         $this->inLine = true;
         $this->inLineSeparator = $separator;
-        $this->badgeCallback = $badge;
+        $this->inLineBadge = $badge;
         $this->inLineLink = $link;
 
         return $this;
@@ -417,15 +417,14 @@ class BelongsToMany extends ModelRelationField implements
                         );
                 }
 
-                if ($this->badgeCallback) {
-                    if(is_bool($this->badgeCallback)) {
-                        return Badge::make((string) $value, 'primary')
-                            ->customAttributes(['class' => 'm-1'])
-                            ->render();
-                    }
+                if ($this->inLineBadge) {
+                    $badgeValue = value($this->inLineBadge, $item, (string) $value, $this);
 
-                    $badge = value($this->badgeCallback, $item, $value);
-                    return $badge instanceof Badge ? $badge->customAttributes(['class' => 'm-1'])->render() : $value;
+                    $badge = $badgeValue instanceof Badge
+                        ? $badgeValue
+                        : Badge::make((string) $value, 'primary');
+
+                    return $badge->customAttributes(['class' => 'm-1'])->render();
                 }
 
                 return $value;

--- a/src/Fields/Relationships/BelongsToMany.php
+++ b/src/Fields/Relationships/BelongsToMany.php
@@ -70,7 +70,7 @@ class BelongsToMany extends ModelRelationField implements
 
     protected string $inLineSeparator = '';
 
-    protected bool $inLineBadge = false;
+    protected Closure|bool|null $badgeCallback = null;
 
     protected bool $selectMode = false;
 
@@ -100,13 +100,12 @@ class BelongsToMany extends ModelRelationField implements
         return $this;
     }
 
-    public function inLine(string $separator = '', bool $badge = false, ?Closure $link = null, string $badgeColor = 'primary'): static
+    public function inLine(string $separator = '', Closure|bool $badge = null, ?Closure $link = null): static
     {
         $this->inLine = true;
         $this->inLineSeparator = $separator;
-        $this->inLineBadge = $badge;
+        $this->badgeCallback = $badge;
         $this->inLineLink = $link;
-        $this->badgeColor = $badgeColor;
 
         return $this;
     }
@@ -418,10 +417,15 @@ class BelongsToMany extends ModelRelationField implements
                         );
                 }
 
-                if ($this->inLineBadge) {
-                    return Badge::make((string) $value, $this->badgeColor)
-                        ->customAttributes(['class' => 'm-1'])
-                        ->render();
+                if ($this->badgeCallback) {
+                    if(is_bool($this->badgeCallback)) {
+                        return Badge::make((string) $value, 'primary')
+                            ->customAttributes(['class' => 'm-1'])
+                            ->render();
+                    }
+
+                    $badge = value($this->badgeCallback, $item, $value);
+                    return $badge instanceof Badge ? $badge->customAttributes(['class' => 'm-1'])->render() : $value;
                 }
 
                 return $value;


### PR DESCRIPTION
Для поля BelongsToMany в сахар `->inline()` добавил возможность в качестве **badge** передавать компонент `Badge`.

![image](https://github.com/moonshine-software/moonshine/assets/73887319/25a01ad9-ebd6-4ad0-bae8-609e6f6f102f)

Теперь при наличии нескольких полей **BelongsToMany** на индексной странице есть возможность указать цвет, отличный от **primary**.