### PR TITLE
Update burger.blade.php

### DIFF
--- a/src/UI/resources/views/components/layout/burger.blade.php
+++ b/src/UI/resources/views/components/layout/burger.blade.php
@@ -1,4 +1,4 @@
-<button type="button" @click.prevent="asideMenuOpen = ! asideMenuOpen" class="text-white hover:text-secondary">
+<button type="button" @click.prevent="asideMenuOpen = ! asideMenuOpen" {{ $attributes }} >
     <svg x-show="!asideMenuOpen" style="display: none" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-8 w-8">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
     </svg>

--- a/src/UI/resources/views/components/layout/burger.blade.php
+++ b/src/UI/resources/views/components/layout/burger.blade.php
@@ -1,4 +1,4 @@
-<button type="button" @click.prevent="asideMenuOpen = ! asideMenuOpen" {{ $attributes }} >
+<button type="button" {{ $attributes->merge(['@click.prevent' => 'asideMenuOpen = ! asideMenuOpen'])->class(['text-white', 'hover:text-secondary']) }} >
     <svg x-show="!asideMenuOpen" style="display: none" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-8 w-8">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
     </svg>


### PR DESCRIPTION

    ## What was changed
    repleced class atribute to  {{ $attributes }}

    ## Why?
    Changing the color scheme(when style is "light" and background: none; ), I came across that you can't change the color of the burger menu text. I tried to remove the "class" attribute and add {{ $attrinbutes }} in Burger::make()->customAttributes(). Work fine! 
    But do not forget about @click.prevent, it will not be overwritten and may be some default style settings need merge/overwrite class attribute.

