### PR TITLE
Update Change Password Heading to Use Translation String

### DIFF
--- a/src/Resources/MoonShineUserResource.php
+++ b/src/Resources/MoonShineUserResource.php
@@ -76,7 +76,7 @@ class MoonShineUserResource extends ModelResource
                     ]),
 
                     Tab::make(__('moonshine::ui.resource.password'), [
-                        Heading::make('Change password'),
+                        Heading::make(__('moonshine::ui.resource.change_password')),
 
                         Password::make(__('moonshine::ui.resource.password'), 'password')
                             ->customAttributes(['autocomplete' => 'new-password'])


### PR DESCRIPTION
This PR updates the "Change Password" heading to use a translation string for improved internationalization support. 

- **Change Made:** 
  - Replaced `Heading::make('Change password')` with `Heading::make(__('moonshine::ui.resource.change_password'))`
- **Reason:** 
  - This change ensures that the heading text is properly translated based on the user's locale settings, enhancing the user experience for non-English speakers.
- **Impact:** 
  - This change is backward compatible and only affects the display of the heading text. There are no functional changes to the application.

Please review and merge this PR to improve our application's internationalization support.

Thank you!