### PR TITLE
fix: Moonshine command for create policy class

### DIFF
--- a/src/Laravel/src/Commands/MakePolicyCommand.php
+++ b/src/Laravel/src/Commands/MakePolicyCommand.php
@@ -34,6 +34,7 @@ class MakePolicyCommand extends MoonShineCommand
                     ->map(static fn ($file) => $file->getBasename('.php'))
                     ->values()
                     ->all(),
+                required: true,
             );
         }
 

--- a/src/Laravel/src/Commands/MakePolicyCommand.php
+++ b/src/Laravel/src/Commands/MakePolicyCommand.php
@@ -27,13 +27,15 @@ class MakePolicyCommand extends MoonShineCommand
     {
         $modelPath = is_dir(app_path('Models')) ? app_path('Models') : app_path();
 
-        $className = suggest(
-            'Model',
-            collect((new Finder())->files()->depth(0)->in($modelPath))
-                ->map(static fn ($file) => $file->getBasename('.php'))
-                ->values()
-                ->all()
-        );
+        if (! $className = $this->argument('className')) {
+            $className = suggest(
+                label: 'Model',
+                options: collect((new Finder())->files()->depth(0)->in($modelPath))
+                    ->map(static fn ($file) => $file->getBasename('.php'))
+                    ->values()
+                    ->all(),
+            );
+        }
 
         $model = $this->qualifyModel($className);
         $className = class_basename($model) . "Policy";


### PR DESCRIPTION
Поправил команду, создающую policy. 
Проблему описал в [Issue #1392](https://github.com/moonshine-software/moonshine/issues/1392 ) 