### PR TITLE
feat: dynamic profile username, nameOfUser and avatar

### DIFF
--- a/src/Components/Layout/Profile.php
+++ b/src/Components/Layout/Profile.php
@@ -60,9 +60,9 @@ final class Profile extends MoonShineComponent
         return [
             'route' => $this->route ?? to_page(config('moonshine.pages.profile', ProfilePage::class)),
             'logOutRoute' => $this->logOutRoute ?? moonshineRouter()->to('logout'),
-            'avatar' => value($this->avatar) ?? $avatar,
-            'nameOfUser' => value($this->nameOfUser) ?? $nameOfUser,
-            'username' => value($this->username) ?? $username,
+            'avatar' => value($this->avatar, $this) ?? $avatar,
+            'nameOfUser' => value($this->nameOfUser, $this) ?? $nameOfUser,
+            'username' => value($this->username, $this) ?? $username,
             'withBorder' => $this->isWithBorder(),
         ];
     }

--- a/src/Components/Layout/Profile.php
+++ b/src/Components/Layout/Profile.php
@@ -60,7 +60,7 @@ final class Profile extends MoonShineComponent
         return [
             'route' => $this->route ?? to_page(config('moonshine.pages.profile', ProfilePage::class)),
             'logOutRoute' => $this->logOutRoute ?? moonshineRouter()->to('logout'),
-            'avatar' => $this->avatar ?? $avatar,
+            'avatar' => value($this->avatar) ?? $avatar,
             'nameOfUser' => value($this->nameOfUser) ?? $nameOfUser,
             'username' => value($this->username) ?? $username,
             'withBorder' => $this->isWithBorder(),

--- a/src/Components/Layout/Profile.php
+++ b/src/Components/Layout/Profile.php
@@ -10,7 +10,7 @@ use MoonShine\Components\MoonShineComponent;
 use MoonShine\Pages\ProfilePage;
 
 /**
- * @method static static make(?string $route = null, ?string $logOutRoute = null, ?string $avatar = null, \Closure|string|null $nameOfUser = null, \Closure|string|null $username = null, bool $withBorder = false)
+ * @method static static make(?string $route = null, ?string $logOutRoute = null, \Closure|string|null $avatar = null, \Closure|string|null $nameOfUser = null, \Closure|string|null $username = null, bool $withBorder = false)
  */
 final class Profile extends MoonShineComponent
 {
@@ -21,7 +21,7 @@ final class Profile extends MoonShineComponent
     public function __construct(
         protected ?string $route = null,
         protected ?string $logOutRoute = null,
-        protected ?string $avatar = null,
+        protected Closure|string|null $avatar = null,
         protected Closure|string|null $nameOfUser = null,
         protected Closure|string|null $username = null,
         protected bool $withBorder = false,

--- a/src/Components/Layout/Profile.php
+++ b/src/Components/Layout/Profile.php
@@ -10,7 +10,7 @@ use MoonShine\Components\MoonShineComponent;
 use MoonShine\Pages\ProfilePage;
 
 /**
- * @method static static make(?string $route = null, ?string $logOutRoute = null, ?string $avatar = null, ?\Closure|string|null $nameOfUser = null, ?\Closure|string|null $username = null, bool $withBorder = false)
+ * @method static static make(?string $route = null, ?string $logOutRoute = null, ?string $avatar = null, \Closure|string|null $nameOfUser = null, \Closure|string|null $username = null, bool $withBorder = false)
  */
 final class Profile extends MoonShineComponent
 {

--- a/src/Components/Layout/Profile.php
+++ b/src/Components/Layout/Profile.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace MoonShine\Components\Layout;
 
+use Closure;
 use Illuminate\Support\Facades\Storage;
 use MoonShine\Components\MoonShineComponent;
 use MoonShine\Pages\ProfilePage;
 
 /**
- * @method static static make(?string $route = null, ?string $logOutRoute = null, ?string $avatar = null, ?string $nameOfUser = null, ?string $username = null, bool $withBorder = false)
+ * @method static static make(?string $route = null, ?string $logOutRoute = null, ?string $avatar = null, ?\Closure|string|null $nameOfUser = null, ?\Closure|string|null $username = null, bool $withBorder = false)
  */
 final class Profile extends MoonShineComponent
 {
@@ -21,8 +22,8 @@ final class Profile extends MoonShineComponent
         protected ?string $route = null,
         protected ?string $logOutRoute = null,
         protected ?string $avatar = null,
-        protected ?string $nameOfUser = null,
-        protected ?string $username = null,
+        protected Closure|string|null $nameOfUser = null,
+        protected Closure|string|null $username = null,
         protected bool $withBorder = false,
     ) {
         $this->defaultAvatar = asset('vendor/moonshine/avatar.jpg');
@@ -60,8 +61,8 @@ final class Profile extends MoonShineComponent
             'route' => $this->route ?? to_page(config('moonshine.pages.profile', ProfilePage::class)),
             'logOutRoute' => $this->logOutRoute ?? moonshineRouter()->to('logout'),
             'avatar' => $this->avatar ?? $avatar,
-            'nameOfUser' => $this->nameOfUser ?? $nameOfUser,
-            'username' => $this->username ?? $username,
+            'nameOfUser' => value($this->nameOfUser) ?? $nameOfUser,
+            'username' => value($this->username) ?? $username,
             'withBorder' => $this->isWithBorder(),
         ];
     }


### PR DESCRIPTION
С трудом представляю себе ситуацию, в которой нужно было бы вы водить статичную строку вместо имени или логина (это даже не имя проперти, тогда хотя бы муматорами можно было бы управлять значениями)

Поэтому предлагаю изменить тип поля на Closure для подобного использования:

```php
Profile::make(
    username: fn() => auth()->user()?->role == Role::admin || auth()->isImpersonate()
        ? auth()->id() . ' | ' . auth()->user()?->email
        : auth()->user()?->email,
    withBorder: true
),
```

Оставил тип string для обратной совместимости или если вдруг кому-то действительно нужно выводить статику