### PR TITLE
Markdown field

### DIFF
--- a/resources/js/alpine/easyMde.js
+++ b/resources/js/alpine/easyMde.js
@@ -1,53 +1,36 @@
 /* EasyMDE */
 
-export default () => ({
+export default (options = {}) => ({
   easyMDEInstance: null,
+  options: options,
 
   init() {
-    this.easyMDEInstance = new EasyMDE({
-      element: this.$el,
-      previewClass: ['prose', 'dark:prose-invert'],
-      forceSync: true,
-      spellChecker: false,
-      status: false,
-      renderingConfig: {
-        sanitizerFunction: renderedHTML => {
-          return DOMPurify.sanitize(renderedHTML, {
-            USE_PROFILES: {
-              html: true,
-            },
-          })
-        },
-      },
-      toolbar: [
-        'bold',
-        'italic',
-        'strikethrough',
-        'code',
-        'quote',
-        'horizontal-rule',
-        '|',
-        'heading-1',
-        'heading-2',
-        'heading-3',
-        '|',
-        'table',
-        'unordered-list',
-        'ordered-list',
-        '|',
-        'link',
-        'image',
-        '|',
-        'preview',
-        'side-by-side',
-        'fullscreen',
-        '|',
-        'guide',
-      ],
-    })
+    this.easyMDEInstance = new EasyMDE(this.config())
 
     this.$el.addEventListener('reset', () => {
       this.easyMDEInstance.value(this.$el.value)
     })
   },
+
+  config() {
+    for (const key in this.callbacks) {
+      this.callbacks[key] = new Function('return ' + this.callbacks[key])()
+    }
+
+    return Object.assign(
+      {
+        element: this.$el,
+        renderingConfig: {
+          sanitizerFunction: renderedHTML => {
+            return DOMPurify.sanitize(renderedHTML, {
+              USE_PROFILES: {
+                html: true,
+              },
+            })
+          },
+        },
+      },
+      this.options
+    )
+  }
 })

--- a/resources/js/alpine/easyMde.js
+++ b/resources/js/alpine/easyMde.js
@@ -30,7 +30,7 @@ export default (options = {}) => ({
           },
         },
       },
-      this.options
+      this.options,
     )
-  }
+  },
 })

--- a/resources/js/alpine/easyMde.js
+++ b/resources/js/alpine/easyMde.js
@@ -1,14 +1,14 @@
 /* EasyMDE */
 
 export default (options = {}) => ({
-  easyMDEInstance: null,
+  instance: null,
   options: options,
 
   init() {
-    this.easyMDEInstance = new EasyMDE(this.config())
+    this.instance = new EasyMDE(this.config())
 
     this.$el.addEventListener('reset', () => {
-      this.easyMDEInstance.value(this.$el.value)
+      this.instance.value(this.$el.value)
     })
   },
 

--- a/resources/js/alpine/easyMde.js
+++ b/resources/js/alpine/easyMde.js
@@ -1,8 +1,10 @@
 /* EasyMDE */
 
 export default () => ({
+  easyMDEInstance: null,
+
   init() {
-    new EasyMDE({
+    this.easyMDEInstance = new EasyMDE({
       element: this.$el,
       previewClass: ['prose', 'dark:prose-invert'],
       forceSync: true,
@@ -42,6 +44,10 @@ export default () => ({
         '|',
         'guide',
       ],
+    })
+
+    this.$el.addEventListener('reset', () => {
+      this.easyMDEInstance.value(this.$el.value)
     })
   },
 })

--- a/resources/views/fields/markdown.blade.php
+++ b/resources/views/fields/markdown.blade.php
@@ -1,10 +1,15 @@
+@props([
+    'value' => '',
+    'options' => '',
+])
+
 <div class="easyMde">
     <x-moonshine::form.textarea
         :attributes="$element->attributes()->merge([
             'id' => 'markdown_' . $element->id(),
-            'name' => $element->name(),
-            'x-data' => 'easyMde'
+            'name' => $element->name()
         ])"
         @class(['form-invalid' => formErrors($errors, $element->getFormName())->has($element->name())])
+        x-data="easyMde({{ $options }})"
     >{!! $value ?? '' !!}</x-moonshine::form.textarea>
 </div>

--- a/src/Buttons/ExportButton.php
+++ b/src/Buttons/ExportButton.php
@@ -36,7 +36,7 @@ final class ExportButton
         if ($export->isWithConfirm()) {
             $button->withConfirm(
                 content: trans('moonshine::ui.resource.export.confirm_content'),
-                formBuilder: static fn(FormBuilder $form): FormBuilder => $form->customAttributes($attributes)
+                formBuilder: static fn (FormBuilder $form): FormBuilder => $form->customAttributes($attributes)
             );
         }
 

--- a/src/Fields/Markdown.php
+++ b/src/Fields/Markdown.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MoonShine\Fields;
 
+use JsonException;
+
 class Markdown extends Textarea
 {
     protected string $view = 'moonshine::fields.markdown';
@@ -26,19 +28,6 @@ class Markdown extends Textarea
         'renderingConfig',
     ];
 
-    public static function setDefaultOption(string $name, string|int|float|bool|array $value): void
-    {
-        if (in_array($name, static::$reservedOptions)) {
-            return;
-        }
-
-        if (is_string($value) && str($value)->isJson()) {
-            $value = json_decode($value, true);
-        }
-
-        static::$defaultOptions[$name] = $value;
-    }
-
     public function getAssets(): array
     {
         return [
@@ -46,6 +35,22 @@ class Markdown extends Textarea
             'vendor/moonshine/libs/easymde/easymde.min.js',
             'vendor/moonshine/libs/easymde/purify.min.js',
         ];
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public static function setDefaultOption(string $name, string|int|float|bool|array $value): void
+    {
+        if (in_array($name, static::$reservedOptions, true)) {
+            return;
+        }
+
+        if (is_string($value) && str($value)->isJson()) {
+            $value = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        }
+
+        static::$defaultOptions[$name] = $value;
     }
 
     public function addOption(string $name, string|int|float|bool|array $value): self
@@ -66,6 +71,13 @@ class Markdown extends Textarea
     public function getOptions(): array
     {
         return array_merge(static::$defaultOptions, $this->options);
+    }
+
+    public function toolbar(string|bool|array $value): self
+    {
+        $this->addOption('toolbar', $value);
+
+        return $this;
     }
 
     /**

--- a/src/Fields/Markdown.php
+++ b/src/Fields/Markdown.php
@@ -4,13 +4,79 @@ declare(strict_types=1);
 
 namespace MoonShine\Fields;
 
-final class Markdown extends Textarea
+use Closure;
+
+class Markdown extends Textarea
 {
     protected string $view = 'moonshine::fields.markdown';
 
-    protected array $assets = [
-        'vendor/moonshine/libs/easymde/easymde.min.css',
-        'vendor/moonshine/libs/easymde/easymde.min.js',
-        'vendor/moonshine/libs/easymde/purify.min.js',
+    protected static array $defaultOptions = [
+        'previewClass' => ['prose', 'dark:prose-invert'],
+        'forceSync' => true,
+        'spellChecker' => false,
+        'status' => false,
+        'toolbar' => [ 'bold', 'italic', 'strikethrough', 'code', 'quote', 'horizontal-rule', '|', 'heading-1',
+            'heading-2', 'heading-3', '|', 'table', 'unordered-list', 'ordered-list', '|', 'link', 'image', '|',
+            'preview', 'side-by-side', 'fullscreen', '|', 'guide',
+        ],
     ];
+
+    protected array $options = [];
+
+    protected static array $reservedOptions = [
+        'element',
+        'renderingConfig',
+    ];
+
+    public static function setDefaultOption(string $name, string|int|float|bool|array $value): void
+    {
+        if (in_array($name, static::$reservedOptions)) {
+            return;
+        }
+
+        if (is_string($value) && str($value)->isJson()) {
+            $value = json_decode($value, true);
+        }
+
+        static::$defaultOptions[$name] = $value;
+    }
+
+    public function getAssets(): array
+    {
+        return [
+            'vendor/moonshine/libs/easymde/easymde.min.css',
+            'vendor/moonshine/libs/easymde/easymde.min.js',
+            'vendor/moonshine/libs/easymde/purify.min.js',
+        ];
+    }
+
+    public function addOption(string $name, string|int|float|bool|array $value): self
+    {
+        if (in_array($name, static::$reservedOptions)) {
+            return $this;
+        }
+
+        if (is_string($value) && str($value)->isJson()) {
+            $value = json_decode($value, true);
+        }
+
+        $this->options[$name] = $value;
+
+        return $this;
+    }
+
+    public function getOptions(): array
+    {
+        return array_merge(static::$defaultOptions, $this->options);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function viewData(): array
+    {
+        return [
+            'options' => json_encode($this->getOptions()),
+        ];
+    }
 }

--- a/src/Fields/Markdown.php
+++ b/src/Fields/Markdown.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace MoonShine\Fields;
 
-use Closure;
-
 class Markdown extends Textarea
 {
     protected string $view = 'moonshine::fields.markdown';

--- a/src/Fields/Markdown.php
+++ b/src/Fields/Markdown.php
@@ -58,7 +58,7 @@ class Markdown extends Textarea
      */
     public function addOption(string $name, string|int|float|bool|array $value): self
     {
-        if (in_array(needle: $name, haystack: self::$reservedOptions, strict: true)) {
+        if (in_array($name, self::$reservedOptions, true)) {
             return $this;
         }
 

--- a/src/Fields/Markdown.php
+++ b/src/Fields/Markdown.php
@@ -53,14 +53,17 @@ class Markdown extends Textarea
         static::$defaultOptions[$name] = $value;
     }
 
+    /**
+     * @throws JsonException
+     */
     public function addOption(string $name, string|int|float|bool|array $value): self
     {
-        if (in_array($name, static::$reservedOptions)) {
+        if (in_array(needle: $name, haystack: self::$reservedOptions, strict: true)) {
             return $this;
         }
 
         if (is_string($value) && str($value)->isJson()) {
-            $value = json_decode($value, true);
+            $value = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
         }
 
         $this->options[$name] = $value;
@@ -73,6 +76,9 @@ class Markdown extends Textarea
         return array_merge(static::$defaultOptions, $this->options);
     }
 
+    /**
+     * @throws JsonException
+     */
     public function toolbar(string|bool|array $value): self
     {
         $this->addOption('toolbar', $value);
@@ -82,11 +88,12 @@ class Markdown extends Textarea
 
     /**
      * @return array<string, mixed>
+     * @throws JsonException
      */
     protected function viewData(): array
     {
         return [
-            'options' => json_encode($this->getOptions()),
+            'options' => json_encode($this->getOptions(), JSON_THROW_ON_ERROR),
         ];
     }
 }

--- a/src/Menu/MenuManager.php
+++ b/src/Menu/MenuManager.php
@@ -20,7 +20,7 @@ class MenuManager
 
     public function all(): Collection
     {
-        if(!is_null($this->preparedMenu)) {
+        if(! is_null($this->preparedMenu)) {
             return $this->preparedMenu;
         }
 

--- a/tests/Unit/Fields/MarkdownFieldTest.php
+++ b/tests/Unit/Fields/MarkdownFieldTest.php
@@ -51,6 +51,21 @@ it('add option method', function (): void {
     ;
 });
 
+it('global config method', function (): void {
+    Markdown::setDefaultOption('test-config', 'global-config-value');
+
+    $field = Markdown::make('Markdown');
+
+    expect($field)
+        ->getOptions()->toContain('global-config-value');
+});
+
+it('toolbar method', function (): void {
+    expect($this->field)
+        ->toolbar(['toolbar 1', 'toolbar 2'])
+        ->getOptions()->toContain(['toolbar 1', 'toolbar 2']);
+});
+
 it('apply', function (): void {
     $data = ['markdown' => 'test'];
 

--- a/tests/Unit/Fields/MarkdownFieldTest.php
+++ b/tests/Unit/Fields/MarkdownFieldTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Model;
+use MoonShine\Fields\Markdown;
+use MoonShine\Fields\Textarea;
+use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
+
+uses()->group('fields');
+
+beforeEach(function (): void {
+    $this->field = Markdown::make('Markdown');
+});
+
+it('textarea is parent', function (): void {
+    expect($this->field)
+        ->toBeInstanceOf(Textarea::class);
+});
+
+it('type', function (): void {
+    expect($this->field->type())
+        ->toBeEmpty();
+});
+
+it('view', function (): void {
+    expect($this->field->getView())
+        ->toBe('moonshine::fields.markdown');
+});
+
+it('has assets', function (): void {
+    expect($this->field->getAssets())
+        ->toBeArray()
+        ->not->toBeEmpty();
+});
+
+it('add option method', function (): void {
+    expect($this->field)
+        ->addOption('test-config', 1)
+        ->getOptions()->toContain(1)
+        ->addOption('test-config-string', 'string')
+        ->getOptions()->toContain('string')
+        ->addOption('test-config-float', 1.2)
+        ->getOptions()->toContain(1.2)
+        ->addOption('test-config-bool', true)
+        ->getOptions()->toContain(true)
+        ->addOption('test-config-array', ['array' => 'array'])
+        ->getOptions()->toContain(['array' => 'array'])
+        ->addOption('test-config-json', json_encode([['json' => 'json']]))
+        ->getOptions()->toContain([['json' => 'json']])
+    ;
+});
+
+it('apply', function (): void {
+    $data = ['markdown' => 'test'];
+
+    fakeRequest(parameters: $data);
+
+    expect(
+        $this->field->apply(
+            TestResourceBuilder::new()->onSave($this->field),
+            new class () extends Model {
+                protected $fillable = [
+                    'markdown',
+                ];
+            }
+        )
+    )
+        ->toBeInstanceOf(Model::class)
+        ->markdown
+        ->toBe($data['markdown'])
+    ;
+});


### PR DESCRIPTION
- fix reset Markdown field
- `addOption()` method for configuration field
- `toolbar()` method for configuration toolbar
- `::setDefaultOption()` static method for global configuration

\
**Field configuration**
```
addOption(string $name, string|int|float|bool|array $value)
```
```php
Markdown::make('Description')
    ->addOption('toolbar',  ['bold', 'italic', 'strikethrough', 'code', 'quote', 'horizontal-rule'])
```

\
**Toolbar**
```
toolbar(string|bool|array $value)
```
```php
Markdown::make('Description')
    ->toolbar(['bold', 'italic', 'strikethrough', 'code', 'quote', 'horizontal-rule'])
```

\
**Global configuration**
```
setDefaultOption(string $name, string|int|float|bool|array $value)
```
```php
namespace App\Providers;

use MoonShine\Fields\Markdown;
use MoonShine\Providers\MoonShineApplicationServiceProvider;

class MoonShineServiceProvider extends MoonShineApplicationServiceProvider
{
    public function boot(): void
    {
        parent::boot();

        Markdown::setDefaultOption('toolbar',  ['bold', 'italic', 'strikethrough', 'code', 'quote']);
    }
}        
```
