### PR TITLE
InputExtensions Copy customize. Copying with custom text

### DIFF
--- a/resources/views/components/field-container.blade.php
+++ b/resources/views/components/field-container.blade.php
@@ -9,9 +9,9 @@
     <x-moonshine::form.input-wrapper
         :attributes="$field->wrapperAttributes()
             ->merge(['required' => $field->attributes()->get('required')])"
-        label="{{ $field->label() }}"
-        name="{{ $field->name() }}"
-        id="{{ $field->id() }}"
+        :label="$field->label()"
+        :name="$field->name()"
+        :id="$field->id()"
         :beforeLabel="$field->isBeforeLabel()"
         :inLabel="$field->isInLabel()"
         :formName="$field->getFormName()"

--- a/resources/views/components/form/input-extensions/copy.blade.php
+++ b/resources/views/components/form/input-extensions/copy.blade.php
@@ -1,5 +1,5 @@
 @props(['extension'])
-<button @click.prevent="copy()"
+<button @click.prevent="copy('{{ $extension->getValue() }}')"
         {{ $attributes->class(['expansion']) }}
         type="button"
         x-data="tooltip('{{ __('moonshine::ui.copied') }}', {placement: 'top', trigger: 'click', delay: [0, 800]})"

--- a/src/InputExtensions/InputCopy.php
+++ b/src/InputExtensions/InputCopy.php
@@ -11,7 +11,7 @@ final class InputCopy extends InputExtension
     protected array $xData = [
         <<<'HTML'
           copy(value) {
-            navigator.clipboard.writeText(value.replace('[value]', $refs.extensionInput.value));
+            navigator.clipboard.writeText(value.replace('{{value}}', $refs.extensionInput.value));
           }
         HTML,
     ];

--- a/src/InputExtensions/InputCopy.php
+++ b/src/InputExtensions/InputCopy.php
@@ -10,8 +10,8 @@ final class InputCopy extends InputExtension
 
     protected array $xData = [
         <<<'HTML'
-          copy() {
-            navigator.clipboard.writeText($refs.extensionInput.value);
+          copy(value) {
+            navigator.clipboard.writeText(value.replace('[value]', $refs.extensionInput.value));
           }
         HTML,
     ];

--- a/src/Traits/Fields/WithInputExtensions.php
+++ b/src/Traits/Fields/WithInputExtensions.php
@@ -21,9 +21,9 @@ trait WithInputExtensions
     }
 
     /** Just a sugar methods below */
-    public function copy(): static
+    public function copy(string $value = '[value]'): static
     {
-        $this->extension(new InputCopy());
+        $this->extension(new InputCopy($value));
 
         return $this;
     }

--- a/src/Traits/Fields/WithInputExtensions.php
+++ b/src/Traits/Fields/WithInputExtensions.php
@@ -21,7 +21,7 @@ trait WithInputExtensions
     }
 
     /** Just a sugar methods below */
-    public function copy(string $value = '[value]'): static
+    public function copy(string $value = '{{value}}'): static
     {
         $this->extension(new InputCopy($value));
 


### PR DESCRIPTION
Данная фича позволяет модифицировать "InputExtensions Copy". Добавляя возможность дополнять текст из поля input.

Применение:

```
Text::make()->copy() // Скопируется только значение поля

Text::make()->copy('https://domain.com?token={{value}}') // Скопируется https://domain.com?token=значение поля
```