### PR TITLE
fix: linked-object

### DIFF
--- a/src/UI/resources/js/Support/DispatchEvents.js
+++ b/src/UI/resources/js/Support/DispatchEvents.js
@@ -22,7 +22,7 @@ export function dispatchEvents(events, type, component, extraProperties = {}) {
 
       const attributes = {}
       Object.assign(attributes, extraProperties)
-      
+
       if (Array.isArray(parts) && parts.length > 1) {
         let params = parts[1].split(';')
 

--- a/src/UI/resources/js/Support/DispatchEvents.js
+++ b/src/UI/resources/js/Support/DispatchEvents.js
@@ -20,8 +20,9 @@ export function dispatchEvents(events, type, component, extraProperties = {}) {
 
       let eventName = parts[0]
 
-      let attributes = extraProperties
-
+      const attributes = {}
+      Object.assign(attributes, extraProperties)
+      
       if (Array.isArray(parts) && parts.length > 1) {
         let params = parts[1].split(';')
 


### PR DESCRIPTION
## What was changed
Bug with object link

## Why?
Example:
`click|param1=value1,hover|param2=value2`

The `attributes = extraProperties` line creates a reference to the object, not a copy of it. Because of this, inside the loop `attributes[pair[0]] = pair[1]...` actually adds elements inside the `extraProperties` object. When the loop is called again, `extraProperties` already contains elements from the previous loop. And with our example:
first `$dispath = click, {param1: value1}`
next `$dipatch = hover, {param1: value1, param2: value2}`

In this fix, I made `attributes` a copy, not a reference to the object.

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Tests added
