### PR TITLE
forceFill in ModelCast

### DIFF
--- a/src/TypeCasts/ModelCast.php
+++ b/src/TypeCasts/ModelCast.php
@@ -39,10 +39,7 @@ final class ModelCast implements MoonShineDataCast
         $value = (new ($this->getClass())());
 
         $value
-            ->forceFill([
-                $value->getKeyName() => $data[$value->getKeyName()] ?? null,
-                ...collect($data)->filter(fn ($item): bool => is_scalar($item))->toArray(),
-            ])
+            ->forceFill(collect($data)->except('_relations')->toArray())
             ->setRelations($data['_relations'] ?? []);
 
         $value->exists = ! empty($value->getKey());

--- a/src/TypeCasts/ModelCast.php
+++ b/src/TypeCasts/ModelCast.php
@@ -43,11 +43,6 @@ final class ModelCast implements MoonShineDataCast
                 $value->getKeyName() => $data[$value->getKeyName()] ?? null,
                 ...collect($data)->filter(fn ($item): bool => is_scalar($item))->toArray(),
             ])
-            ->fill(
-                collect($data)
-                    ->except([$value->getKeyName(), $value->getUpdatedAtColumn(), $value->getCreatedAtColumn()])
-                    ->toArray()
-            )
             ->setRelations($data['_relations'] ?? []);
 
         $value->exists = ! empty($value->getKey());


### PR DESCRIPTION
The model is filled twice. A mass assignment error will not occur if the model has any fillable value