### PR TITLE
Commands refactoring

### DIFF
--- a/src/Laravel/src/Commands/InstallCommand.php
+++ b/src/Laravel/src/Commands/InstallCommand.php
@@ -72,7 +72,7 @@ class InstallCommand extends MoonShineCommand
         }
 
         if (! $this->testsMode) {
-            confirm('Can you quickly star our GitHub repository? 🙏🏻', true);
+            confirm('Can you quickly star our GitHub repository? 🙏🏻');
 
             $this->components->bulletList([
                 'Star or contribute to MoonShine: https://github.com/moonshine-software/moonshine',
@@ -259,7 +259,7 @@ class InstallCommand extends MoonShineCommand
             );
         }
 
-        $this->makeDir($this->getDirectory() . '/Resources');
+        $this->makeDir($this->getDirectory('/Resources'));
 
         $this->components->task('Resources directory created');
     }
@@ -283,10 +283,14 @@ class InstallCommand extends MoonShineCommand
         $this->components->task('Dashboard created');
     }
 
-
     protected function initLayout(): void
     {
-        $compact = $this->confirmAction('Want to use a minimalist theme?', skipOption: 'default-layout', autoEnable: $this->testsMode, default: false);
+        $compact = $this->confirmAction(
+            'Want to use a minimalist theme?',
+            skipOption: 'default-layout',
+            autoEnable: $this->testsMode,
+            default: false,
+        );
 
         $this->call(MakeLayoutCommand::class, [
             'className' => 'MoonShineLayout',
@@ -323,7 +327,10 @@ class InstallCommand extends MoonShineCommand
 
     private function registerServiceProvider(): void
     {
-        if (method_exists(ServiceProvider::class, 'addProviderToBootstrapFile') && file_exists(base_path('bootstrap/app.php'))) {
+        if (
+            method_exists(ServiceProvider::class, 'addProviderToBootstrapFile')
+            && file_exists(base_path('bootstrap/app.php'))
+        ) {
             // @phpstan-ignore-next-line
             ServiceProvider::addProviderToBootstrapFile(\App\Providers\MoonShineServiceProvider::class);
 

--- a/src/Laravel/src/Commands/MakeApplyCommand.php
+++ b/src/Laravel/src/Commands/MakeApplyCommand.php
@@ -30,7 +30,7 @@ class MakeApplyCommand extends MoonShineCommand
         $appliesDir = $this->getDirectory('/Applies');
         $apply = "$appliesDir/$className.php";
 
-        $this->ensureMakeDir($appliesDir);
+        $this->makeDir($appliesDir);
 
         $this->copyStub('Apply', $apply, [
             '{namespace}' => moonshineConfig()->getNamespace('\Applies'),

--- a/src/Laravel/src/Commands/MakeApplyCommand.php
+++ b/src/Laravel/src/Commands/MakeApplyCommand.php
@@ -30,7 +30,7 @@ class MakeApplyCommand extends MoonShineCommand
         $appliesDir = $this->getDirectory('/Applies');
         $apply = "$appliesDir/$className.php";
 
-        $this->makeDirectory($appliesDir);
+        $this->ensureMakeDir($appliesDir);
 
         $this->copyStub('Apply', $apply, [
             '{namespace}' => moonshineConfig()->getNamespace('\Applies'),

--- a/src/Laravel/src/Commands/MakeApplyCommand.php
+++ b/src/Laravel/src/Commands/MakeApplyCommand.php
@@ -6,8 +6,7 @@ namespace MoonShine\Laravel\Commands;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-use function Laravel\Prompts\outro;
-use function Laravel\Prompts\text;
+use function Laravel\Prompts\{outro, text};
 
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -28,11 +27,10 @@ class MakeApplyCommand extends MoonShineCommand
             required: true
         );
 
-        $apply = $this->getDirectory() . "/Applies/$className.php";
+        $appliesDir = $this->getDirectory('/Applies');
+        $apply = "$appliesDir/$className.php";
 
-        if (! is_dir($this->getDirectory() . '/Applies')) {
-            $this->makeDir($this->getDirectory() . '/Applies');
-        }
+        $this->makeDirectory($appliesDir);
 
         $this->copyStub('Apply', $apply, [
             '{namespace}' => moonshineConfig()->getNamespace('\Applies'),
@@ -40,11 +38,7 @@ class MakeApplyCommand extends MoonShineCommand
         ]);
 
         outro(
-            "$className was created: " . str_replace(
-                base_path(),
-                '',
-                $apply
-            )
+            "$className was created: " . $this->getRelativePath($apply)
         );
 
         return self::SUCCESS;

--- a/src/Laravel/src/Commands/MakeComponentCommand.php
+++ b/src/Laravel/src/Commands/MakeComponentCommand.php
@@ -6,8 +6,7 @@ namespace MoonShine\Laravel\Commands;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-use function Laravel\Prompts\outro;
-use function Laravel\Prompts\text;
+use function Laravel\Prompts\{outro, text};
 
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -41,42 +40,33 @@ class MakeComponentCommand extends MoonShineCommand
             required: true
         );
 
-        $component = $this->getDirectory() . "/Components/$className.php";
+        $componentsDir = $this->getDirectory('/Components');
+        $componentPath = "$componentsDir/$className.php";
 
-        if (! is_dir($this->getDirectory() . '/Components')) {
-            $this->makeDir($this->getDirectory() . '/Components');
-        }
+        $this->makeDirectory($componentsDir);
 
         $view = str_replace('.blade.php', '', $view);
         $viewPath = resource_path('views/' . str_replace('.', DIRECTORY_SEPARATOR, $view));
         $viewPath .= '.blade.php';
 
-        if (! is_dir(\dirname($viewPath))) {
-            $this->makeDir(\dirname($viewPath));
-        }
+        $this->makeDirectory(
+            \dirname($viewPath)
+        );
 
         $this->copyStub('view', $viewPath);
 
-        $this->copyStub('Component', $component, [
+        $this->copyStub('Component', $componentPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\Components'),
             '{view}' => $view,
             'DummyClass' => $className,
         ]);
 
         outro(
-            "$className was created: " . str_replace(
-                base_path(),
-                '',
-                $component
-            )
+            "$className was created: " . $this->getRelativePath($componentPath)
         );
 
         outro(
-            "View was created: " . str_replace(
-                base_path(),
-                '',
-                $viewPath
-            )
+            "View was created: " . $this->getRelativePath($viewPath)
         );
 
         return self::SUCCESS;

--- a/src/Laravel/src/Commands/MakeComponentCommand.php
+++ b/src/Laravel/src/Commands/MakeComponentCommand.php
@@ -43,13 +43,13 @@ class MakeComponentCommand extends MoonShineCommand
         $componentsDir = $this->getDirectory('/Components');
         $componentPath = "$componentsDir/$className.php";
 
-        $this->ensureMakeDir($componentsDir);
+        $this->makeDir($componentsDir);
 
         $view = str_replace('.blade.php', '', $view);
         $viewPath = resource_path('views/' . str_replace('.', DIRECTORY_SEPARATOR, $view));
         $viewPath .= '.blade.php';
 
-        $this->ensureMakeDir(
+        $this->makeDir(
             \dirname($viewPath)
         );
 

--- a/src/Laravel/src/Commands/MakeComponentCommand.php
+++ b/src/Laravel/src/Commands/MakeComponentCommand.php
@@ -43,13 +43,13 @@ class MakeComponentCommand extends MoonShineCommand
         $componentsDir = $this->getDirectory('/Components');
         $componentPath = "$componentsDir/$className.php";
 
-        $this->makeDirectory($componentsDir);
+        $this->ensureMakeDir($componentsDir);
 
         $view = str_replace('.blade.php', '', $view);
         $viewPath = resource_path('views/' . str_replace('.', DIRECTORY_SEPARATOR, $view));
         $viewPath .= '.blade.php';
 
-        $this->makeDirectory(
+        $this->ensureMakeDir(
             \dirname($viewPath)
         );
 

--- a/src/Laravel/src/Commands/MakeControllerCommand.php
+++ b/src/Laravel/src/Commands/MakeControllerCommand.php
@@ -30,7 +30,7 @@ class MakeControllerCommand extends MoonShineCommand
         $controllersDir = $this->getDirectory('/Controllers');
         $controllerPath = "$controllersDir/$name.php";
 
-        $this->ensureMakeDir($controllersDir);
+        $this->makeDir($controllersDir);
 
         $this->copyStub('Controller', $controllerPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\Controllers'),

--- a/src/Laravel/src/Commands/MakeControllerCommand.php
+++ b/src/Laravel/src/Commands/MakeControllerCommand.php
@@ -30,7 +30,7 @@ class MakeControllerCommand extends MoonShineCommand
         $controllersDir = $this->getDirectory('/Controllers');
         $controllerPath = "$controllersDir/$name.php";
 
-        $this->makeDirectory($controllersDir);
+        $this->ensureMakeDir($controllersDir);
 
         $this->copyStub('Controller', $controllerPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\Controllers'),

--- a/src/Laravel/src/Commands/MakeControllerCommand.php
+++ b/src/Laravel/src/Commands/MakeControllerCommand.php
@@ -6,15 +6,14 @@ namespace MoonShine\Laravel\Commands;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-use function Laravel\Prompts\outro;
-use function Laravel\Prompts\text;
+use function Laravel\Prompts\{outro, text};
 
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'moonshine:controller')]
 class MakeControllerCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:controller {className?}';
+    protected $signature = 'moonshine:controller {name?}';
 
     protected $description = 'Create controller';
 
@@ -23,28 +22,23 @@ class MakeControllerCommand extends MoonShineCommand
      */
     public function handle(): int
     {
-        $className = $this->argument('className') ?? text(
+        $name = $this->argument('name') ?? text(
             'Class name',
             required: true
         );
 
-        $controller = $this->getDirectory() . "/Controllers/$className.php";
+        $controllersDir = $this->getDirectory('/Controllers');
+        $controllerPath = "$controllersDir/$name.php";
 
-        if (! is_dir($this->getDirectory() . '/Controllers')) {
-            $this->makeDir($this->getDirectory() . '/Controllers');
-        }
+        $this->makeDirectory($controllersDir);
 
-        $this->copyStub('Controller', $controller, [
+        $this->copyStub('Controller', $controllerPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\Controllers'),
-            'DummyClass' => $className,
+            'DummyClass' => $name,
         ]);
 
         outro(
-            "$className was created: " . str_replace(
-                base_path(),
-                '',
-                $controller
-            )
+            "$name was created: " . $this->getRelativePath($controllerPath)
         );
 
         return self::SUCCESS;

--- a/src/Laravel/src/Commands/MakeFieldCommand.php
+++ b/src/Laravel/src/Commands/MakeFieldCommand.php
@@ -62,7 +62,7 @@ class MakeFieldCommand extends MoonShineCommand
         $fieldsDir = $this->getDirectory('/Fields');
         $fieldPath = "$fieldsDir/$className.php";
 
-        $this->ensureMakeDir($fieldsDir);
+        $this->makeDir($fieldsDir);
 
         $this->copyStub('Field', $fieldPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\Fields'),
@@ -76,7 +76,7 @@ class MakeFieldCommand extends MoonShineCommand
         $viewPath = resource_path('views/' . str_replace('.', DIRECTORY_SEPARATOR, $view));
         $viewPath .= '.blade.php';
 
-        $this->ensureMakeDir(
+        $this->makeDir(
             \dirname($viewPath)
         );
 

--- a/src/Laravel/src/Commands/MakeFieldCommand.php
+++ b/src/Laravel/src/Commands/MakeFieldCommand.php
@@ -62,7 +62,7 @@ class MakeFieldCommand extends MoonShineCommand
         $fieldsDir = $this->getDirectory('/Fields');
         $fieldPath = "$fieldsDir/$className.php";
 
-        $this->makeDirectory($fieldsDir);
+        $this->ensureMakeDir($fieldsDir);
 
         $this->copyStub('Field', $fieldPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\Fields'),
@@ -76,7 +76,7 @@ class MakeFieldCommand extends MoonShineCommand
         $viewPath = resource_path('views/' . str_replace('.', DIRECTORY_SEPARATOR, $view));
         $viewPath .= '.blade.php';
 
-        $this->makeDirectory(
+        $this->ensureMakeDir(
             \dirname($viewPath)
         );
 

--- a/src/Laravel/src/Commands/MakeFieldCommand.php
+++ b/src/Laravel/src/Commands/MakeFieldCommand.php
@@ -7,9 +7,7 @@ namespace MoonShine\Laravel\Commands;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Facades\File;
 
-use function Laravel\Prompts\outro;
-use function Laravel\Prompts\select;
-use function Laravel\Prompts\text;
+use function Laravel\Prompts\{outro, select, text};
 
 use MoonShine\UI\Fields\Field;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -61,13 +59,12 @@ class MakeFieldCommand extends MoonShineCommand
             Field::class
         );
 
-        $field = $this->getDirectory() . "/Fields/$className.php";
+        $fieldsDir = $this->getDirectory('/Fields');
+        $fieldPath = "$fieldsDir/$className.php";
 
-        if (! is_dir($this->getDirectory() . '/Fields')) {
-            $this->makeDir($this->getDirectory() . '/Fields');
-        }
+        $this->makeDirectory($fieldsDir);
 
-        $this->copyStub('Field', $field, [
+        $this->copyStub('Field', $fieldPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\Fields'),
             '{view}' => $view,
             '{extend}' => $extends,
@@ -79,26 +76,18 @@ class MakeFieldCommand extends MoonShineCommand
         $viewPath = resource_path('views/' . str_replace('.', DIRECTORY_SEPARATOR, $view));
         $viewPath .= '.blade.php';
 
-        if (! is_dir(\dirname($viewPath))) {
-            $this->makeDir(\dirname($viewPath));
-        }
+        $this->makeDirectory(
+            \dirname($viewPath)
+        );
 
         $this->copyStub('view', $viewPath);
 
         outro(
-            "$className was created: " . str_replace(
-                base_path(),
-                '',
-                $field
-            )
+            "$className was created: " . $this->getRelativePath($fieldPath)
         );
 
         outro(
-            "View was created: " . str_replace(
-                base_path(),
-                '',
-                $viewPath
-            )
+            "View was created: " . $this->getRelativePath($viewPath)
         );
 
         return self::SUCCESS;

--- a/src/Laravel/src/Commands/MakeHandlerCommand.php
+++ b/src/Laravel/src/Commands/MakeHandlerCommand.php
@@ -30,7 +30,7 @@ class MakeHandlerCommand extends MoonShineCommand
         $handlersDir = $this->getDirectory() . '/Handlers';
         $handlerPath = "$handlersDir/$className.php";
 
-        $this->ensureMakeDir($handlersDir);
+        $this->makeDir($handlersDir);
 
         $this->copyStub('Handler', $handlerPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\Handlers'),

--- a/src/Laravel/src/Commands/MakeHandlerCommand.php
+++ b/src/Laravel/src/Commands/MakeHandlerCommand.php
@@ -30,7 +30,7 @@ class MakeHandlerCommand extends MoonShineCommand
         $handlersDir = $this->getDirectory() . '/Handlers';
         $handlerPath = "$handlersDir/$className.php";
 
-        $this->makeDirectory($handlersDir);
+        $this->ensureMakeDir($handlersDir);
 
         $this->copyStub('Handler', $handlerPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\Handlers'),

--- a/src/Laravel/src/Commands/MakeHandlerCommand.php
+++ b/src/Laravel/src/Commands/MakeHandlerCommand.php
@@ -27,23 +27,18 @@ class MakeHandlerCommand extends MoonShineCommand
             required: true
         );
 
-        $path = $this->getDirectory() . "/Handlers/$className.php";
+        $handlersDir = $this->getDirectory() . '/Handlers';
+        $handlerPath = "$handlersDir/$className.php";
 
-        if (! is_dir($this->getDirectory() . '/Handlers')) {
-            $this->makeDir($this->getDirectory() . '/Handlers');
-        }
+        $this->makeDirectory($handlersDir);
 
-        $this->copyStub('Handler', $path, [
+        $this->copyStub('Handler', $handlerPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\Handlers'),
             'DummyHandler' => $className,
         ]);
 
         outro(
-            "$className was created: " . str_replace(
-                base_path(),
-                '',
-                $path
-            )
+            "$className was created: " . $this->getRelativePath($handlerPath)
         );
 
         return self::SUCCESS;

--- a/src/Laravel/src/Commands/MakeLayoutCommand.php
+++ b/src/Laravel/src/Commands/MakeLayoutCommand.php
@@ -37,7 +37,7 @@ class MakeLayoutCommand extends MoonShineCommand
         $layoutsDir = $this->getDirectory() . "/$dir";
         $layoutPath = "$layoutsDir/$className.php";
 
-        $this->makeDirectory($layoutsDir);
+        $this->ensureMakeDir($layoutsDir);
 
         $compact = ! $this->option('full') && ($this->option('compact') || confirm('Want to use a minimalist theme?'));
 

--- a/src/Laravel/src/Commands/MakeLayoutCommand.php
+++ b/src/Laravel/src/Commands/MakeLayoutCommand.php
@@ -6,9 +6,7 @@ namespace MoonShine\Laravel\Commands;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-use function Laravel\Prompts\confirm;
-use function Laravel\Prompts\outro;
-use function Laravel\Prompts\text;
+use function Laravel\Prompts\{confirm, outro, text};
 
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -36,18 +34,17 @@ class MakeLayoutCommand extends MoonShineCommand
             $dir = 'Layouts';
         }
 
-        $layout = $this->getDirectory() . "/$dir/$className.php";
+        $layoutsDir = $this->getDirectory() . "/$dir";
+        $layoutPath = "$layoutsDir/$className.php";
 
-        if (! is_dir($this->getDirectory() . "/$dir")) {
-            $this->makeDir($this->getDirectory() . "/$dir");
-        }
+        $this->makeDirectory($layoutsDir);
 
         $compact = ! $this->option('full') && ($this->option('compact') || confirm('Want to use a minimalist theme?'));
 
         $extendClassName = $compact ? 'CompactLayout' : 'AppLayout';
         $extends = "MoonShine\Laravel\Layouts\\$extendClassName";
 
-        $this->copyStub('Layout', $layout, [
+        $this->copyStub('Layout', $layoutPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\\' . str_replace('/', '\\', $dir)),
             '{extend}' => $extends,
             '{extendShort}' => class_basename($extends),
@@ -55,11 +52,7 @@ class MakeLayoutCommand extends MoonShineCommand
         ]);
 
         outro(
-            "$className was created: " . str_replace(
-                base_path(),
-                '',
-                $layout
-            )
+            "$className was created: " . $this->getRelativePath($layoutPath)
         );
 
         if ($this->option('default') || confirm('Use the default template in the system?')) {

--- a/src/Laravel/src/Commands/MakeLayoutCommand.php
+++ b/src/Laravel/src/Commands/MakeLayoutCommand.php
@@ -37,7 +37,7 @@ class MakeLayoutCommand extends MoonShineCommand
         $layoutsDir = $this->getDirectory() . "/$dir";
         $layoutPath = "$layoutsDir/$className.php";
 
-        $this->ensureMakeDir($layoutsDir);
+        $this->makeDir($layoutsDir);
 
         $compact = ! $this->option('full') && ($this->option('compact') || confirm('Want to use a minimalist theme?'));
 

--- a/src/Laravel/src/Commands/MakePageCommand.php
+++ b/src/Laravel/src/Commands/MakePageCommand.php
@@ -86,7 +86,7 @@ class MakePageCommand extends MoonShineCommand
         $pagesDir = $this->getDirectory("/$dir");
         $pagePath = "$pagesDir/$className.php";
 
-        $this->makeDirectory($pagesDir);
+        $this->ensureMakeDir($pagesDir);
 
         $this->copyStub($stub, $pagePath, [
             '{namespace}' => moonshineConfig()->getNamespace('\\' . str_replace('/', '\\', $dir)),

--- a/src/Laravel/src/Commands/MakePageCommand.php
+++ b/src/Laravel/src/Commands/MakePageCommand.php
@@ -6,9 +6,7 @@ namespace MoonShine\Laravel\Commands;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-use function Laravel\Prompts\outro;
-use function Laravel\Prompts\select;
-use function Laravel\Prompts\text;
+use function Laravel\Prompts\{outro, select, text};
 
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -85,13 +83,12 @@ class MakePageCommand extends MoonShineCommand
         $dir = \is_null($dir) ? 'Pages' : $dir;
         $extends = $extends === null || $extends === '' || $extends === '0' ? 'Page' : $extends;
 
-        $page = $this->getDirectory() . "/$dir/$className.php";
+        $pagesDir = $this->getDirectory("/$dir");
+        $pagePath = "$pagesDir/$className.php";
 
-        if (! is_dir($this->getDirectory() . "/$dir")) {
-            $this->makeDir($this->getDirectory() . "/$dir");
-        }
+        $this->makeDirectory($pagesDir);
 
-        $this->copyStub($stub, $page, [
+        $this->copyStub($stub, $pagePath, [
             '{namespace}' => moonshineConfig()->getNamespace('\\' . str_replace('/', '\\', $dir)),
             'DummyPage' => $className,
             'DummyTitle' => $className,
@@ -99,11 +96,7 @@ class MakePageCommand extends MoonShineCommand
         ]);
 
         outro(
-            "$className was created: " . str_replace(
-                base_path(),
-                '',
-                $page
-            )
+            "$className was created: " . $this->getRelativePath($pagePath)
         );
 
         if (! $this->option('without-register')) {

--- a/src/Laravel/src/Commands/MakePageCommand.php
+++ b/src/Laravel/src/Commands/MakePageCommand.php
@@ -86,7 +86,7 @@ class MakePageCommand extends MoonShineCommand
         $pagesDir = $this->getDirectory("/$dir");
         $pagePath = "$pagesDir/$className.php";
 
-        $this->ensureMakeDir($pagesDir);
+        $this->makeDir($pagesDir);
 
         $this->copyStub($stub, $pagePath, [
             '{namespace}' => moonshineConfig()->getNamespace('\\' . str_replace('/', '\\', $dir)),

--- a/src/Laravel/src/Commands/MakePolicyCommand.php
+++ b/src/Laravel/src/Commands/MakePolicyCommand.php
@@ -46,7 +46,7 @@ class MakePolicyCommand extends MoonShineCommand
         $policiesDir = app_path('/Policies');
         $policyPath = "$policiesDir/$className.php";
 
-        $this->makeDirectory($policiesDir);
+        $this->ensureMakeDir($policiesDir);
 
         $this->copyStub('Policy', $policyPath, [
             'DummyClass' => $className,

--- a/src/Laravel/src/Commands/MakePolicyCommand.php
+++ b/src/Laravel/src/Commands/MakePolicyCommand.php
@@ -46,7 +46,7 @@ class MakePolicyCommand extends MoonShineCommand
         $policiesDir = app_path('/Policies');
         $policyPath = "$policiesDir/$className.php";
 
-        $this->ensureMakeDir($policiesDir);
+        $this->makeDir($policiesDir);
 
         $this->copyStub('Policy', $policyPath, [
             'DummyClass' => $className,

--- a/src/Laravel/src/Commands/MakePolicyCommand.php
+++ b/src/Laravel/src/Commands/MakePolicyCommand.php
@@ -6,8 +6,7 @@ namespace MoonShine\Laravel\Commands;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
-use function Laravel\Prompts\outro;
-use function Laravel\Prompts\suggest;
+use function Laravel\Prompts\{outro, suggest};
 
 use MoonShine\Laravel\MoonShineAuth;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -27,27 +26,29 @@ class MakePolicyCommand extends MoonShineCommand
     {
         $modelPath = is_dir(app_path('Models')) ? app_path('Models') : app_path();
 
-        if (! $className = $this->argument('className')) {
-            $className = suggest(
-                label: 'Model',
-                options: collect((new Finder())->files()->depth(0)->in($modelPath))
-                    ->map(static fn ($file) => $file->getBasename('.php'))
-                    ->values()
-                    ->all(),
-                required: true,
-            );
-        }
+        $className = $this->argument('className') ?? suggest(
+            label: 'Model',
+            options: collect((new Finder())->files()->depth(0)->in($modelPath))
+                ->map(static fn ($file) => $file->getBasename('.php'))
+                ->values()
+                ->all(),
+            required: true,
+        );
+
+        $className = str($className)
+            ->ucfirst()
+            ->remove('policy', false)
+            ->value();
 
         $model = $this->qualifyModel($className);
-        $className = class_basename($model) . "Policy";
+        $className = class_basename($model) . 'Policy';
 
-        $path = app_path("/Policies/$className.php");
+        $policiesDir = app_path('/Policies');
+        $policyPath = "$policiesDir/$className.php";
 
-        if (! is_dir(app_path('/Policies'))) {
-            $this->makeDir(app_path('/Policies'));
-        }
+        $this->makeDirectory($policiesDir);
 
-        $this->copyStub('Policy', $path, [
+        $this->copyStub('Policy', $policyPath, [
             'DummyClass' => $className,
             '{model-namespace}' => $model,
             '{model}' => class_basename($model),
@@ -56,11 +57,7 @@ class MakePolicyCommand extends MoonShineCommand
         ]);
 
         outro(
-            "$className was created: " . str_replace(
-                base_path(),
-                '',
-                $path
-            )
+            "$className was created: " . $this->getRelativePath($policyPath)
         );
 
         return self::SUCCESS;

--- a/src/Laravel/src/Commands/MakeResourceCommand.php
+++ b/src/Laravel/src/Commands/MakeResourceCommand.php
@@ -39,7 +39,7 @@ class MakeResourceCommand extends MoonShineCommand
 
         $resource = "$resourcesDir/{$name}Resource.php";
 
-        $this->ensureMakeDir($resourcesDir);
+        $this->makeDir($resourcesDir);
 
         $stub = select('Resource type', [
             'ModelResourceDefault' => 'Default model resource',

--- a/src/Laravel/src/Commands/MakeResourceCommand.php
+++ b/src/Laravel/src/Commands/MakeResourceCommand.php
@@ -39,7 +39,7 @@ class MakeResourceCommand extends MoonShineCommand
 
         $resource = "$resourcesDir/{$name}Resource.php";
 
-        $this->makeDirectory($resourcesDir);
+        $this->ensureMakeDir($resourcesDir);
 
         $stub = select('Resource type', [
             'ModelResourceDefault' => 'Default model resource',

--- a/src/Laravel/src/Commands/MakeTypeCastCommand.php
+++ b/src/Laravel/src/Commands/MakeTypeCastCommand.php
@@ -27,23 +27,18 @@ class MakeTypeCastCommand extends MoonShineCommand
             required: true
         );
 
-        $path = $this->getDirectory() . "/TypeCasts/$className.php";
+        $typeCastsDir = $this->getDirectory('/TypeCasts');
+        $typeCastPath = "$typeCastsDir/$className.php";
 
-        if (! is_dir($this->getDirectory() . '/TypeCasts')) {
-            $this->makeDir($this->getDirectory() . '/TypeCasts');
-        }
+        $this->makeDirectory($typeCastsDir);
 
-        $this->copyStub('TypeCast', $path, [
+        $this->copyStub('TypeCast', $typeCastPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\TypeCasts'),
             'DummyCast' => $className,
         ]);
 
         outro(
-            "$className was created: " . str_replace(
-                base_path(),
-                '',
-                $path
-            )
+            "$className was created: " . $this->getRelativePath($typeCastPath)
         );
 
         return self::SUCCESS;

--- a/src/Laravel/src/Commands/MakeTypeCastCommand.php
+++ b/src/Laravel/src/Commands/MakeTypeCastCommand.php
@@ -30,7 +30,7 @@ class MakeTypeCastCommand extends MoonShineCommand
         $typeCastsDir = $this->getDirectory('/TypeCasts');
         $typeCastPath = "$typeCastsDir/$className.php";
 
-        $this->makeDirectory($typeCastsDir);
+        $this->ensureMakeDir($typeCastsDir);
 
         $this->copyStub('TypeCast', $typeCastPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\TypeCasts'),

--- a/src/Laravel/src/Commands/MakeTypeCastCommand.php
+++ b/src/Laravel/src/Commands/MakeTypeCastCommand.php
@@ -30,7 +30,7 @@ class MakeTypeCastCommand extends MoonShineCommand
         $typeCastsDir = $this->getDirectory('/TypeCasts');
         $typeCastPath = "$typeCastsDir/$className.php";
 
-        $this->ensureMakeDir($typeCastsDir);
+        $this->makeDir($typeCastsDir);
 
         $this->copyStub('TypeCast', $typeCastPath, [
             '{namespace}' => moonshineConfig()->getNamespace('\TypeCasts'),

--- a/src/Laravel/src/Commands/MakeUserCommand.php
+++ b/src/Laravel/src/Commands/MakeUserCommand.php
@@ -26,7 +26,7 @@ class MakeUserCommand extends MoonShineCommand
         $password = $this->option('password') ?? password('Password');
 
         if ($username && $name && $password) {
-            MoonShineAuth::getModel()->query()->create([
+            MoonShineAuth::getModel()::query()->create([
                 moonshineConfig()->getUserField('username', 'email') => $username,
                 moonshineConfig()->getUserField('name') => $name,
                 moonshineConfig()->getUserField('password') => Hash::make($password),
@@ -53,8 +53,7 @@ class MakeUserCommand extends MoonShineCommand
                 required: true
             );
 
-            $exists = MoonShineAuth::getModel()
-                ->query()
+            $exists = MoonShineAuth::getModel()::query()
                 ->where(
                     moonshineConfig()->getUserField('username', 'email'),
                     $username,

--- a/src/Laravel/src/Commands/MoonShineCommand.php
+++ b/src/Laravel/src/Commands/MoonShineCommand.php
@@ -18,13 +18,6 @@ abstract class MoonShineCommand extends Command
         return moonshineConfig()->getDir($path);
     }
 
-    protected function makeDir(string $path): void
-    {
-        if (! is_dir($path)) {
-            parent::makeDir($path);
-        }
-    }
-
     protected function getRelativePath(string $path): string
     {
         return str_replace(base_path(), '', $path);

--- a/src/Laravel/src/Commands/MoonShineCommand.php
+++ b/src/Laravel/src/Commands/MoonShineCommand.php
@@ -18,7 +18,7 @@ abstract class MoonShineCommand extends Command
         return moonshineConfig()->getDir($path);
     }
 
-    protected function makeDirectory(string $path): void
+    protected function ensureMakeDir(string $path): void
     {
         if (! is_dir($path)) {
             $this->makeDir($path);

--- a/src/Laravel/src/Commands/MoonShineCommand.php
+++ b/src/Laravel/src/Commands/MoonShineCommand.php
@@ -18,10 +18,10 @@ abstract class MoonShineCommand extends Command
         return moonshineConfig()->getDir($path);
     }
 
-    protected function ensureMakeDir(string $path): void
+    protected function makeDir(string $path): void
     {
         if (! is_dir($path)) {
-            $this->makeDir($path);
+            parent::makeDir($path);
         }
     }
 

--- a/src/Laravel/src/Commands/MoonShineCommand.php
+++ b/src/Laravel/src/Commands/MoonShineCommand.php
@@ -13,9 +13,21 @@ abstract class MoonShineCommand extends Command
 {
     protected string $stubsDir = __DIR__ . '/../../stubs';
 
-    protected function getDirectory(): string
+    protected function getDirectory(string $path = ''): string
     {
-        return moonshineConfig()->getDir();
+        return moonshineConfig()->getDir($path);
+    }
+
+    protected function makeDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            $this->makeDir($path);
+        }
+    }
+
+    protected function getRelativePath(string $path): string
+    {
+        return str_replace(base_path(), '', $path);
     }
 
     public static function addResourceOrPageToProviderFile(string $class, bool $page = false, string $prefix = ''): void
@@ -38,7 +50,7 @@ abstract class MoonShineCommand extends Command
             to: app_path('MoonShine/Layouts/MoonShineLayout.php'),
             isPage: $page,
             between: static fn (Stringable $content): Stringable => $content->betweenFirst("protected function menu(): array", '}'),
-            replace: static fn (Stringable $content, Closure $tab): Stringable => $content->replace("];", "{$tab()}MenuItem::make('{$title}', $class::class),\n{$tab(2)}];"),
+            replace: static fn (Stringable $content, Closure $tab): Stringable => $content->replace("];", "{$tab()}MenuItem::make('$title', $class::class),\n{$tab(2)}];"),
             use: MenuItem::class,
         );
     }

--- a/src/Laravel/src/Commands/PublishCommand.php
+++ b/src/Laravel/src/Commands/PublishCommand.php
@@ -151,7 +151,7 @@ class PublishCommand extends MoonShineCommand
 
     private function publishSystemForm(string $className, string $configKey): void
     {
-        $this->makeDirectory($this->getDirectory('/Forms'));
+        $this->ensureMakeDir($this->getDirectory('/Forms'));
 
         $this->copySystemClass($className, 'Forms');
 
@@ -190,7 +190,7 @@ class PublishCommand extends MoonShineCommand
 
     private function publishSystemPage(string $className, string $configKey): void
     {
-        $this->makeDirectory($this->getDirectory('/Pages'));
+        $this->ensureMakeDir($this->getDirectory('/Pages'));
 
         $copyInfo = $this->copySystemClass($className, 'Pages');
 

--- a/src/Laravel/src/Commands/PublishCommand.php
+++ b/src/Laravel/src/Commands/PublishCommand.php
@@ -151,7 +151,7 @@ class PublishCommand extends MoonShineCommand
 
     private function publishSystemForm(string $className, string $configKey): void
     {
-        $this->ensureMakeDir($this->getDirectory('/Forms'));
+        $this->makeDir($this->getDirectory('/Forms'));
 
         $this->copySystemClass($className, 'Forms');
 
@@ -190,7 +190,7 @@ class PublishCommand extends MoonShineCommand
 
     private function publishSystemPage(string $className, string $configKey): void
     {
-        $this->ensureMakeDir($this->getDirectory('/Pages'));
+        $this->makeDir($this->getDirectory('/Pages'));
 
         $copyInfo = $this->copySystemClass($className, 'Pages');
 

--- a/src/Laravel/src/Commands/PublishCommand.php
+++ b/src/Laravel/src/Commands/PublishCommand.php
@@ -151,9 +151,7 @@ class PublishCommand extends MoonShineCommand
 
     private function publishSystemForm(string $className, string $configKey): void
     {
-        if (! is_dir($this->getDirectory() . "/Forms")) {
-            $this->makeDir($this->getDirectory() . "/Forms");
-        }
+        $this->makeDirectory($this->getDirectory('/Forms'));
 
         $this->copySystemClass($className, 'Forms');
 
@@ -192,9 +190,7 @@ class PublishCommand extends MoonShineCommand
 
     private function publishSystemPage(string $className, string $configKey): void
     {
-        if (! is_dir($this->getDirectory() . "/Pages")) {
-            $this->makeDir($this->getDirectory() . "/Pages");
-        }
+        $this->makeDirectory($this->getDirectory('/Pages'));
 
         $copyInfo = $this->copySystemClass($className, 'Pages');
 


### PR DESCRIPTION
Решил немного отрефакторить команду перед добавлением опции **--policy**

Заметил, что во многих командах присутствует подобная конструкция:
```
if (! is_dir("$moonshineDir/Resources")) {
    $this->makeDir("$moonshineDir/Resources");
}
```
может есть смысл заменить её на `(new Filesystem)->ensureDirectoryExists`, чтобы не делать каждый раз проверку существования директории?