### PR TITLE
only sidebar or top bar in mobile browser

### DIFF
--- a/src/UI/resources/css/base/layout.css
+++ b/src/UI/resources/css/base/layout.css
@@ -3,6 +3,11 @@
   &-wrapper {
     @apply relative flex min-h-screen flex-col gap-y-5 py-3 transition-all md:p-5 lg:flex-row lg:p-6;
 
+    .layout-menu-horizontal ~ .layout-menu,
+    .layout-menu ~ .layout-menu-horizontal {
+      @apply mobile:!hidden;
+    }
+
     /* MOBILEBAR */
     /* selector :has not supported */
 
@@ -76,6 +81,10 @@
         /* .layout-menu {
           @apply invisible lg:visible;
         } */
+      }
+
+      &:has(.layout-menu ~ .layout-menu-horizontal) {
+        @apply mobile:pt-16 !important;
       }
     }
   }


### PR DESCRIPTION
When using Topbar and Sidebar at the same time in a mobile browser, both were displayed. Now only the first one is displayed.
