### PR TITLE
feat: TableBuilder sugar

### DIFF
--- a/resources/js/Components/CardsBuilder.js
+++ b/resources/js/Components/CardsBuilder.js
@@ -7,6 +7,6 @@ export default (async = false, asyncUrl = '') => ({
   loading: false,
   init() {},
   asyncRequest() {
-    listComponentRequest(this, this.$root?.dataset?.pushstate)
+    listComponentRequest(this, this.$root?.dataset?.pushState)
   },
 })

--- a/resources/js/Components/TableBuilder.js
+++ b/resources/js/Components/TableBuilder.js
@@ -124,7 +124,7 @@ export default (
     this.asyncRequest()
   },
   asyncRequest() {
-    listComponentRequest(this, this.$root?.dataset?.pushstate)
+    listComponentRequest(this, this.$root?.dataset?.pushState)
   },
   asyncRowRequest(key, index) {
     const t = this
@@ -221,13 +221,13 @@ export default (
 
     switch (this.table.dataset.clickAction) {
       case 'detail':
-        rowElement.querySelector('.js-detail-button')?.click()
+        rowElement.querySelector(this.table.dataset.clickActionSelector ?? '.js-detail-button')?.click()
         break
       case 'edit':
-        rowElement.querySelector('.js-edit-button')?.click()
+        rowElement.querySelector(this.table.dataset.clickActionSelector ?? '.js-edit-button')?.click()
         break
       case 'select':
-        rowElement.querySelector('.js-table-action-row[type="checkbox"]')?.click()
+        rowElement.querySelector(this.table.dataset.clickActionSelector ?? '.js-table-action-row[type="checkbox"]')?.click()
         break
     }
   },

--- a/src/Laravel/Fields/Relationships/BelongsToMany.php
+++ b/src/Laravel/Fields/Relationships/BelongsToMany.php
@@ -298,9 +298,7 @@ class BelongsToMany extends ModelRelationField implements
             ->fields($fields)
             ->when(
                 $removeAfterClone,
-                static fn (TableBuilderContract $table): TableBuilderContract => $table->customAttributes([
-                    'data-remove-after-clone' => 1,
-                ])
+                static fn (TableBuilderContract $table): TableBuilderContract => $table->removeAfterClone()
             )
             ->cast($this->getResource()->getModelCast())
             ->simple()

--- a/src/Laravel/Pages/Crud/IndexPage.php
+++ b/src/Laravel/Pages/Crud/IndexPage.php
@@ -186,21 +186,9 @@ class IndexPage extends Page
                 )
             )
             ->buttons($this->getResource()->getIndexButtons())
-            ->customAttributes([
-                'data-click-action' => $this->getResource()->getClickAction(),
-            ])
-            ->when(
-                ! is_null($this->getResource()->getClickAction()),
-                static fn (TableBuilderContract $table): TableBuilderContract => $table->tdAttributes(
-                    static fn (): array => [
-                        '@click.stop' => 'rowClickAction',
-                    ]
-                )
-            )
+            ->clickAction($this->getResource()->getClickAction())
             ->when($this->getResource()->isAsync(), static function (TableBuilderContract $table): void {
-                $table->async()->customAttributes([
-                    'data-pushstate' => 'true',
-                ]);
+                $table->async()->pushState();
             })
             ->when($this->getResource()->isStickyTable(), function (TableBuilderContract $table): void {
                 $table->sticky();

--- a/src/UI/Traits/Table/TableStates.php
+++ b/src/UI/Traits/Table/TableStates.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\UI\Traits\Table;
 
 use MoonShine\Contracts\UI\ActionButtonContract;
+use MoonShine\Support\Enums\ClickAction;
 use MoonShine\UI\Components\ActionButton;
 
 trait TableStates
@@ -210,6 +211,36 @@ trait TableStates
     public function isColumnSelection(): bool
     {
         return ! $this->isVertical() && $this->isColumnSelection;
+    }
+
+    public function clickAction(?ClickAction $action = null, ?string $selector = null): static
+    {
+        if(is_null($action)) {
+            return $this;
+        }
+
+        return $this->customAttributes(array_filter([
+            'data-click-action' => $action->value,
+            'data-click-action-selector' => $selector,
+        ]))->tdAttributes(
+            static fn (): array => [
+                '@click.stop' => 'rowClickAction',
+            ]
+        );
+    }
+
+    public function pushState(): static
+    {
+        return $this->customAttributes([
+            'data-push-state' => 'true',
+        ]);
+    }
+
+    public function removeAfterClone(): static
+    {
+        return $this->customAttributes([
+            'data-remove-after-clone' => 1,
+        ]);
     }
 
     /**


### PR DESCRIPTION
New TableBuilder sugar methods clickAction, pushState, removeAfterClone

```php
TableBuilder::make()
    ->fields([
        Text::make('Title'),
    ])
    ->items([
        ['title' => 'Test']
    ])
    ->buttons([
        ActionButton::make('Go', '#')
            ->class('some-class')
            ->inModal('Title')
    ])
    ->clickAction(ClickAction::EDIT, '.some-class')
    ->pushState()
    ->removeAfterClone()
```

#### ClickAction

When you click on a table row, a click occurs on a specific button (via a selector) by default the selector is '.js-(edit|detail)-button'

#### pushState

If the table is asynchronous, then the called URLs are saved in the browser history

#### removeAfterClone (system method)
An empty table row will be cloned into memory and deleted.