### PR TITLE
feat: Remove LineBreak before first field in StackFields and Td

### DIFF
--- a/src/Components/FieldsGroup.php
+++ b/src/Components/FieldsGroup.php
@@ -24,6 +24,9 @@ final class FieldsGroup extends WithComponents
         );
     }
 
+    /**
+     * @throws Throwable
+     */
     public function fill(array $raw = [], mixed $casted = null, int $index = 0): self
     {
         return $this->mapFields(
@@ -31,6 +34,9 @@ final class FieldsGroup extends WithComponents
         );
     }
 
+    /**
+     * @throws Throwable
+     */
     public function withoutWrappers(): self
     {
         return $this->mapFields(
@@ -50,7 +56,7 @@ final class FieldsGroup extends WithComponents
 
         $this->components
             ->onlyFields()
-            ->map(fn (Field $field): Field => $callback($field));
+            ->map(fn (Field $field, int $index): Field => $callback($field, $index));
 
         return $this;
     }

--- a/src/Fields/StackFields.php
+++ b/src/Fields/StackFields.php
@@ -51,13 +51,16 @@ class StackFields extends Field implements HasFields, FieldsWrapper
         return $this;
     }
 
+    /**
+     * @throws Throwable
+     */
     protected function resolvePreview(): View|string
     {
         return FieldsGroup::make(
             $this->getFields()->indexFields()
         )
-            ->mapFields(fn (Field $field): Field => $field
-                ->beforeRender(fn (): string => $this->hasLabels() ? '' : (string) LineBreak::make())
+            ->mapFields(fn (Field $field, int $index): Field => $field
+                ->beforeRender(fn (): string => $this->hasLabels() || $index === 0 ? '' : (string) LineBreak::make())
                 ->withoutWrapper($this->hasLabels())
                 ->forcePreview())
             ->render();

--- a/src/Fields/Td.php
+++ b/src/Fields/Td.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\View\ComponentAttributeBag;
 use MoonShine\Components\FieldsGroup;
 use MoonShine\Decorations\LineBreak;
+use Throwable;
 
 /**
  * @method static static make(Closure|string $label, ?Closure $fields = null)
@@ -95,6 +96,9 @@ class Td extends Template
             : $attributes;
     }
 
+    /**
+     * @throws Throwable
+     */
     protected function resolvePreview(): string|View
     {
         if($this->isRawMode()) {
@@ -108,9 +112,9 @@ class Td extends Template
         return FieldsGroup::make(
             Fields::make($fields)
         )
-            ->mapFields(fn (Field $field): Field => $field
+            ->mapFields(fn (Field $field, int $index): Field => $field
                 ->resolveFill($this->toRawValue(withoutModify: true), $this->getData())
-                ->beforeRender(fn (): string => $this->hasLabels() ? '' : (string) LineBreak::make())
+                ->beforeRender(fn (): string => $this->hasLabels() || $index === 0 ? '' : (string) LineBreak::make())
                 ->withoutWrapper($this->hasLabels())
                 ->forcePreview())
             ->render();


### PR DESCRIPTION
In fields **StackFields** and **Td** before each field is inserted _LineBreak_:

![photo_2024-07-30 17 26 06](https://github.com/user-attachments/assets/6c4b3b4d-17ae-4d32-9f47-9af503f1033b)
