### PR TITLE
fix: prevent select dropdown open when it's in disabled state

### DIFF
--- a/resources/js/alpine/select.js
+++ b/resources/js/alpine/select.js
@@ -181,9 +181,11 @@ export default (asyncUrl = '') => ({
         callbackOnInit: () => {
           this.searchTerms = this.$el.closest('.choices').querySelector('[name="search_terms"]')
 
-          this.$el.closest('.choices').addEventListener('focus', () => {
-            this.choicesInstance.showDropdown()
-          })
+          if (!this.$el?.disabled) {
+            this.$el.closest('.choices').addEventListener('focus', () => {
+              this.choicesInstance.showDropdown()
+            })
+          }
 
           if (this.associatedWith && asyncUrl) {
             this.asyncSearch(true)


### PR DESCRIPTION
### Description

This pull request fixes an issue with the dropdown for the select element when it receives focus while in a disabled state.

### Problem

Previously, a disabled select element would open its dropdown upon focus and remain open, obstructing the rest of the website interface. This issue caused a broken user experience, as the dropdown would not close, and users had to refresh the page to resolve the problem, which may not be intuitive for them.

### Solution

The issue has been resolved by ensuring that the dropdown does not open when the select element is in a disabled state. Now, users can navigate forms confidently without encountering this issue, even if the select element is disabled.

### Benefits

- Ensures a seamless user experience by preventing the dropdown from opening when the select element is disabled.
- No need for additional custom logic to handle disabled states for the select element.
- Users can rely on the form's behavior, knowing that a disabled select element will not cause interface obstructions.

### Testing

- The code was tested locally for various states, both with and without the disabled attribute.
- Verified the functionality when navigating through the form using the Tab key.
- Confirmed that the select element still opens automatically upon focus when it is not in a disabled state.