### PR TITLE
Hide errors header form

### DIFF
--- a/resources/views/components/form/builder.blade.php
+++ b/resources/views/components/form/builder.blade.php
@@ -2,7 +2,7 @@
     :attributes="$attributes"
     :name="$name"
     :precognitive="$precognitive"
-    :showErrorsAtFormTop="$showErrorsAtFormTop"
+    :errorsAbove="$errorsAbove"
 >
     <x-moonshine::fields-group
         :components="$fields"

--- a/resources/views/components/form/builder.blade.php
+++ b/resources/views/components/form/builder.blade.php
@@ -2,7 +2,7 @@
     :attributes="$attributes"
     :name="$name"
     :precognitive="$precognitive"
-    :isShowErrorsAtFormTop="$isShowErrorsAtFormTop"
+    :showErrorsAtFormTop="$showErrorsAtFormTop"
 >
     <x-moonshine::fields-group
         :components="$fields"

--- a/resources/views/components/form/builder.blade.php
+++ b/resources/views/components/form/builder.blade.php
@@ -2,6 +2,7 @@
     :attributes="$attributes"
     :name="$name"
     :precognitive="$precognitive"
+    :isShowErrorsAtFormTop="$isShowErrorsAtFormTop"
 >
     <x-moonshine::fields-group
         :components="$fields"

--- a/resources/views/components/form/index.blade.php
+++ b/resources/views/components/form/index.blade.php
@@ -4,7 +4,7 @@
     'errors' => false,
     'precognitive' => false,
     'raw' => false,
-    'isShowErrorsAtFormTop' => true,
+    'showErrorsAtFormTop' => true,
 ])
 
 @if($isShowErrorsAtFormTop && formErrors($errors, $name)->isNotEmpty())

--- a/resources/views/components/form/index.blade.php
+++ b/resources/views/components/form/index.blade.php
@@ -3,10 +3,11 @@
     'name' => null,
     'errors' => false,
     'precognitive' => false,
-    'raw' => false
+    'raw' => false,
+    'isShowErrorsAtFormTop' => true,
 ])
 
-@if(formErrors($errors, $name)->isNotEmpty())
+@if($isShowErrorsAtFormTop && formErrors($errors, $name)->isNotEmpty())
     <x-moonshine::form.all-errors :errors="formErrors($errors, $name)" />
 @endif
 

--- a/resources/views/components/form/index.blade.php
+++ b/resources/views/components/form/index.blade.php
@@ -4,10 +4,10 @@
     'errors' => false,
     'precognitive' => false,
     'raw' => false,
-    'showErrorsAtFormTop' => true,
+    'errorsAbove' => true,
 ])
 
-@if($showErrorsAtFormTop && formErrors($errors, $name)->isNotEmpty())
+@if($errorsAbove && formErrors($errors, $name)->isNotEmpty())
     <x-moonshine::form.all-errors :errors="formErrors($errors, $name)" />
 @endif
 

--- a/resources/views/components/form/index.blade.php
+++ b/resources/views/components/form/index.blade.php
@@ -7,7 +7,7 @@
     'showErrorsAtFormTop' => true,
 ])
 
-@if($isShowErrorsAtFormTop && formErrors($errors, $name)->isNotEmpty())
+@if($showErrorsAtFormTop && formErrors($errors, $name)->isNotEmpty())
     <x-moonshine::form.all-errors :errors="formErrors($errors, $name)" />
 @endif
 

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -50,7 +50,7 @@ final class FormBuilder extends RowComponent
 
     protected Closure|string|null $reactiveUrl = null;
 
-    protected bool $showErrorsAtFormTop = true;
+    protected bool $errorsAbove = true;
 
     public function __construct(
         protected string $action = '',
@@ -97,16 +97,16 @@ final class FormBuilder extends RowComponent
         return $this->isPrecognitive;
     }
 
-    public function hideErrorsAtFormTop(): self
+    public function errorsAbove(?bool $enable = true): self
     {
-        $this->showErrorsAtFormTop = false;
+        $this->errorsAbove = $enable;
 
         return $this;
     }
 
-    public function showErrorsAtFormTop(): bool
+    public function hasErrorsAbove(): bool
     {
-        return $this->showErrorsAtFormTop;
+        return $this->errorsAbove;
     }
 
 
@@ -382,7 +382,7 @@ final class FormBuilder extends RowComponent
             'hideSubmit' => $this->isHideSubmit(),
             'submitLabel' => $this->submitLabel(),
             'submitAttributes' => $this->submitAttributes(),
-            'showErrorsAtFormTop' => $this->showErrorsAtFormTop(),
+            'errorsAbove' => $this->hasErrorsAbove(),
         ];
     }
 }

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -97,7 +97,7 @@ final class FormBuilder extends RowComponent
         return $this->isPrecognitive;
     }
 
-    public function errorsAbove(?bool $enable = true): self
+    public function errorsAbove(bool $enable = true): self
     {
         $this->errorsAbove = $enable;
 

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -50,6 +50,8 @@ final class FormBuilder extends RowComponent
 
     protected Closure|string|null $reactiveUrl = null;
 
+    protected bool $isShowErrorsAtFormTop = true;
+
     public function __construct(
         protected string $action = '',
         protected string $method = 'POST',
@@ -95,6 +97,19 @@ final class FormBuilder extends RowComponent
         return $this->isPrecognitive;
     }
 
+    public function hideErrorsAtFormTop(): self
+    {
+        $this->isShowErrorsAtFormTop = false;
+
+        return $this;
+    }
+
+    public function isShowErrorsAtFormTop(): bool
+    {
+        return $this->isShowErrorsAtFormTop;
+    }
+
+
     protected function prepareAsyncUrl(Closure|string|null $asyncUrl = null): Closure|string|null
     {
         return $asyncUrl ?? $this->getAction();
@@ -135,7 +150,7 @@ final class FormBuilder extends RowComponent
 
     private function getReactiveUrl(): string
     {
-        if(! is_null($this->reactiveUrl)) {
+        if (! is_null($this->reactiveUrl)) {
             return value($this->reactiveUrl, $this);
         }
 
@@ -367,6 +382,7 @@ final class FormBuilder extends RowComponent
             'hideSubmit' => $this->isHideSubmit(),
             'submitLabel' => $this->submitLabel(),
             'submitAttributes' => $this->submitAttributes(),
+            'isShowErrorsAtFormTop' => $this->isShowErrorsAtFormTop(),
         ];
     }
 }

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -50,7 +50,7 @@ final class FormBuilder extends RowComponent
 
     protected Closure|string|null $reactiveUrl = null;
 
-    protected bool $isShowErrorsAtFormTop = true;
+    protected bool $showErrorsAtFormTop = true;
 
     public function __construct(
         protected string $action = '',
@@ -104,9 +104,9 @@ final class FormBuilder extends RowComponent
         return $this;
     }
 
-    public function isShowErrorsAtFormTop(): bool
+    public function showErrorsAtFormTop(): bool
     {
-        return $this->isShowErrorsAtFormTop;
+        return $this->showErrorsAtFormTop;
     }
 
 

--- a/src/Components/FormBuilder.php
+++ b/src/Components/FormBuilder.php
@@ -99,7 +99,7 @@ final class FormBuilder extends RowComponent
 
     public function hideErrorsAtFormTop(): self
     {
-        $this->isShowErrorsAtFormTop = false;
+        $this->showErrorsAtFormTop = false;
 
         return $this;
     }
@@ -382,7 +382,7 @@ final class FormBuilder extends RowComponent
             'hideSubmit' => $this->isHideSubmit(),
             'submitLabel' => $this->submitLabel(),
             'submitAttributes' => $this->submitAttributes(),
-            'isShowErrorsAtFormTop' => $this->isShowErrorsAtFormTop(),
+            'showErrorsAtFormTop' => $this->showErrorsAtFormTop(),
         ];
     }
 }

--- a/src/Pages/Crud/FormPage.php
+++ b/src/Pages/Crud/FormPage.php
@@ -153,6 +153,10 @@ class FormPage extends Page
                 $resource->isPrecognitive() || (moonshineRequest()->isFragmentLoad('crud-form') && ! $isAsync),
                 fn (FormBuilder $form): FormBuilder => $form->precognitive()
             )
+            ->when(
+                $resource->isHideErrorsAtFormTop(),
+                fn (FormBuilder $form): FormBuilder => $form->hideErrorsAtFormTop()
+            )
             ->name($resource->uriKey())
             ->buttons($resource->getFormBuilderButtons())
             ->submit(__('moonshine::ui.save'), ['class' => 'btn-primary btn-lg']);

--- a/src/Pages/Crud/FormPage.php
+++ b/src/Pages/Crud/FormPage.php
@@ -154,7 +154,7 @@ class FormPage extends Page
                 fn (FormBuilder $form): FormBuilder => $form->precognitive()
             )
             ->when(
-                $resource->isHideErrorsAtFormTop(),
+                $resource->hideErrorsAtFormTop(),
                 fn (FormBuilder $form): FormBuilder => $form->hideErrorsAtFormTop()
             )
             ->name($resource->uriKey())

--- a/src/Pages/Crud/FormPage.php
+++ b/src/Pages/Crud/FormPage.php
@@ -154,8 +154,8 @@ class FormPage extends Page
                 fn (FormBuilder $form): FormBuilder => $form->precognitive()
             )
             ->when(
-                $resource->hideErrorsAtFormTop(),
-                fn (FormBuilder $form): FormBuilder => $form->hideErrorsAtFormTop()
+                !$resource->hasErrorsAbove(),
+                fn (FormBuilder $form): FormBuilder => $form->errorsAbove($resource->hasErrorsAbove())
             )
             ->name($resource->uriKey())
             ->buttons($resource->getFormBuilderButtons())

--- a/src/Resources/ModelResource.php
+++ b/src/Resources/ModelResource.php
@@ -82,7 +82,7 @@ abstract class ModelResource extends Resource
 
     protected bool $columnSelection = false;
 
-    protected bool $hideErrorsAtFormTop = false;
+    protected bool $errorsAbove = true;
 
     public function flushState(): void
     {
@@ -186,9 +186,9 @@ abstract class ModelResource extends Resource
         return $this->columnSelection;
     }
 
-    public function hideErrorsAtFormTop(): bool
+    public function hasErrorsAbove(): bool
     {
-        return $this->hideErrorsAtFormTop;
+        return $this->errorsAbove;
     }
 
 

--- a/src/Resources/ModelResource.php
+++ b/src/Resources/ModelResource.php
@@ -82,7 +82,7 @@ abstract class ModelResource extends Resource
 
     protected bool $columnSelection = false;
 
-    protected bool $isHideErrorsAtFormTop = false;
+    protected bool $hideErrorsAtFormTop = false;
 
     public function flushState(): void
     {
@@ -186,9 +186,9 @@ abstract class ModelResource extends Resource
         return $this->columnSelection;
     }
 
-    public function isHideErrorsAtFormTop(): bool
+    public function hideErrorsAtFormTop(): bool
     {
-        return $this->isHideErrorsAtFormTop;
+        return $this->hideErrorsAtFormTop;
     }
 
 

--- a/src/Resources/ModelResource.php
+++ b/src/Resources/ModelResource.php
@@ -82,6 +82,8 @@ abstract class ModelResource extends Resource
 
     protected bool $columnSelection = false;
 
+    protected bool $isHideErrorsAtFormTop = false;
+
     public function flushState(): void
     {
         $this->item = null;
@@ -183,6 +185,12 @@ abstract class ModelResource extends Resource
     {
         return $this->columnSelection;
     }
+
+    public function isHideErrorsAtFormTop(): bool
+    {
+        return $this->isHideErrorsAtFormTop;
+    }
+
 
     /**
      * @return list<Metric>
@@ -346,7 +354,7 @@ abstract class ModelResource extends Resource
 
         $fields->each(fn (Field $field): mixed => $field->afterApply($item));
 
-        if($item->isDirty()) {
+        if ($item->isDirty()) {
             $item->save();
         }
 


### PR DESCRIPTION
Добавлена возможность скрывать отображение ошибок валидации в верхней части формы.
![validation](https://github.com/user-attachments/assets/2c1b7e8a-d1eb-4eeb-be1c-44b11813d9ab)

```php
<?php
namespace App\MoonShine\Resources;
//...
class ImageResource extends ModelResource
{
  //...
  protected bool $hideErrorsAtFormTop = true;
  //...
}
```
![hide-validation](https://github.com/user-attachments/assets/71801e46-4d01-4a7c-b33e-9a85ffddaf57)
