### PR TITLE
Tabs content through slots

### DIFF
--- a/resources/views/components/tabs.blade.php
+++ b/resources/views/components/tabs.blade.php
@@ -1,12 +1,21 @@
 @props([
     'tabs',
-    'contents',
-    'active',
+    'contents' => [],
+    'active' => null,
     'justifyAlign' => 'start',
     'isVertical' => false,
 ])
 
 @if($tabs)
+    @php
+        if ($contents === []) {
+            $contents = collect($__laravel_slots ?? [])
+                ->mapWithKeys(fn($contentSlot, $name) => [Str::after($name, 'content-') => $contentSlot])
+                ->filter(fn($contentSlot, $name) => array_key_exists($name, $tabs))
+                ->all();
+        }
+    @endphp
+
     <!-- Tabs -->
     <div {{ $attributes->class(['tabs']) }}
         x-data="tabs(

--- a/resources/views/components/tabs.blade.php
+++ b/resources/views/components/tabs.blade.php
@@ -9,8 +9,12 @@
 @if($tabs)
     @php
         if ($contents === []) {
+            $tabs = collect($tabs)
+                ->mapWithKeys(fn($value, $name) => [Str::camel($name) => $value])
+                ->all();
+
             $contents = collect($__laravel_slots ?? [])
-                ->mapWithKeys(fn($contentSlot, $name) => [Str::after($name, 'content-') => $contentSlot])
+                ->mapWithKeys(fn($contentSlot, $name) => [Str::camel($name) => $contentSlot])
                 ->filter(fn($contentSlot, $name) => array_key_exists($name, $tabs))
                 ->all();
         }


### PR DESCRIPTION
Компонент "tabs", добавлена возможность создавать "content" через слоты.

Применение:

```
<x-moonshine::tabs :tabs="[
    'tab_1' => 'Таб 1',
    'tab_2' => 'Таб 2',
    'tab-3' => 'Таб 3',
]">
    <x-slot:tab_1>
        Таб 1 content
    </x-slot>

    <x-slot name="tab_2">
        Таб 2 content
    </x-slot>

    <x-slot:tab-3>
        Таб 3 content
    </x-slot>
</x-moonshine::tabs>
```