### PR TITLE
Fix: order by column not exists

### DIFF
--- a/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Traits/Resource/ResourceModelQuery.php
@@ -405,7 +405,11 @@ trait ResourceModelQuery
             ->onlyFields()
             ->findByColumn($column);
 
-        $callback = $field?->sortableCallback();
+        if (is_null($field)) {
+            return $this;
+        }
+
+        $callback = $field->sortableCallback();
 
         if (is_string($callback)) {
             $column = value($callback);


### PR DESCRIPTION
Если в адресе указать в `?sort=` несуществующую колонку, то выскакивает ошибка.