### PR TITLE
Vertical span

### DIFF
--- a/src/Contracts/src/UI/TableBuilderContract.php
+++ b/src/Contracts/src/UI/TableBuilderContract.php
@@ -68,10 +68,10 @@ interface TableBuilderContract extends
     public function isEditable(): bool;
 
     /**
-     * @param  ?Closure(FieldContract $field, ComponentContract $default, static $ctx): ComponentContract  $title
-     * @param  ?Closure(FieldContract $field, ComponentContract $default, static $ctx): ComponentContract   $value
+     * @param  null|int|Closure(FieldContract $field, ComponentContract $default, static $ctx): ComponentContract  $title
+     * @param  null|int|Closure(FieldContract $field, ComponentContract $default, static $ctx): ComponentContract  $value
      */
-    public function vertical(?Closure $title = null, ?Closure $value = null): static;
+    public function vertical(null|Closure|int $title = null, null|Closure|int $value = null): static;
 
     public function isVertical(): bool;
 

--- a/src/Laravel/src/Pages/Crud/DetailPage.php
+++ b/src/Laravel/src/Pages/Crud/DetailPage.php
@@ -154,7 +154,10 @@ class DetailPage extends CrudPage
         return TableBuilder::make($fields)
             ->cast($this->getResource()->getCaster())
             ->items([$item])
-            ->vertical(title: $this->getResource()->isDetailInModal() ? 3 : 2)
+            ->vertical(
+                title: $this->getResource()->isDetailInModal() ? 3 : 2,
+                value: $this->getResource()->isDetailInModal() ? 9 : 10,
+            )
             ->simple()
             ->preview();
     }

--- a/src/Laravel/src/Pages/Crud/DetailPage.php
+++ b/src/Laravel/src/Pages/Crud/DetailPage.php
@@ -154,7 +154,7 @@ class DetailPage extends CrudPage
         return TableBuilder::make($fields)
             ->cast($this->getResource()->getCaster())
             ->items([$item])
-            ->vertical()
+            ->vertical(title: $this->getResource()->isDetailInModal() ? 3 : 2)
             ->simple()
             ->preview();
     }

--- a/src/UI/src/Components/Table/TableBuilder.php
+++ b/src/UI/src/Components/Table/TableBuilder.php
@@ -260,17 +260,21 @@ final class TableBuilder extends IterableComponent implements
                     $attributes = $field->getWrapperAttributes()->jsonSerialize();
                     $title = Column::make([
                         Heading::make($field->getLabel())->h(4),
-                    ])->columnSpan(1);
+                    ])->columnSpan(is_int($this->verticalTitleCallback) ? $this->verticalTitleCallback : 2);
 
                     $value = Column::make([
                         Div::make([
                             $field,
                         ])->customAttributes($attributes),
-                    ])->columnSpan(11);
+                    ])->columnSpan(is_int($this->verticalTitleCallback) ? $this->verticalTitleCallback : 10);
 
                     $components[] = Grid::make([
-                        \is_null($this->verticalTitleCallback) ? $title : \call_user_func($this->verticalTitleCallback, $field, $title, $this),
-                        \is_null($this->verticalValueCallback) ? $value : \call_user_func($this->verticalValueCallback, $field, $value, $this),
+                        \is_null($this->verticalTitleCallback) || is_int($this->verticalTitleCallback)
+                            ? $title
+                            : \call_user_func($this->verticalTitleCallback, $field, $title, $this),
+                        \is_null($this->verticalValueCallback) || is_int($this->verticalValueCallback)
+                            ? $value
+                            : \call_user_func($this->verticalValueCallback, $field, $value, $this),
                     ]);
                 }
 

--- a/src/UI/src/Components/Table/TableBuilder.php
+++ b/src/UI/src/Components/Table/TableBuilder.php
@@ -260,19 +260,19 @@ final class TableBuilder extends IterableComponent implements
                     $attributes = $field->getWrapperAttributes()->jsonSerialize();
                     $title = Column::make([
                         Heading::make($field->getLabel())->h(4),
-                    ])->columnSpan(is_int($this->verticalTitleCallback) ? $this->verticalTitleCallback : 2);
+                    ])->columnSpan(\is_int($this->verticalTitleCallback) ? $this->verticalTitleCallback : 2);
 
                     $value = Column::make([
                         Div::make([
                             $field,
                         ])->customAttributes($attributes),
-                    ])->columnSpan(is_int($this->verticalTitleCallback) ? $this->verticalTitleCallback : 10);
+                    ])->columnSpan(\is_int($this->verticalTitleCallback) ? $this->verticalTitleCallback : 10);
 
                     $components[] = Grid::make([
-                        \is_null($this->verticalTitleCallback) || is_int($this->verticalTitleCallback)
+                        \is_null($this->verticalTitleCallback) || \is_int($this->verticalTitleCallback)
                             ? $title
                             : \call_user_func($this->verticalTitleCallback, $field, $title, $this),
-                        \is_null($this->verticalValueCallback) || is_int($this->verticalValueCallback)
+                        \is_null($this->verticalValueCallback) || \is_int($this->verticalValueCallback)
                             ? $value
                             : \call_user_func($this->verticalValueCallback, $field, $value, $this),
                     ]);

--- a/src/UI/src/Traits/Table/TableStates.php
+++ b/src/UI/src/Traits/Table/TableStates.php
@@ -17,9 +17,9 @@ trait TableStates
 
     protected bool $isVertical = false;
 
-    protected ?Closure $verticalTitleCallback = null;
+    protected null|Closure|int $verticalTitleCallback = null;
 
-    protected ?Closure $verticalValueCallback = null;
+    protected null|Closure|int $verticalValueCallback = null;
 
     protected bool $isEditable = false;
 
@@ -88,10 +88,10 @@ trait TableStates
     }
 
     /**
-     * @param  ?Closure(FieldContract $field, ComponentContract $default, static $ctx): ComponentContract  $title
-     * @param  ?Closure(FieldContract $field, ComponentContract $default, static $ctx): ComponentContract  $value
+     * @param  null|int|Closure(FieldContract $field, ComponentContract $default, static $ctx): ComponentContract  $title
+     * @param  null|int|Closure(FieldContract $field, ComponentContract $default, static $ctx): ComponentContract  $value
      */
-    public function vertical(?Closure $title = null, ?Closure $value = null): static
+    public function vertical(null|Closure|int $title = null, null|Closure|int $value = null): static
     {
         $this->isVertical = true;
         $this->verticalTitleCallback = $title;


### PR DESCRIPTION
## What was changed
TableBuilder vertical mode:
- Default colspans 1-11 to 2-10
- Ability to pass integer values

## Why?
There were problems with modal windows

  ## Checklist

- Tested
  - [x] Tested manually
  - [ ] Tests added
- [ ] Documentation
