### PR TITLE
feat(export): added the ability to export with confirmation

### DIFF
--- a/lang/en/ui.php
+++ b/lang/en/ui.php
@@ -73,6 +73,7 @@ return [
 
         'export' => [
             'exported' => 'File exported',
+            'confirm_content' => 'Is everything ready for export?',
         ],
 
         'import' => [

--- a/lang/en/ui.php
+++ b/lang/en/ui.php
@@ -73,7 +73,7 @@ return [
 
         'export' => [
             'exported' => 'File exported',
-            'confirm_content' => 'Is everything ready for export?',
+            'confirm_content' => 'Confirm data export',
         ],
 
         'import' => [

--- a/lang/ru/ui.php
+++ b/lang/ru/ui.php
@@ -73,7 +73,7 @@ return [
 
         'export' => [
             'exported' => 'Экспортирован',
-            'confirm_content' => 'Всё готово для экспорта?',
+            'confirm_content' => 'Подтвердите экспорт данных',
         ],
 
         'import' => [

--- a/lang/ru/ui.php
+++ b/lang/ru/ui.php
@@ -73,6 +73,7 @@ return [
 
         'export' => [
             'exported' => 'Экспортирован',
+            'confirm_content' => 'Всё готово для экспорта?',
         ],
 
         'import' => [

--- a/src/Buttons/ExportButton.php
+++ b/src/Buttons/ExportButton.php
@@ -25,7 +25,7 @@ final class ExportButton
             ->customAttributes(['class' => '_change-query', 'data-original-url' => $url])
             ->icon($export->iconValue());
 
-        if ($export->getWithConfirm()) {
+        if ($export->isWithConfirm()) {
             $button->withConfirm(content: trans('moonshine::ui.resource.export.confirm_content'));
         }
 

--- a/src/Buttons/ExportButton.php
+++ b/src/Buttons/ExportButton.php
@@ -25,7 +25,7 @@ final class ExportButton
             ->customAttributes(['class' => '_change-query', 'data-original-url' => $url])
             ->icon($export->iconValue());
 
-        if ($export->withConfirm()) {
+        if ($export->getWithConfirm()) {
             $button->withConfirm(content: trans('moonshine::ui.resource.export.confirm_content'));
         }
 

--- a/src/Buttons/ExportButton.php
+++ b/src/Buttons/ExportButton.php
@@ -17,12 +17,18 @@ final class ExportButton
 
         $url = $resource->route('handler', query: ['handlerUri' => $export->uriKey()]);
 
-        return ActionButton::make(
+        $button = ActionButton::make(
             $export->label(),
             trim("$url?ts=" . time() . "&$query", '&')
         )
             ->primary()
             ->customAttributes(['class' => '_change-query', 'data-original-url' => $url])
             ->icon($export->iconValue());
+
+        if ($export->withConfirm()) {
+            $button->withConfirm(content: trans('moonshine::ui.resource.export.confirm_content'));
+        }
+
+        return $button;
     }
 }

--- a/src/Handlers/ExportHandler.php
+++ b/src/Handlers/ExportHandler.php
@@ -28,6 +28,8 @@ class ExportHandler extends Handler
 
     protected bool $isCsv = false;
 
+    protected bool $withConfirm = false;
+
     protected string $csvDelimiter = ',';
 
     protected ?string $filename = null;
@@ -35,6 +37,13 @@ class ExportHandler extends Handler
     public function csv(): static
     {
         $this->isCsv = true;
+
+        return $this;
+    }
+
+    public function withConfirm(): static
+    {
+        $this->withConfirm = true;
 
         return $this;
     }

--- a/src/Handlers/ExportHandler.php
+++ b/src/Handlers/ExportHandler.php
@@ -41,6 +41,13 @@ class ExportHandler extends Handler
         return $this;
     }
 
+    public function withConfirm(): static
+    {
+        $this->withConfirm = true;
+
+        return $this;
+    }
+
     public function getWithConfirm(): bool
     {
         return $this->withConfirm;

--- a/src/Handlers/ExportHandler.php
+++ b/src/Handlers/ExportHandler.php
@@ -41,11 +41,9 @@ class ExportHandler extends Handler
         return $this;
     }
 
-    public function withConfirm(): static
+    public function getWithConfirm(): bool
     {
-        $this->withConfirm = true;
-
-        return $this;
+        return $this->withConfirm;
     }
 
     public function delimiter(string $value): static

--- a/src/Handlers/ExportHandler.php
+++ b/src/Handlers/ExportHandler.php
@@ -48,7 +48,7 @@ class ExportHandler extends Handler
         return $this;
     }
 
-    public function getWithConfirm(): bool
+    public function isWithConfirm(): bool
     {
         return $this->withConfirm;
     }

--- a/src/Pages/Crud/IndexPage.php
+++ b/src/Pages/Crud/IndexPage.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace MoonShine\Pages\Crud;
 
-use MoonShine\Buttons\ExportButton;
-use MoonShine\Buttons\FiltersButton;
-use MoonShine\Buttons\ImportButton;
 use MoonShine\Buttons\QueryTagButton;
 use MoonShine\Components\ActionGroup;
 use MoonShine\Components\Layout\LayoutBlock;
@@ -124,17 +121,17 @@ class IndexPage extends Page
                     ActionGroup::make()->when(
                         $this->getResource()->filters() !== [],
                         fn (ActionGroup $group): ActionGroup => $group->add(
-                            FiltersButton::for($this->getResource())
+                            $this->getResource()->getFiltersButton(),
                         )
                     )->when(
-                        ! is_null($export = $this->getResource()->export()),
+                        ! is_null($this->getResource()->export()),
                         fn (ActionGroup $group): ActionGroup => $group->add(
-                            ExportButton::for($this->getResource(), $export)
+                            $this->getResource()->getExportButton(),
                         ),
                     )->when(
-                        ! is_null($import = $this->getResource()->import()),
+                        ! is_null($this->getResource()->import()),
                         fn (ActionGroup $group): ActionGroup => $group->add(
-                            ImportButton::for($this->getResource(), $import)
+                            $this->getResource()->getImportButton(),
                         ),
                     ),
                 ])->customAttributes([

--- a/src/Traits/Resource/ResourceWithButtons.php
+++ b/src/Traits/Resource/ResourceWithButtons.php
@@ -146,7 +146,7 @@ trait ResourceWithButtons
 
     public function getImportButton(): ActionButton
     {
-        return $this->modifyEditButton(
+        return $this->modifyImportButton(
             ImportButton::for($this, import: $this->import())
         );
     }
@@ -158,7 +158,7 @@ trait ResourceWithButtons
 
     public function getFiltersButton(): ActionButton
     {
-        return $this->modifyEditButton(
+        return $this->modifyFiltersButton(
             FiltersButton::for($this)
         );
     }

--- a/src/Traits/Resource/ResourceWithButtons.php
+++ b/src/Traits/Resource/ResourceWithButtons.php
@@ -10,6 +10,7 @@ use MoonShine\Buttons\CreateButton;
 use MoonShine\Buttons\DeleteButton;
 use MoonShine\Buttons\DetailButton;
 use MoonShine\Buttons\EditButton;
+use MoonShine\Buttons\ExportButton;
 use MoonShine\Buttons\MassDeleteButton;
 
 trait ResourceWithButtons
@@ -121,6 +122,18 @@ trait ResourceWithButtons
                 componentName: $componentName,
                 isAsync: $isAsync
             )
+        );
+    }
+
+    protected function modifyExportButton(ActionButton $button): ActionButton
+    {
+        return $button;
+    }
+
+    public function getExportButton(): ActionButton
+    {
+        return $this->modifyEditButton(
+            ExportButton::for($this, export: $this->export())
         );
     }
 

--- a/src/Traits/Resource/ResourceWithButtons.php
+++ b/src/Traits/Resource/ResourceWithButtons.php
@@ -11,6 +11,8 @@ use MoonShine\Buttons\DeleteButton;
 use MoonShine\Buttons\DetailButton;
 use MoonShine\Buttons\EditButton;
 use MoonShine\Buttons\ExportButton;
+use MoonShine\Buttons\FiltersButton;
+use MoonShine\Buttons\ImportButton;
 use MoonShine\Buttons\MassDeleteButton;
 
 trait ResourceWithButtons
@@ -134,6 +136,30 @@ trait ResourceWithButtons
     {
         return $this->modifyEditButton(
             ExportButton::for($this, export: $this->export())
+        );
+    }
+
+    protected function modifyImportButton(ActionButton $button): ActionButton
+    {
+        return $button;
+    }
+
+    public function getImportButton(): ActionButton
+    {
+        return $this->modifyEditButton(
+            ImportButton::for($this, import: $this->import())
+        );
+    }
+
+    protected function modifyFiltersButton(ActionButton $button): ActionButton
+    {
+        return $button;
+    }
+
+    public function getFiltersButton(): ActionButton
+    {
+        return $this->modifyEditButton(
+            FiltersButton::for($this)
         );
     }
 

--- a/src/Traits/Resource/ResourceWithButtons.php
+++ b/src/Traits/Resource/ResourceWithButtons.php
@@ -134,7 +134,7 @@ trait ResourceWithButtons
 
     public function getExportButton(): ActionButton
     {
-        return $this->modifyEditButton(
+        return $this->modifyExportButton(
             ExportButton::for($this, export: $this->export())
         );
     }


### PR DESCRIPTION
Для экспорта добавил возможность экспорта по подтверждению. 
Теперь есть сахар в виде `->withConfirm()`:

```php
public function export(): ?ExportHandler
{
    return ExportHandler::make(__('moonshine::ui.export'))->withConfirm();
}
```

При работе с кастомным `ExportHandler` есть возможность установить подтверждение при экспорте для любого ресурса, путём указания переменной 
```php
class ExportHandler extends Handler
{
...
  protected bool $withConfirm = true;
...
}
```
![image](https://github.com/user-attachments/assets/66f77a53-3b22-4419-b9d7-6e63a1dc380c)
![image](https://github.com/user-attachments/assets/41a9f7c9-76f8-43da-9270-458d621289ca)

Добавлены декораторы `modifyExportButton`, `modifyImportButton` и `modifyFiltersButton`. Теперь есть возможность кастомизировать кнопки "Экспорт", "Импорт" и "Фильтры".
