### PR TITLE
chore: style fix

### DIFF
--- a/src/Laravel/src/Pages/Crud/IndexPage.php
+++ b/src/Laravel/src/Pages/Crud/IndexPage.php
@@ -182,7 +182,7 @@ class IndexPage extends CrudPage
 
                     return $group;
                 }
-            ),
+            )->customAttributes(['class' => 'flex-wrap']),
             LineBreak::make(),
         ];
     }

--- a/src/UI/resources/views/components/layout/flex.blade.php
+++ b/src/UI/resources/views/components/layout/flex.blade.php
@@ -8,7 +8,7 @@
     {{ $attributes
         ->class([
             'sm:flex sm:flex-row',
-            'gap-4' => !$isWithoutSpace,
+            'space-y-4 gap-4' => !$isWithoutSpace,
             'items-' . $itemsAlign,
             'justify-' . $justifyAlign
         ])


### PR DESCRIPTION
## What was changed
- [flex wrap queryTag](https://github.com/moonshine-software/moonshine/commit/03a39b54ea1386511ff455797c2e0c9d9b9f0f65)
-  [space for mobile flex](https://github.com/moonshine-software/moonshine/commit/a5e15b730beefeb00578c5cd51cbfd91195eb139)

## Why?
### Flex wrap queryTag
before:
<img width="1168" alt="Снимок экрана 2024-12-30 в 17 03 47" src="https://github.com/user-attachments/assets/3525c9b0-b398-49f0-90fd-0a8d92d2f6ad" />

after:
<img width="1169" alt="Снимок экрана 2024-12-30 в 17 02 49" src="https://github.com/user-attachments/assets/826cfb17-403f-4289-86f3-9c13464fd5d4" />


### Space for mobile flex
before:
<img width="413" alt="Снимок экрана 2024-12-30 в 17 04 47" src="https://github.com/user-attachments/assets/561edc89-b044-467e-809c-e02fd2410c78" />

after:
<img width="408" alt="Снимок экрана 2024-12-30 в 17 04 26" src="https://github.com/user-attachments/assets/b6de2ccb-54a9-4597-be22-38ab37cce0dd" />

## Checklist

- Issue #1433
- Tested
    - [x] Tested manually
