### PR TITLE
refactor: :recycle:  Тестов ListOf

### DIFF
--- a/tests/Unit/ListOfTest.php
+++ b/tests/Unit/ListOfTest.php
@@ -61,22 +61,32 @@ it('except elements', function () {
 });
 
 it('except type', function () {
-    expect($this->listOfObjects->except(SomeTypeSub2::class, SomeTypeSub3::class)->toArray())
+    $listOf = $this->listOfObjects->except(SomeTypeSub2::class, SomeTypeSub3::class)->toArray();
+    expect($listOf)
         ->toHaveCount(1)
-        ->not->toContain(new SomeTypeSub2(), new SomeTypeSub3());
+        ->and(collect($listOf)->every(fn ($item) => $item instanceof SomeTypeSub1))
+        ->toBeTrue()
+        ->and(collect($listOf)->contains(fn ($item) => $item instanceof SomeTypeSub2 || $item instanceof SomeTypeSub3))
+        ->toBeFalse();
 });
 
 it('except closure', function () {
-    expect($this->listOfObjects->except(fn ($item) => get_class($item) === SomeTypeSub2::class)->toArray())
+    $listOf = $this->listOfObjects->except(fn ($item) => get_class($item) === SomeTypeSub2::class)->toArray();
+    expect($listOf)
         ->toHaveCount(2)
-        ->not->toContain(new SomeTypeSub2());
+        ->and(collect($listOf)->contains(fn ($item) => $item instanceof SomeTypeSub2))
+        ->toBeFalse();
 });
 
 
 it('except mixed', function () {
-    expect($this->listOfObjects->except(fn ($item) => get_class($item) === SomeTypeSub2::class, SomeTypeSub3::class)->toArray())
+    $listOf = $this->listOfObjects->except(fn ($item) => $item instanceof SomeTypeSub2, SomeTypeSub3::class)->toArray();
+    expect($listOf)
         ->toHaveCount(1)
-        ->not->toContain(new SomeTypeSub2(), new SomeTypeSub3());
+        ->and(collect($listOf)->every(fn ($item) => $item instanceof SomeTypeSub1))
+        ->toBeTrue()
+        ->and(collect($listOf)->contains(fn ($item) => $item instanceof SomeTypeSub2 || $item instanceof SomeTypeSub3))
+        ->toBeFalse();
 });
 
 it('add elements', function () {
@@ -109,7 +119,8 @@ it('only type', function () {
     $listOf = $this->listOfObjects->only(SomeTypeSub1::class, SomeTypeSub2::class)->toArray();
     expect($listOf)
         ->toHaveCount(2)
-        ->not->toContain(new SomeTypeSub3())
+        ->and(collect($listOf)->contains(fn ($item) => $item instanceof SomeTypeSub3))
+        ->toBeFalse()
         ->and(collect($listOf)->every(fn ($item) => $item instanceof SomeTypeSub1 || $item instanceof SomeTypeSub2))
         ->toBeTrue();
 });
@@ -118,7 +129,8 @@ it('only closure', function () {
     $listOf = $this->listOfObjects->only(fn ($item) => get_class($item) === SomeTypeSub1::class)->toArray();
     expect($listOf)
         ->toHaveCount(1)
-        ->not->toContain(new SomeTypeSub2(), new SomeTypeSub3())
+        ->and(collect($listOf)->contains(fn ($item) => $item instanceof SomeTypeSub2 || $item instanceof SomeTypeSub3))
+        ->toBeFalse()
         ->and(collect($listOf)->every(fn ($item) => $item instanceof SomeTypeSub1))
         ->toBeTrue();
 });
@@ -127,7 +139,8 @@ it('only mixed', function () {
     $listOf = $this->listOfObjects->only(fn ($item) => get_class($item) === SomeTypeSub1::class, SomeTypeSub3::class)->toArray();
     expect($listOf)
         ->toHaveCount(2)
-        ->not->toContain(new SomeTypeSub2())
+        ->and(collect($listOf)->contains(fn ($item) => $item instanceof SomeTypeSub2))
+        ->toBeFalse()
         ->and(collect($listOf)->every(fn ($item) => $item instanceof SomeTypeSub1 || $item instanceof SomeTypeSub3))
         ->toBeTrue();
 });


### PR DESCRIPTION
В ходе проверки `toContain(new ...())` создается новый экземпляр, который не является объектом, фактически находящемся в ListOf.