### PR TITLE
Add support for nullable link in WithLink trait

### DIFF
--- a/src/UI/src/Traits/Fields/WithLink.php
+++ b/src/UI/src/Traits/Fields/WithLink.php
@@ -55,13 +55,13 @@ trait WithLink
      * @param  string|(Closure(string $value, static $ctx): string)  $name
      */
     public function link(
-        string|Closure $link,
+        null|string|Closure $link,
         string|Closure $name = '',
         ?string $icon = null,
         bool $withoutIcon = false,
         bool $blank = false,
     ): static {
-        $this->isLink = true;
+        $this->isLink = !is_null($link);
 
         $this->linkIcon = $icon;
         $this->withoutIcon = $withoutIcon;


### PR DESCRIPTION
Updated the `link` method to allow `null` as a valid input for the `$link` parameter. This ensures better flexibility and prevents setting `$isLink` to true when no link is provided.

   
## What was changed
Removed the hardcore `true` to the dynamic `is_null`

## Why?
Sometimes you need to put a link if there is one, for example, if I had a phone number, then you need to put a link to it 
In the example below, there is no data and the link is out of place
![image](https://github.com/user-attachments/assets/2abe4f49-4dc5-4dd8-bd5b-8ee1339461c0)

  ## Checklist
  - Tested
    - [+] Tested manually
    - [-] Tests added

