### PR TITLE
feat: MenuElements attributes

### DIFF
--- a/resources/views/components/menu/group.blade.php
+++ b/resources/views/components/menu/group.blade.php
@@ -3,27 +3,25 @@
     'top' => false,
 ])
 <li
+    {{ $item->attributes()->class(['menu-inner-item', 'dropdown' => $top]) }}
     @if($top)
-        class="menu-inner-item dropdown"
         x-data="dropdown"
         x-ref="dropdownEl"
         @click.outside="closeDropdown"
         data-dropdown-placement="bottom-start"
     @else
-        class="menu-inner-item"
         x-data="{ dropdown: {{ $item->isActive() ? 'true' : 'false' }} }"
     @endif
 >
     <button
+        {{ $item->linkAttributes()->merge(['class' => 'menu-inner-button', 'dropdown-btn' => $top]) }}
         @if($top)
             @click="toggleDropdown"
-            class="menu-inner-button dropdown-btn"
             :class="open && '_is-active'"
         @else
-        x-data="navTooltip"
+            x-data="navTooltip"
             @mouseenter="toggleTooltip()"
             @click.prevent="dropdown = ! dropdown"
-            class="menu-inner-button"
             :class="dropdown && '_is-active'"
         @endif
         type="button"

--- a/resources/views/components/menu/item.blade.php
+++ b/resources/views/components/menu/item.blade.php
@@ -3,14 +3,14 @@
     'top' => false,
 ])
 @if($item instanceof MoonShine\Menu\MenuDivider)
-    <li class="menu-inner-divider">
+    <li {{ $item->attributes()->merge(['class' => 'menu-inner-divider']) }}>
         {!! $item->label() ? "<span>{$item->label()}</span>" : '' !!}
     </li>
 @else
-    <li class="menu-inner-item {{ $item->isActive() ? '_is-active' : '' }}">
+    <li {{ $item->attributes()->class(['menu-inner-item', '_is-active' => $item->isActive()]) }}>
         <a
             href="{{ $item->url() }}" {!! $item->isBlank() ? 'target="_blank"' : '' !!}
-            class="menu-inner-link"
+            {{ $item->linkAttributes()->merge(['class' => 'menu-inner-link']) }}
             x-data="navTooltip"
             @mouseenter="toggleTooltip()"
         >

--- a/src/Menu/MenuElement.php
+++ b/src/Menu/MenuElement.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace MoonShine\Menu;
 
 use Closure;
+use Illuminate\View\ComponentAttributeBag;
 use MoonShine\Contracts\Menu\MenuFiller;
 use MoonShine\Support\Condition;
 use MoonShine\Traits\HasCanSee;
 use MoonShine\Traits\Makeable;
+use MoonShine\Traits\WithComponentAttributes;
 use MoonShine\Traits\WithIcon;
 use MoonShine\Traits\WithLabel;
 use Throwable;
@@ -19,12 +21,15 @@ abstract class MenuElement
     use WithIcon;
     use HasCanSee;
     use WithLabel;
+    use WithComponentAttributes;
 
     protected Closure|string|null $url = null;
 
     protected Closure|bool $blank = false;
 
     protected Closure|bool|null $forceActive = null;
+
+    protected array $customLinkAttributes = [];
 
     public function forceActive(Closure|bool $forceActive): static
     {
@@ -124,5 +129,31 @@ abstract class MenuElement
     public function isBlank(): bool
     {
         return $this->blank;
+    }
+
+    public function customLinkAttributes(array $attributes): static
+    {
+        if (isset($attributes['class'])) {
+            $this->customLinkAttributes['class'] = $this->uniqueAttribute(
+                old: $this->customLinkAttributes['class'] ?? '',
+                new: $attributes['class']
+            );
+
+            unset($attributes['class']);
+        }
+
+        $this->customLinkAttributes = array_merge(
+            $this->customLinkAttributes,
+            $attributes
+        );
+
+        return $this;
+    }
+
+    public function linkAttributes(): ComponentAttributeBag
+    {
+        return new ComponentAttributeBag(
+            $this->customLinkAttributes
+        );
     }
 }


### PR DESCRIPTION
```php
MenuGroup::make(static fn () => __('moonshine::ui.resource.system'), [
    MenuItem::make(
        static fn () => __('moonshine::ui.resource.admins_title'),
        new MoonShineUserResource()
    )->linkAttributes(['class' => 'group-a-custom-class']),
    MenuItem::make(
        static fn () => __('moonshine::ui.resource.role_title'),
        new MoonShineUserRoleResource()
    )->customAttributes(['class' => 'group-li-custom-class']),
])->customAttributes(['class' => 'group-li-custom-class'])->linkAttributes(['class' => 'group-button-custom-class'])
```