### PR TITLE
Tabs content through slots

### DIFF
--- a/resources/views/components/field-container.blade.php
+++ b/resources/views/components/field-container.blade.php
@@ -9,9 +9,9 @@
     <x-moonshine::form.input-wrapper
         :attributes="$field->wrapperAttributes()
             ->merge(['required' => $field->attributes()->get('required')])"
-        label="{{ $field->label() }}"
-        name="{{ $field->name() }}"
-        id="{{ $field->id() }}"
+        :label="$field->label()"
+        :name="$field->name()"
+        :id="$field->id()"
         :beforeLabel="$field->isBeforeLabel()"
         :inLabel="$field->isInLabel()"
         :formName="$field->getFormName()"

--- a/resources/views/components/form/input-extensions/copy.blade.php
+++ b/resources/views/components/form/input-extensions/copy.blade.php
@@ -1,5 +1,5 @@
 @props(['extension'])
-<button @click.prevent="copy()"
+<button @click.prevent="copy('{{ $extension->getValue() }}')"
         {{ $attributes->class(['expansion']) }}
         type="button"
         x-data="tooltip('{{ __('moonshine::ui.copied') }}', {placement: 'top', trigger: 'click', delay: [0, 800]})"

--- a/resources/views/components/tabs.blade.php
+++ b/resources/views/components/tabs.blade.php
@@ -1,12 +1,21 @@
 @props([
     'tabs',
-    'contents',
-    'active',
+    'contents' => [],
+    'active' => null,
     'justifyAlign' => 'start',
     'isVertical' => false,
 ])
 
 @if($tabs)
+    @php
+        if (! $contents) {
+            $contents = collect($__laravel_slots ?? [])
+                ->mapWithKeys(fn($contentSlot, $name) => [Str::after($name, 'content-') => $contentSlot])
+                ->filter(fn($contentSlot, $name) => array_key_exists($name, $tabs))
+                ->all();
+        }
+    @endphp
+
     <!-- Tabs -->
     <div {{ $attributes->class(['tabs']) }}
         x-data="tabs(
@@ -38,6 +47,8 @@
                     :class="activeTab === '{{ $tabId }}' ? 'block' : 'hidden'"
                     class="tab-panel"
                     @set-active-tab="setActiveTab(`{{ $tabId }}`)"
+
+                    {{ $tabContent instanceof \Illuminate\View\ComponentSlot ? $tabContent->attributes  : '' }}
                 >
                     <div class="tabs-body">
                         {!! $tabContent !!}

--- a/src/InputExtensions/InputCopy.php
+++ b/src/InputExtensions/InputCopy.php
@@ -10,8 +10,8 @@ final class InputCopy extends InputExtension
 
     protected array $xData = [
         <<<'HTML'
-          copy() {
-            navigator.clipboard.writeText($refs.extensionInput.value);
+          copy(value) {
+            navigator.clipboard.writeText(value.replace('[value]', $refs.extensionInput.value));
           }
         HTML,
     ];

--- a/src/Traits/Fields/WithInputExtensions.php
+++ b/src/Traits/Fields/WithInputExtensions.php
@@ -21,9 +21,9 @@ trait WithInputExtensions
     }
 
     /** Just a sugar methods below */
-    public function copy(): static
+    public function copy(string $value = '[value]'): static
     {
-        $this->extension(new InputCopy());
+        $this->extension(new InputCopy($value));
 
         return $this;
     }


### PR DESCRIPTION
Компонент "tabs", добавлена возможность создавать "content" через слоты.

Применение:

Используем префикс "content-" в названии слота.

```
<x-moonshine::tabs :tabs="[
    'general' => 'Таб 1',
    'tokens' => 'Таб 2',
    'others' => 'Таб 3',
]">
    <x-slot name="content-general">
        Таб 1 content
    </x-slot>

    <x-slot name="content-tokens">
        Таб 2 content
    </x-slot>

    <x-slot name="content-others">
        Таб 3 content
    </x-slot>
</x-moonshine::tabs>
```