### PR TITLE
[3.x] add styles for tfoot td (for support TableBuilder footRows)

### DIFF
--- a/src/UI/resources/css/components/tables.css
+++ b/src/UI/resources/css/components/tables.css
@@ -70,6 +70,16 @@ table {
     }
   }
 
+  tfoot {
+    tr:not(:has(td[class$=-bulk-actions])) {
+      @apply bg-white dark:bg-dark-600;
+    }
+    td:not([class$=-bulk-actions]),
+    th {
+      @apply max-w-lg whitespace-nowrap px-5 py-3 first:rounded-l-lg last:rounded-r-lg dark:border-dark-300 lg:whitespace-normal;
+    }
+  }
+
   &[data-click-action] {
     tbody {
       tr {

--- a/src/UI/resources/css/components/tables.css
+++ b/src/UI/resources/css/components/tables.css
@@ -41,6 +41,10 @@ table {
   }
 
   tfoot {
+    td:not([class$='-bulk-actions']),
+    th {
+      @apply max-w-lg break-words border-b p-2 py-3 dark:border-dark-400;
+    }
     tr:first-child {
       td,
       th {

--- a/src/UI/resources/css/components/tables.css
+++ b/src/UI/resources/css/components/tables.css
@@ -115,6 +115,11 @@ table {
   max-height: calc(70dvh);
 
   & > table > thead {
-    @apply sticky -top-1 z-1 bg-slate-50 dark:bg-dark-700;
+    @apply sticky -top-1 z-1;
+
+    &:before {
+      content: '';
+      @apply -z-1 bg-slate-50 dark:bg-dark-700 absolute top-0 left-0 w-full h-full;
+    }
   }
 }

--- a/src/UI/resources/css/components/tables.css
+++ b/src/UI/resources/css/components/tables.css
@@ -50,7 +50,7 @@ table {
       @apply break-words p-2 py-3;
     }
     td[class$='-bulk-actions'] {
-      @apply pt-3 pb-3;
+      @apply pb-3 pt-3;
     }
   }
 }

--- a/src/UI/resources/css/components/tables.css
+++ b/src/UI/resources/css/components/tables.css
@@ -41,15 +41,16 @@ table {
   }
 
   tfoot {
+    td,
+    th {
+      @apply max-w-lg border-t dark:border-dark-400;
+    }
     td:not([class$='-bulk-actions']),
     th {
-      @apply max-w-lg break-words border-b p-2 py-3 dark:border-dark-400;
+      @apply break-words p-2 py-3;
     }
-    tr:first-child {
-      td,
-      th {
-        @apply max-w-lg border-t pt-3 dark:border-dark-300;
-      }
+    td[class$='-bulk-actions'] {
+      @apply pt-3 pb-3;
     }
   }
 }

--- a/src/UI/resources/css/components/tables.css
+++ b/src/UI/resources/css/components/tables.css
@@ -71,10 +71,10 @@ table {
   }
 
   tfoot {
-    tr:not(:has(td[class$=-bulk-actions])) {
+    tr:not(:has(td[class$='-bulk-actions'])) {
       @apply bg-white dark:bg-dark-600;
     }
-    td:not([class$=-bulk-actions]),
+    td:not([class$='-bulk-actions']),
     th {
       @apply max-w-lg whitespace-nowrap px-5 py-3 first:rounded-l-lg last:rounded-r-lg dark:border-dark-300 lg:whitespace-normal;
     }
@@ -119,7 +119,7 @@ table {
 
     &:before {
       content: '';
-      @apply -z-1 bg-slate-50 dark:bg-dark-700 absolute top-0 left-0 w-full h-full;
+      @apply absolute left-0 top-0 -z-1 h-full w-full bg-slate-50 dark:bg-dark-700;
     }
   }
 }

--- a/src/UI/resources/css/minimalistic.css
+++ b/src/UI/resources/css/minimalistic.css
@@ -481,6 +481,12 @@ body.theme-minimalistic {
         @apply px-2 py-1.5 text-3xs;
       }
     }
+    tfoot {
+      th,
+      td:not([class$=-bulk-actions]) {
+        @apply px-2 py-1.5 text-3xs;
+      }
+    }
   }
 
   .table-sticky > table > thead {

--- a/src/UI/resources/css/minimalistic.css
+++ b/src/UI/resources/css/minimalistic.css
@@ -489,7 +489,7 @@ body.theme-minimalistic {
     }
   }
 
-  .table-sticky > table > thead {
+  .table-sticky > table > thead:before {
     @apply dark:bg-dark-800;
   }
 

--- a/src/UI/resources/css/minimalistic.css
+++ b/src/UI/resources/css/minimalistic.css
@@ -483,7 +483,7 @@ body.theme-minimalistic {
     }
     tfoot {
       th,
-      td:not([class$=-bulk-actions]) {
+      td:not([class$='-bulk-actions']) {
         @apply px-2 py-1.5 text-3xs;
       }
     }

--- a/src/UI/resources/css/minimalistic.css
+++ b/src/UI/resources/css/minimalistic.css
@@ -470,6 +470,12 @@ body.theme-minimalistic {
         @apply p-1 text-3xs;
       }
     }
+    tfoot {
+      th,
+      td:not([class$='-bulk-actions']) {
+        @apply p-1 text-3xs;
+      }
+    }
   }
 
   .table-list {

--- a/src/UI/src/Components/Table/TableBuilder.php
+++ b/src/UI/src/Components/Table/TableBuilder.php
@@ -490,7 +490,8 @@ final class TableBuilder extends IterableComponent implements
 
         if ($this->getBulkButtons()->isNotEmpty()) {
             $row->mergeAttribute(
-                ':class', "actionsOpen ? 'translate-y-none ease-out' : '-translate-y-full ease-in hidden'"
+                ':class',
+                "actionsOpen ? 'translate-y-none ease-out' : '-translate-y-full ease-in hidden'"
             );
         }
 

--- a/src/UI/src/Components/Table/TableBuilder.php
+++ b/src/UI/src/Components/Table/TableBuilder.php
@@ -486,13 +486,15 @@ final class TableBuilder extends IterableComponent implements
             ])
         );
 
+        $row = TableRow::make($cells);
+
         if ($this->getBulkButtons()->isNotEmpty()) {
-            $this->footAttributes([
-                ':class' => "actionsOpen ? 'translate-y-none ease-out' : '-translate-y-full ease-in hidden'",
-            ]);
+            $row->mergeAttribute(
+                ':class', "actionsOpen ? 'translate-y-none ease-out' : '-translate-y-full ease-in hidden'"
+            );
         }
 
-        return TableRow::make($cells);
+        return $row;
     }
 
     protected function prepareBeforeRender(): void

--- a/src/UI/src/Components/Table/TableBuilder.php
+++ b/src/UI/src/Components/Table/TableBuilder.php
@@ -473,8 +473,12 @@ final class TableBuilder extends IterableComponent implements
         ]);
     }
 
-    private function resolveFootRow(): TableRowContract
+    private function resolveFootRow(): ?TableRowContract
     {
+        if ($this->getBulkButtons()->isEmpty()) {
+            return null;
+        }
+
         $cells = TableCells::make()->pushCellWhen(
             ! $this->isPreview(),
             fn (): string => (string) Flex::make([
@@ -486,21 +490,10 @@ final class TableBuilder extends IterableComponent implements
             ])
         );
 
-        $row = TableRow::make($cells);
-
-        if ($this->getBulkButtons()->isNotEmpty()) {
-            $row->mergeAttribute(
-                ':class',
-                "actionsOpen ? 'translate-y-none ease-out' : '-translate-y-full ease-in hidden'"
-            );
-        } else {
-            $row->mergeAttribute(
-                'class',
-                'hidden'
-            );
-        }
-
-        return $row;
+        return TableRow::make($cells)->mergeAttribute(
+            ':class',
+            "actionsOpen ? 'translate-y-none ease-out' : '-translate-y-full ease-in hidden'"
+        );
     }
 
     protected function prepareBeforeRender(): void

--- a/src/UI/src/Components/Table/TableBuilder.php
+++ b/src/UI/src/Components/Table/TableBuilder.php
@@ -493,6 +493,11 @@ final class TableBuilder extends IterableComponent implements
                 ':class',
                 "actionsOpen ? 'translate-y-none ease-out' : '-translate-y-full ease-in hidden'"
             );
+        } else {
+            $row->mergeAttribute(
+                'class',
+                'hidden'
+            );
         }
 
         return $row;


### PR DESCRIPTION
В TableBuilder через footRows можно добавить новые TableRow (например можно добавить строку "Итого"). Но для tfoot отсутствует дизайн ячеек, поэтому такие строки выбиваются из дизайна:
<img width="1159" alt="image" src="https://github.com/user-attachments/assets/8102f302-296c-4033-8313-6d236b4817e3">

Коммит добавляет стили для tfoot tr td th, такие же как для tbody, в исключения добавлен класс td *-bulk-actions чтобы не трогать кнопки, которые находятся в tfoot
