### PR TITLE
feat: Имя отношения для отображения к полю MorphTo

### DIFF
--- a/src/Fields/Relationships/MorphTo.php
+++ b/src/Fields/Relationships/MorphTo.php
@@ -28,7 +28,7 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * @param  array<string, string>  $types
+     * @param  array<string, string|array>  $types
      * @return $this
      */
     public function types(array $types): self
@@ -38,18 +38,22 @@ class MorphTo extends BelongsTo
         $this->searchColumns = collect($types)
             ->mapWithKeys(
                 fn (
-                    string $searchColumn,
+                    string|array $searchColumn,
                     string $type
-                ): array => [$type => $searchColumn]
+                ): array => [
+                    $type => !is_array($searchColumn) ? $searchColumn : $searchColumn[0]
+                ]
             )
             ->toArray();
 
         $this->types = collect($types)
             ->mapWithKeys(
                 fn (
-                    string $searchColumn,
+                    string|array $searchColumn,
                     string $type
-                ): array => [$type => class_basename($type)]
+                ): array => [
+                    $type => is_array($searchColumn) ? $searchColumn[1] : class_basename($type)
+                ]
             )
             ->toArray();
 


### PR DESCRIPTION
Реализована возможность указания имени отношения вместо названия модели для поля MorpTo. Путем задания значения для ключа(ссылки на модель) массива: первым элементом поле для отображения, вторым название для отображения.
```php
//...
MorphTo::make('Изображение', 'imageable')->types([
  Post::class => ['title', 'Публикация'],
  Comment::class => 'title'
])
//...
```