### PR TITLE
feat: Tabs with slots

### DIFF
--- a/resources/views/components/tabs.blade.php
+++ b/resources/views/components/tabs.blade.php
@@ -1,6 +1,5 @@
 @props([
     'tabs' => [],
-    'contents' => [],
     'active' => null,
     'justifyAlign' => 'start',
     'isVertical' => false,


### PR DESCRIPTION
```blade
<x-moonshine::tabs :items="['tab_1' => 'Tab title 1', 'tab_2' => 'Tab title 2']">
        <x-slot:tab_1>
            Text 1
        </x-slot:tab_1>

        <x-slot:tab_2>
            Text 2
        </x-slot:tab_2>
    </x-moonshine::tabs>
```