### PR TITLE
fix: show when style.display

### DIFF
--- a/src/UI/resources/js/Support/ShowWhen.js
+++ b/src/UI/resources/js/Support/ShowWhen.js
@@ -184,7 +184,7 @@ function showHideTableInputs(isShow, table, fieldName, showWhenSubmit) {
       if (element.cellIndex !== cellIndexTd) {
         return
       }
-      element.style.display = isShow ? 'block' : 'none'
+      element.style.display = isShow ? null : 'none'
     })
   }
 }


### PR DESCRIPTION
## What was changed
After applying showWhen, table styles no longer break

  ## Checklist
  - Issue [1395](https://github.com/moonshine-software/moonshine/issues/1395)
