### PR TITLE
fix: HiddenValuesAttributes

### DIFF
--- a/resources/views/components/form/file-item.blade.php
+++ b/resources/views/components/form/file-item.blade.php
@@ -5,6 +5,7 @@
     'download' => false,
     'removable' => true,
     'removableAttributes' => null,
+    'hiddenAttributes' => null,
     'imageable' => true,
     'itemAttributes',
 ])
@@ -16,12 +17,7 @@
 >
     <x-moonshine::form.input
         type="hidden"
-        :name="'hidden_' . $attributes->get('name')"
-        :attributes="$attributes->only(['data-level'])->merge([
-            'data-name' => str($attributes->get('data-name'))
-                ->replaceLast($attributes->get('data-column'), 'hidden_' . $attributes->get('data-column'))
-                ->value()
-        ])"
+        :attributes="$hiddenAttributes"
         :value="$raw"
     />
 

--- a/resources/views/components/form/file.blade.php
+++ b/resources/views/components/form/file.blade.php
@@ -7,6 +7,7 @@
     'imageable' => true,
     'names' => null,
     'itemAttributes' => null,
+    'hiddenAttributes' => null,
 ])
 <div class="form-group form-group-dropzone">
     <x-moonshine::form.input
@@ -30,6 +31,7 @@
                         :download="$download"
                         :removable="$removable"
                         :removableAttributes="$removableAttributes"
+                        :hiddenAttributes="$hiddenAttributes"
                         :imageable="$imageable"
                     />
                 @endforeach

--- a/resources/views/fields/file.blade.php
+++ b/resources/views/fields/file.blade.php
@@ -11,4 +11,5 @@
     :download="$element->canDownload()"
     :names="$element->resolveNames()"
     :itemAttributes="$element->resolveItemAttributes()"
+    :hiddenAttributes="$element->getHiddenAttributes()"
 />

--- a/resources/views/fields/image.blade.php
+++ b/resources/views/fields/image.blade.php
@@ -10,4 +10,5 @@
     :imageable="true"
     :names="$element->resolveNames()"
     :itemAttributes="$element->resolveItemAttributes()"
+    :hiddenAttributes="$element->getHiddenAttributes()"
 />

--- a/src/Applies/Filters/JsonModelApply.php
+++ b/src/Applies/Filters/JsonModelApply.php
@@ -23,21 +23,23 @@ class JsonModelApply implements ApplyContract
                     $data = array_filter($values->first());
 
                     if (filled($data)) {
+                        $column = str_replace('.', '->', $field->column());
+
                         $q
                             ->when(
                                 ! $field->isKeyOrOnlyValue(),
-                                fn (Builder $qq) => $qq->whereJsonContains($field->column(), $data)
+                                fn (Builder $qq) => $qq->whereJsonContains($column, $data)
                             )
                             ->when(
                                 $field->isKeyValue(),
                                 fn (Builder $qq) => $qq->where(
-                                    $field->column() . '->' . ($data['key'] ?? '*'),
+                                    $column . '->' . ($data['key'] ?? '*'),
                                     $data['value'] ?? ''
                                 )
                             )
                             ->when(
                                 $field->isOnlyValue(),
-                                fn (Builder $qq) => $qq->whereJsonContains($field->column(), $data['value'] ?? '')
+                                fn (Builder $qq) => $qq->whereJsonContains($column, $data['value'] ?? '')
                             );
                     }
                 });

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -40,6 +40,8 @@ abstract class Field extends FormElement
 
     protected string $column;
 
+    protected ?string $virtualColumn = null;
+
     protected mixed $value = null;
 
     protected bool $rawMode = false;
@@ -109,6 +111,18 @@ abstract class Field extends FormElement
         $this->column = $column;
 
         return $this;
+    }
+
+    public function virtualColumn(string $column): static
+    {
+        $this->virtualColumn = $column;
+
+        return $this;
+    }
+
+    public function getVirtualColumn(): string
+    {
+        return $this->virtualColumn ?? $this->column();
     }
 
     protected function prepareFill(array $raw = [], mixed $casted = null): mixed

--- a/src/Fields/Fields.php
+++ b/src/Fields/Fields.php
@@ -123,7 +123,7 @@ final class Fields extends FormElements
         return $this->map(function (Field $field) use ($parent, $before): Field {
             value($before, $parent, $field);
 
-            $name = str($parent ? $parent->name() : $field->name());
+            $name = str($parent ? $parent->nameDot() : $field->nameDot());
             $level = $name->substrCount('$');
 
             if ($field instanceof Json) {
@@ -134,14 +134,15 @@ final class Fields extends FormElements
                 $field->beforeRender(fn (ID $id): View|string => $id->preview());
             }
 
-            $name = $name
-                ->append('[${index' . $level . '}]')
-                ->append($parent ? "[{$field->column()}]" : '')
-                ->replace('[]', '')
-                ->when(
-                    $field->getAttribute('multiple') || $field->isGroup(),
-                    static fn (Stringable $str): Stringable => $str->append('[]')
-                )->value();
+            $name = $field->nameFrom(
+                $name->value(),
+                "\${index$level}",
+                $parent ? $field->column() : null,
+            );
+
+            if($field->getAttribute('multiple') || $field->isGroup()) {
+                $name .= '[]';
+            }
 
             if($parent) {
                 $field

--- a/src/Fields/File.php
+++ b/src/Fields/File.php
@@ -44,10 +44,8 @@ class File extends Field implements Fileable, RemovableContract
     public function getHiddenAttributes(): ComponentAttributeBag
     {
         return $this->attributes()->only(['data-level'])->merge([
-            'name' => $this->hiddenOldValuesKey(),
-            'data-name' => str($this->attributes()->get('data-name'))
-                ->replaceLast($this->attributes()->get('data-column'), 'hidden_' . $this->attributes()->get('data-column'))
-                ->value(),
+            'name' => $this->hiddenOldValuesName(),
+            'data-name' => $this->hiddenOldValuesName(),
         ]);
     }
 

--- a/src/Fields/File.php
+++ b/src/Fields/File.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\Fields;
 
 use Illuminate\Contracts\View\View;
+use Illuminate\View\ComponentAttributeBag;
 use MoonShine\Components\Files;
 use MoonShine\Contracts\Fields\Fileable;
 use MoonShine\Contracts\Fields\RemovableContract;
@@ -38,6 +39,16 @@ class File extends Field implements Fileable, RemovableContract
         $this->accept = $value;
 
         return $this;
+    }
+
+    public function getHiddenAttributes(): ComponentAttributeBag
+    {
+        return $this->attributes()->only(['data-level'])->merge([
+            'name' => $this->hiddenOldValuesKey(),
+            'data-name' => str($this->attributes()->get('data-name'))
+                ->replaceLast($this->attributes()->get('data-column'), 'hidden_' . $this->attributes()->get('data-column'))
+                ->value(),
+        ]);
     }
 
     protected function resolvePreview(): View|string

--- a/src/Fields/Json.php
+++ b/src/Fields/Json.php
@@ -523,7 +523,7 @@ class Json extends Field implements
         return fn ($item): mixed => $this->resolveAppliesCallback(
             data: $item,
             callback: fn (Field $field, mixed $values): mixed => $field->apply(
-                static fn ($data): mixed => data_set($data, $field->column(), $values[$field->column()] ?? ''),
+                static fn ($data): mixed => data_set($data, $field->column(), data_get($values, $field->column(), '')),
                 $values
             ),
         );
@@ -538,7 +538,7 @@ class Json extends Field implements
             data: $data,
             callback: fn (Field $field, mixed $values): mixed => $this->isAsRelation()
                 ? $field->apply(
-                    static fn ($data): mixed => data_set($data, $field->column(), $values[$field->column()] ?? ''),
+                    static fn ($data): mixed => data_set($data, $field->column(), data_get($values, $field->column(), '')),
                     $values
                 )
                 : $field->afterApply($values),

--- a/src/Fields/Json.php
+++ b/src/Fields/Json.php
@@ -473,15 +473,10 @@ class Json extends Field implements
                 $requestValues[$index] = $values;
             }
 
-            foreach ($this->getFields()->onlyFields() as $field) {
-                $field->appendRequestKeyPrefix(
-                    "{$this->column()}.$index",
-                    $this->requestKeyPrefix()
-                );
+            foreach ($this->preparedFields() as $field) {
+                $field->setNameIndex($index);
 
                 $field->when($fill, fn (Field $f): Field => $f->resolveFill($values->toArray(), $values));
-
-                $field->setParent($this);
 
                 $apply = $callback($field, $values, $data);
 

--- a/src/Fields/Relationships/BelongsToMany.php
+++ b/src/Fields/Relationships/BelongsToMany.php
@@ -23,7 +23,6 @@ use MoonShine\Contracts\Fields\Relationships\HasRelatedValues;
 use MoonShine\Fields\Checkbox;
 use MoonShine\Fields\Field;
 use MoonShine\Fields\Fields;
-use MoonShine\Fields\File;
 use MoonShine\Fields\ID;
 use MoonShine\Fields\Preview;
 use MoonShine\Fields\Text;
@@ -228,7 +227,9 @@ class BelongsToMany extends ModelRelationField implements
                 ->setColumn("{$this->getPivotAs()}.{$field->column()}")
                 ->setAttribute('class', 'pivotField')
                 ->setName(
-                    "{$this->getPivotName()}[\${index0}][{$this->getPivotAs()}][{$field->column()}]"
+                    $field->nameFrom(
+                        $this->getWrapName(), $this->getPivotName(), "\${index0}", $this->getPivotAs(), $field->column()
+                    )
                 )
                 ->setParent($this)
                 ->formName($this->getFormName())
@@ -282,7 +283,7 @@ class BelongsToMany extends ModelRelationField implements
             $this->memoizeAllValues = $this->memoizeValues;
         }
 
-        if($this->isOnlyLink() && $this->isOnlyLinkOnForm()) {
+        if ($this->isOnlyLink() && $this->isOnlyLinkOnForm()) {
             return $this->getOnlyLinkButton();
         }
 
@@ -395,7 +396,7 @@ class BelongsToMany extends ModelRelationField implements
                 ->toJson();
         }
 
-        if($this->isOnlyLink()) {
+        if ($this->isOnlyLink()) {
             return $this->getOnlyLinkButton(preview: true)->render();
         }
 

--- a/src/Fields/Relationships/BelongsToMany.php
+++ b/src/Fields/Relationships/BelongsToMany.php
@@ -23,6 +23,7 @@ use MoonShine\Contracts\Fields\Relationships\HasRelatedValues;
 use MoonShine\Fields\Checkbox;
 use MoonShine\Fields\Field;
 use MoonShine\Fields\Fields;
+use MoonShine\Fields\File;
 use MoonShine\Fields\ID;
 use MoonShine\Fields\Preview;
 use MoonShine\Fields\Text;
@@ -227,7 +228,7 @@ class BelongsToMany extends ModelRelationField implements
                 ->setColumn("{$this->getPivotAs()}.{$field->column()}")
                 ->setAttribute('class', 'pivotField')
                 ->setName(
-                    "{$this->getPivotName()}[\${index0}][{$field->column()}]"
+                    "{$this->getPivotName()}[\${index0}][{$this->getPivotAs()}][{$field->column()}]"
                 )
                 ->setParent($this)
                 ->formName($this->getFormName())
@@ -472,22 +473,19 @@ class BelongsToMany extends ModelRelationField implements
         }
 
         foreach ($requestValues as $key => $checked) {
-            foreach ($this->getFields() as $field) {
-                $field->appendRequestKeyPrefix(
-                    "{$this->getPivotName()}.$key",
-                    $this->requestKeyPrefix()
-                );
+            foreach ($this->preparedFields() as $field) {
+                $field->setNameIndex($key);
 
-                $values = request()->input($field->requestKeyPrefix(), []);
+                $values = request()->input("{$this->getPivotName()}.$key", []);
 
                 $apply = $field->apply(
-                    fn ($data): mixed => data_set($data, $field->column(), $values[$field->column()] ?? null),
+                    fn ($data): mixed => data_set($data, $field->column(), data_get($values, $field->column())),
                     $values
                 );
 
                 data_set(
                     $applyValues[$key],
-                    $field->column(),
+                    str_replace($this->getPivotAs() . '.', '', $field->column()),
                     data_get($apply, $field->column())
                 );
             }
@@ -505,12 +503,7 @@ class BelongsToMany extends ModelRelationField implements
     {
         $this->getFields()
             ->onlyFields()
-            ->each(function (Field $field, $index) use ($data): void {
-                $field->appendRequestKeyPrefix(
-                    "{$this->getPivotName()}.$index",
-                    $this->requestKeyPrefix()
-                );
-
+            ->each(function (Field $field) use ($data): void {
                 $field->beforeApply($data);
             });
 

--- a/src/Traits/Fields/FileTrait.php
+++ b/src/Traits/Fields/FileTrait.php
@@ -139,14 +139,21 @@ trait FileTrait
 
     public function hiddenOldValuesKey(): string
     {
-        return str('')
-            ->when(
-                $this->requestKeyPrefix(),
-                fn (Stringable $str): Stringable => $str->append(
-                    $this->requestKeyPrefix() . "."
-                )
-            )
-            ->append('hidden_' . str($this->nameDot())->replace('.', '_'))
+        $column = str($this->column())->explode('.')->last();
+        $hiddenColumn = str($this->getVirtualColumn())->explode('.')->last();
+
+        return str($this->nameDot())
+            ->replaceLast($column, "hidden_$hiddenColumn")
+            ->value();
+    }
+
+    public function hiddenOldValuesName(): string
+    {
+        $column = str($this->column())->explode('.')->last();
+        $hiddenColumn = str($this->getVirtualColumn())->explode('.')->last();
+
+        return str($this->name())
+            ->replaceLast($column, "hidden_$hiddenColumn")
             ->value();
     }
 

--- a/src/Traits/Fields/FileTrait.php
+++ b/src/Traits/Fields/FileTrait.php
@@ -31,6 +31,8 @@ trait FileTrait
 
     protected ?Closure $itemAttributes = null;
 
+    protected ?Closure $remainingValuesResolver = null;
+
     public function names(Closure $closure): static
     {
         $this->names = $closure;
@@ -144,7 +146,7 @@ trait FileTrait
                     $this->requestKeyPrefix() . "."
                 )
             )
-            ->append('hidden_' . $this->column())
+            ->append('hidden_' . str($this->nameDot())->replace('.', '_'))
             ->value();
     }
 
@@ -194,8 +196,22 @@ trait FileTrait
         return $this->allowedExtensions;
     }
 
+    /**
+     * @param  Closure(static $ctx): Collection  $closure
+     */
+    public function remainingValuesResolver(Closure $closure): static
+    {
+        $this->remainingValuesResolver = $closure;
+
+        return $this;
+    }
+
     public function getRemainingValues(): Collection
     {
+        if(!is_null($this->remainingValuesResolver)) {
+            return value($this->remainingValuesResolver, $this);
+        }
+
         return request()->collect(
             $this->hiddenOldValuesKey()
         );

--- a/src/Traits/Fields/WithFormElementAttributes.php
+++ b/src/Traits/Fields/WithFormElementAttributes.php
@@ -136,6 +136,15 @@ trait WithFormElementAttributes
         return $this;
     }
 
+    public function setNameIndex(int|string $key, int $index = 0): static
+    {
+        $this->setName(
+            str_replace("\${index$index}", (string) $key, $this->name())
+        );
+
+        return $this;
+    }
+
     public function setId(string $id): static
     {
         $this->id = str($id)

--- a/src/Traits/Fields/WithFormElementAttributes.php
+++ b/src/Traits/Fields/WithFormElementAttributes.php
@@ -78,17 +78,15 @@ trait WithFormElementAttributes
         return $this->wrapName;
     }
 
-    protected function nameUnDot(string $name): string
+    public function nameUnDot(string $value): string
     {
-        $parts = explode('.', $name);
-        $count = count($parts);
-        $result = $parts[0];
-
-        for ($i = 1; $i < $count; $i++) {
-            $result .= "[" . $parts[$i] . "]";
+        if (! str_contains($value, '.')) {
+            return $value;
         }
 
-        return $result;
+        return str($value)->explode('.')
+            ->map(static fn ($part, $index): string => $index === 0 ? $part : "[$part]")
+            ->implode('');
     }
 
     protected function prepareName($index = null, $wrap = null): string
@@ -103,11 +101,12 @@ trait WithFormElementAttributes
             return '';
         }
 
-        return (string) str($this->nameUnDot($this->column()))
+        return (string) str($this->column())
             ->when(
                 ! is_null($wrap),
-                fn (Stringable $str): Stringable => $str->wrap("{$wrap}[", "]")
+                fn (Stringable $str): Stringable => $str->prepend("$wrap.")
             )
+            ->pipe(fn(Stringable $str) => $this->nameUnDot($str->value()))
             ->when(
                 $this->isGroup() || $this->getAttribute('multiple'),
                 fn (Stringable $str): Stringable => $str->append(
@@ -116,7 +115,21 @@ trait WithFormElementAttributes
             );
     }
 
-    protected function nameDot(): string
+    public function nameFrom(?string ...$values): string
+    {
+        return str('')
+            ->pipe(static function(Stringable $str) use($values) {
+                foreach (collect($values)->filter() as $value) {
+                    $str = $str->append(".$value");
+                }
+
+                return $str->trim('.');
+            })
+            ->pipe(fn(Stringable $str) => $this->nameUnDot($str->value()))
+            ->value();
+    }
+
+    public function nameDot(): string
     {
         $name = (string) str($this->name())->replace('[]', '');
 

--- a/tests/Feature/Fields/Relationships/BelongsToManyFieldTest.php
+++ b/tests/Feature/Fields/Relationships/BelongsToManyFieldTest.php
@@ -37,7 +37,7 @@ beforeEach(function () {
         ->toBeEmpty();
 });
 
-function testBelongsToManyValue(TestResource $resource, Item $item, array $data, ?array $expectedData = null, array $pivotData = [])
+function testBelongsToManyValue(TestResource $resource, Item $item, array $data, array $pivotData = [])
 {
     asAdmin()->put(
         $resource->route('crud.update', $item->getKey()),
@@ -50,7 +50,7 @@ function testBelongsToManyValue(TestResource $resource, Item $item, array $data,
     $item->refresh();
 
     expect($item->categories->pluck('id', 'id')->sort()->toArray())
-        ->toBe(collect($expectedData ?? $data)->sort()->toArray());
+        ->toBe(collect($data)->sort()->toArray());
 }
 
 it('apply as base', function () {

--- a/tests/Feature/Fields/Relationships/BelongsToManyFieldTest.php
+++ b/tests/Feature/Fields/Relationships/BelongsToManyFieldTest.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use MoonShine\Applies\Filters\BelongsToManyModelApply;
+use MoonShine\Fields\File;
 use MoonShine\Fields\Relationships\BelongsToMany;
 use MoonShine\Fields\Text;
 use MoonShine\Handlers\ExportHandler;
@@ -24,6 +26,7 @@ beforeEach(function () {
     $this->pivotFields = [
         Text::make('Pivot 1', 'pivot_1'),
         Text::make('Pivot 2', 'pivot_2'),
+        File::make('Pivot 3', 'pivot_3'),
     ];
 
     $this->field = BelongsToMany::make('Categories', resource: new TestCategoryResource())
@@ -46,8 +49,8 @@ function testBelongsToManyValue(TestResource $resource, Item $item, array $data,
 
     $item->refresh();
 
-    expect($item->categories->pluck('id', 'id')->toArray())
-        ->toBe($expectedData ?? $data);
+    expect($item->categories->pluck('id', 'id')->sort()->toArray())
+        ->toBe(collect($expectedData ?? $data)->sort()->toArray());
 }
 
 it('apply as base', function () {
@@ -74,7 +77,7 @@ it('apply as base with pivot', function () {
     $pivotData = [];
 
     foreach ($data as $id) {
-        $pivotData[$id] = ['pivot_1' => 'test 1', 'pivot_2' => 'test 2'];
+        $pivotData[$id] = ['pivot' => ['pivot_1' => 'test 1', 'pivot_2' => 'test 2']];
     }
 
     testBelongsToManyValue($resource, $this->item, $data, pivotData: $pivotData);
@@ -84,6 +87,121 @@ it('apply as base with pivot', function () {
             ->toBe('test 1')
             ->and($category->pivot->pivot_2)
             ->toBe('test 2');
+    });
+
+    // unsync
+    $data = $categories->random(1)->pluck('id', 'id')->toArray();
+
+    testBelongsToManyValue($resource, $this->item, $data, pivotData: $pivotData);
+});
+
+it('apply as base with pivot and file', function () {
+    $resource = addFieldsToTestResource(
+        $this->field
+    );
+
+    $categories = Category::factory(5)->create();
+
+    $data = $categories->random(3)->pluck('id', 'id')->toArray();
+
+    $file = UploadedFile::fake()->create('test.csv');
+
+    $pivotData = [];
+
+    foreach ($data as $id) {
+        $pivotData[$id] = ['pivot' => ['pivot_1' => 'test 1', 'pivot_2' => 'test 2', 'pivot_3' => $file]];
+    }
+
+    testBelongsToManyValue($resource, $this->item, $data, pivotData: $pivotData);
+
+    $this->item->categories->each(function ($category) use($file) {
+        expect($category->pivot->pivot_1)
+            ->toBe('test 1')
+            ->and($category->pivot->pivot_2)
+            ->toBe('test 2')
+            ->and($category->pivot->pivot_3)
+            ->toBe($file->hashName())
+        ;
+    });
+});
+
+it('apply as base with pivot and file after remove', function () {
+    $resource = addFieldsToTestResource(
+        $this->field
+    );
+
+    $categories = Category::factory(5)->create();
+
+    $data = $categories->random(3)->pluck('id', 'id')->toArray();
+
+    $file = UploadedFile::fake()->create('test.csv');
+
+    $pivotData = [];
+
+    foreach ($data as $id) {
+        $pivotData[$id] = ['pivot' => ['pivot_1' => 'test 1', 'pivot_2' => 'test 2', 'pivot_3' => $file]];
+    }
+
+    testBelongsToManyValue($resource, $this->item, $data, pivotData: $pivotData);
+
+    $data = $categories->random(3)->pluck('id', 'id')->toArray();
+
+    $pivotData = [];
+
+    foreach ($data as $id) {
+        $pivotData[$id] = ['pivot' => ['pivot_1' => 'test 1', 'pivot_2' => 'test 2']];
+    }
+
+    testBelongsToManyValue($resource, $this->item, $data, pivotData: $pivotData);
+
+    $this->item->categories->each(function ($category) {
+        expect($category->pivot->pivot_1)
+            ->toBe('test 1')
+            ->and($category->pivot->pivot_2)
+            ->toBe('test 2')
+            ->and($category->pivot->pivot_3)
+            ->toBeNull()
+        ;
+    });
+});
+
+it('apply as base with pivot and file stay by hidden', function () {
+    $resource = addFieldsToTestResource(
+        $this->field
+    );
+
+    $categories = Category::factory(5)->create();
+
+    $data = $categories->random(3)->pluck('id', 'id')->toArray();
+
+    $file = UploadedFile::fake()->create('test.csv');
+
+    $pivotData = [];
+
+    foreach ($data as $id) {
+        $pivotData[$id] = ['pivot' => ['pivot_1' => 'test 1', 'pivot_2' => 'test 2', 'pivot_3' => $file]];
+    }
+
+    testBelongsToManyValue($resource, $this->item, $data, pivotData: $pivotData);
+
+    $data = $categories->random(3)->pluck('id', 'id')->toArray();
+
+    $pivotData = [];
+
+    foreach ($data as $id) {
+        $pivotData[$id] = ['pivot' => ['pivot_1' => 'test 1', 'pivot_2' => 'test 2', 'hidden_pivot_3' => $file->hashName()]];
+    }
+
+    testBelongsToManyValue($resource, $this->item, $data, pivotData: $pivotData);
+
+    $this->item->categories->each(function ($category) use($file) {
+        expect($category->pivot->pivot_1)
+            ->toBe('test 1')
+            ->and($category->pivot->pivot_2)
+            ->toBe('test 2')
+            ->and($category->pivot->pivot_3)
+            ->toBe($file->hashName())
+        ;
     });
 });
 

--- a/tests/Feature/Fields/TemplateFieldTest.php
+++ b/tests/Feature/Fields/TemplateFieldTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use MoonShine\Applies\Filters\JsonModelApply;
+use MoonShine\Fields\File;
+use MoonShine\Fields\Json;
+use MoonShine\Fields\Template;
+use MoonShine\Fields\Text;
+use MoonShine\Handlers\ExportHandler;
+use MoonShine\Handlers\ImportHandler;
+use MoonShine\Tests\Fixtures\Models\Item;
+use MoonShine\Tests\Fixtures\Resources\TestCommentResource;
+use MoonShine\Tests\Fixtures\Resources\TestResource;
+
+use function Pest\Laravel\get;
+
+uses()->group('fields');
+uses()->group('template-field');
+
+beforeEach(function () {
+    $this->item = createItem(countComments: 0);
+
+    expect($this->item->data)
+        ->toBeEmpty();
+});
+
+function testTemplateValue(TestResource $resource, Item $item, array $data, ?array $expectedData = null)
+{
+    asAdmin()->put(
+        $resource->route('crud.update', $item->getKey()),
+        [
+            'data' => $data,
+        ]
+    )->assertRedirect();
+
+    $item->refresh();
+
+    expect($item->data->toArray())->toBe($expectedData ?? $data);
+}
+
+function baseTemplateSaveFile(Item $item, ?UploadedFile $changedFile = null, ?array $changedData = null): void
+{
+    $resource = addFieldsToTestResource(
+        Template::make('Data')
+            ->fields([
+                File::make('File')
+            ])
+            ->changeFill(fn(Item $data, Template $field) => data_get($data, $field->column(), []))
+            ->onApply(onApply: function (Item $item, $value, Template $field) {
+                $column = $field->column();
+                $applyValues = [];
+
+                foreach ($field->preparedFields() as $f) {
+                    $apply = $f->apply(
+                        fn($data): mixed => data_set($data, $f->column(), $value[$f->column()] ?? ''),
+                        $value
+                    );
+
+                    data_set(
+                        $applyValues,
+                        $f->column(),
+                        data_get($apply, $f->column())
+                    );
+                }
+
+                return data_set(
+                    $item,
+                    $column,
+                    $applyValues
+                );
+            })
+    );
+
+    $file = $changedFile ?? UploadedFile::fake()->create('test.csv');
+
+    $data = $changedData ?? ['file' => $file];
+
+    testTemplateValue($resource, $item, $data, ['file' => $file->hashName()]);
+}
+
+function baseTemplateIterableSaveFile(Item $item, ?UploadedFile $changedFile = null, ?array $changedData = null): void
+{
+    $resource = addFieldsToTestResource(
+        Template::make('Data')
+            ->fields([
+                File::make('File'),
+            ])
+            ->changeFill(fn(Item $data, Template $field) => data_get($data, $field->column(), []))
+            ->onApply(onApply: function (Item $item, $values, Template $field) {
+                $column = $field->column();
+                $applyValues = [];
+
+                foreach ($values as $index => $value) {
+                    foreach ($field->getFields()->prepareReindex($field) as $f) {
+                        $f->setNameIndex($index);
+
+                        $apply = $f->apply(
+                            fn($data): mixed => data_set($data, $f->column(), $value[$f->column()] ?? ''),
+                            $value
+                        );
+
+                        data_set(
+                            $applyValues[$index],
+                            $f->column(),
+                            data_get($apply, $f->column())
+                        );
+                    }
+                }
+
+                return data_set(
+                    $item,
+                    $column,
+                    $applyValues
+                );
+            })
+    );
+
+    $file = $changedFile ?? UploadedFile::fake()->create('test.csv');
+
+    $data = $changedData ?? [
+        ['file' => $file]
+    ];
+
+    testTemplateValue($resource, $item, $data, [
+        ['file' => $file->hashName()]
+    ]);
+}
+
+it('apply as base with file', function () {
+    baseTemplateSaveFile($this->item);
+});
+
+it('apply as base with file stay hidden', function () {
+    baseTemplateSaveFile($this->item);
+
+    $this->item->refresh();
+
+    $file = UploadedFile::fake()->create('test.csv');
+
+    $data = ['hidden_file' => $file->hashName()];
+
+    baseTemplateSaveFile($this->item, $file, $data);
+});
+
+it('apply iterable as base with file', function () {
+    baseTemplateIterableSaveFile($this->item);
+});
+
+it('apply iterable as base with file stay hidden', function () {
+    baseTemplateIterableSaveFile($this->item);
+
+    $this->item->refresh();
+
+    $file = UploadedFile::fake()->create('test.csv');
+
+    $data = [
+        ['hidden_file' => $file->hashName()]
+    ];
+
+    baseTemplateIterableSaveFile($this->item, $file, $data);
+});

--- a/tests/Fixtures/Migrations/2023_05_22_130906_create_items.php
+++ b/tests/Fixtures/Migrations/2023_05_22_130906_create_items.php
@@ -66,6 +66,7 @@ return new class () extends Migration {
 
             $table->string('pivot_1')->nullable();
             $table->string('pivot_2')->nullable();
+            $table->string('pivot_3')->nullable();
 
             $table->timestamps();
         });

--- a/tests/Fixtures/Models/Item.php
+++ b/tests/Fixtures/Models/Item.php
@@ -61,7 +61,7 @@ class Item extends Model
     public function categories(): BelongsToMany
     {
         return $this->belongsToMany(Category::class)
-            ->withPivot(['pivot_1', 'pivot_2']);
+            ->withPivot(['pivot_1', 'pivot_2', 'pivot_3']);
     }
 
     public function comments(): HasMany

--- a/tests/Unit/Fields/FileFieldTest.php
+++ b/tests/Unit/Fields/FileFieldTest.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use MoonShine\Contracts\Fields\Fileable;
 use MoonShine\Contracts\Fields\RemovableContract;
 use MoonShine\Fields\File;
+use MoonShine\Fields\Json;
 
 uses()->group('fields');
 uses()->group('file-field');
@@ -150,3 +151,98 @@ it('names multiple', function (): void {
         ->name('1')
         ->toBe('files[1]');
 });
+
+describe('Hidden input for files', function () {
+    it('hidden single', function (): void {
+        $file = File::make('Thumbnail', 'thumbnail');
+
+        expect($file)
+            ->hiddenOldValuesKey()
+            ->toBe('hidden_thumbnail')
+            ->hiddenOldValuesName()
+            ->toBe('hidden_thumbnail');
+    });
+
+    it('hidden keys multiple', function (): void {
+        $file = File::make('Thumbnail')->multiple();
+
+        expect($file)
+            ->hiddenOldValuesKey()
+            ->toBe('hidden_thumbnail')
+            ->hiddenOldValuesName()
+            ->toBe('hidden_thumbnail[]');
+    });
+
+    it('hidden keys virtual', function (): void {
+        $file = File::make('Thumbnail')->virtualColumn('test');
+
+        expect($file)
+            ->hiddenOldValuesKey()
+            ->toBe('hidden_test')
+            ->hiddenOldValuesName()
+            ->toBe('hidden_test');
+
+        $file = File::make('Thumbnail')->multiple()->virtualColumn('test');
+
+        expect($file)
+            ->hiddenOldValuesKey()
+            ->toBe('hidden_test')
+            ->hiddenOldValuesName()
+            ->toBe('hidden_test[]');
+    });
+
+    it('hidden keys iterable', function (): void {
+        $file = File::make('Thumbnail');
+
+        $json = Json::make('Data', 'data')->fields([
+            $file,
+        ]);
+
+        expect($json->preparedFields()->first())
+            ->hiddenOldValuesKey()
+            ->toBe('data.${index0}.hidden_thumbnail')
+            ->hiddenOldValuesName()
+            ->toBe('data[${index0}][hidden_thumbnail]');
+    });
+
+    it('hidden keys iterable multiple', function (): void {
+        $file = File::make('Thumbnail')->multiple();
+
+        $json = Json::make('Data', 'data')->fields([
+            $file,
+        ]);
+
+        expect($json->preparedFields()->first())
+            ->hiddenOldValuesKey()
+            ->toBe('data.${index0}.hidden_thumbnail')
+            ->hiddenOldValuesName()
+            ->toBe('data[${index0}][hidden_thumbnail][]');
+    });
+
+    it('hidden keys iterable virtual', function (): void {
+        $file = File::make('Thumbnail')->virtualColumn('test');
+
+        $json = Json::make('Data', 'data')->fields([
+            $file,
+        ]);
+
+        expect($json->preparedFields()->first())
+            ->hiddenOldValuesKey()
+            ->toBe('data.${index0}.hidden_test')
+            ->hiddenOldValuesName()
+            ->toBe('data[${index0}][hidden_test]');
+
+        $file = File::make('Thumbnail')->multiple()->virtualColumn('test');
+
+        $json = Json::make('Data', 'data')->fields([
+            $file,
+        ]);
+
+        expect($json->preparedFields()->first())
+            ->hiddenOldValuesKey()
+            ->toBe('data.${index0}.hidden_test')
+            ->hiddenOldValuesName()
+            ->toBe('data[${index0}][hidden_test][]');
+    });
+})->group('hidden-file-input');
+


### PR DESCRIPTION
### Breaking change

Changed the logic for saving Json and BelongsToMany

1) Element "name" of hidden old values ​​for File/Image fields are now based on the name attribute (previously there was a column attribute). Logic is also used in view

You can also completely redefine the logic for getting old values

```php
File::make()->remainingValuesResolver(fn(File $ctx): \Illuminate\Support\Collection => collect(// your logic))
```

2) If you need to leave the column as is but at the same time change the name for iterable elements, then use the virtualColumn method

```php
File::make('File', 'file')->virtualColumn('file_1')
```

When saving you will still work on a column basis, but in the html you will have a virtual name for the iterable elements