### PR TITLE
feat: sticky columns

### DIFF
--- a/src/UI/resources/css/components/tables.css
+++ b/src/UI/resources/css/components/tables.css
@@ -125,8 +125,10 @@ table {
 }
 
 /* Sticky Columns */
-th, td {
-  &.sticky-col--right, &.sticky-col--left {
+th,
+td {
+  &.sticky-col--right,
+  &.sticky-col--left {
     @apply sticky bg-white dark:bg-dark-600;
   }
   &.sticky-col--right {
@@ -138,7 +140,8 @@ th, td {
 }
 
 th {
-  &.sticky-col--right, &.sticky-col--left {
+  &.sticky-col--right,
+  &.sticky-col--left {
     @apply bg-slate-50 p-4 dark:bg-dark-700;
   }
 }

--- a/src/UI/resources/css/components/tables.css
+++ b/src/UI/resources/css/components/tables.css
@@ -123,3 +123,22 @@ table {
     @apply sticky -top-1 z-1 bg-slate-50 dark:bg-dark-700;
   }
 }
+
+/* Sticky Columns */
+th, td {
+  &.sticky-col--right, &.sticky-col--left {
+    @apply sticky bg-white dark:bg-dark-600;
+  }
+  &.sticky-col--right {
+    @apply right-0;
+  }
+  &.sticky-col--left {
+    @apply left-0;
+  }
+}
+
+th {
+  &.sticky-col--right, &.sticky-col--left {
+    @apply bg-slate-50 p-4 dark:bg-dark-700;
+  }
+}

--- a/src/UI/resources/css/minimalistic.css
+++ b/src/UI/resources/css/minimalistic.css
@@ -528,6 +528,13 @@ body.theme-minimalistic {
     @apply dark:bg-dark-800;
   }
 
+  /* Sticky Columns */
+  th {
+    &.sticky-col--right, &.sticky-col--left {
+      @apply bg-dark-50 dark:bg-dark-800;
+    }
+  }
+
   /* Alerts */
   .alert {
     @apply gap-x-2 rounded-md p-2;

--- a/src/UI/resources/css/minimalistic.css
+++ b/src/UI/resources/css/minimalistic.css
@@ -530,7 +530,8 @@ body.theme-minimalistic {
 
   /* Sticky Columns */
   th {
-    &.sticky-col--right, &.sticky-col--left {
+    &.sticky-col--right,
+    &.sticky-col--left {
       @apply bg-dark-50 dark:bg-dark-800;
     }
   }


### PR DESCRIPTION
Styles for #1212

- Todo for backend
Need add something like
```php 
Field::make()->sticky()
```

classes:
`sticky-col--right` for all columns after center position
`sticky-col--left` for others

for example - select and ID cols = sticky-col--left, action cols = sticky-col--right

- Issue #1212 
