### PR TITLE
feat: BaseDir/BaseNamespace

### DIFF
--- a/src/Laravel/src/Commands/InstallCommand.php
+++ b/src/Laravel/src/Commands/InstallCommand.php
@@ -277,7 +277,7 @@ class InstallCommand extends MoonShineCommand
 
         $this->replaceInConfig(
             'dashboard',
-            moonshineConfig()->getNamespace('\Pages\Dashboard') . "::class"
+            $this->getNamespace('\Pages\Dashboard') . "::class"
         );
 
         $this->components->task('Dashboard created');

--- a/src/Laravel/src/Commands/MakeApplyCommand.php
+++ b/src/Laravel/src/Commands/MakeApplyCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'moonshine:apply')]
 class MakeApplyCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:apply {className?}';
+    protected $signature = 'moonshine:apply {className?} {--base-dir=} {--base-namespace=}';
 
     protected $description = 'Create apply for Field';
 

--- a/src/Laravel/src/Commands/MakeComponentCommand.php
+++ b/src/Laravel/src/Commands/MakeComponentCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'moonshine:component')]
 class MakeComponentCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:component {className?}';
+    protected $signature = 'moonshine:component {className?} {--base-dir=} {--base-namespace=}';
 
     protected $description = 'Create component';
 
@@ -32,11 +32,7 @@ class MakeComponentCommand extends MoonShineCommand
 
         $view = $this->makeViewFromStub('admin.components', $stubsPath->name, $stubsPath->dir);
 
-        $stubsPath->prependDir(
-            $this->getDirectory('Components')
-        )->prependNamespace(
-            moonshineConfig()->getNamespace('Components')
-        );
+        $stubsPath = $this->qualifyStubsDir($stubsPath, 'Components');
 
         $this->makeDir($stubsPath->dir);
 

--- a/src/Laravel/src/Commands/MakeControllerCommand.php
+++ b/src/Laravel/src/Commands/MakeControllerCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'moonshine:controller')]
 class MakeControllerCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:controller {className?}';
+    protected $signature = 'moonshine:controller {className?} {--base-dir=} {--base-namespace=}';
 
     protected $description = 'Create controller';
 

--- a/src/Laravel/src/Commands/MakeFieldCommand.php
+++ b/src/Laravel/src/Commands/MakeFieldCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Finder\SplFileInfo;
 #[AsCommand(name: 'moonshine:field')]
 class MakeFieldCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:field {className?}';
+    protected $signature = 'moonshine:field {className?} {--base-dir=} {--base-namespace=}';
 
     protected $description = 'Create field';
 
@@ -36,11 +36,7 @@ class MakeFieldCommand extends MoonShineCommand
 
         $view = $this->makeViewFromStub('admin.fields', $stubsPath->name, $stubsPath->dir);
 
-        $stubsPath->prependDir(
-            $this->getDirectory('Fields'),
-        )->prependNamespace(
-            moonshineConfig()->getNamespace('Fields'),
-        );
+        $stubsPath = $this->qualifyStubsDir($stubsPath, 'Fields');
 
         $extends = select('Extends', $this->findExtends(), Field::class);
 

--- a/src/Laravel/src/Commands/MakeHandlerCommand.php
+++ b/src/Laravel/src/Commands/MakeHandlerCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'moonshine:handler')]
 class MakeHandlerCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:handler {className?}';
+    protected $signature = 'moonshine:handler {className?} {--base-dir=} {--base-namespace=}';
 
     protected $description = 'Create handler class';
 

--- a/src/Laravel/src/Commands/MakeLayoutCommand.php
+++ b/src/Laravel/src/Commands/MakeLayoutCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'moonshine:layout')]
 class MakeLayoutCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:layout {className?} {--compact} {--full} {--default} {--dir=}';
+    protected $signature = 'moonshine:layout {className?} {--compact} {--full} {--default} {--dir=} {--base-dir=} {--base-namespace=}';
 
     protected $description = 'Create layout';
 
@@ -32,11 +32,7 @@ class MakeLayoutCommand extends MoonShineCommand
 
         $dir = $this->option('dir') ?: 'Layouts';
 
-        $stubsPath->prependDir(
-            $this->getDirectory($dir),
-        )->prependNamespace(
-            moonshineConfig()->getNamespace($dir),
-        );
+        $stubsPath = $this->qualifyStubsDir($stubsPath, $dir);
 
         $this->makeDir($stubsPath->dir);
 

--- a/src/Laravel/src/Commands/MakePageCommand.php
+++ b/src/Laravel/src/Commands/MakePageCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'moonshine:page')]
 class MakePageCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:page {className?} {--force} {--without-register} {--crud} {--dir=} {--extends=}';
+    protected $signature = 'moonshine:page {className?} {--force} {--without-register} {--crud} {--dir=} {--extends=} {--base-dir=} {--base-namespace=}';
 
     protected $description = 'Create page';
 
@@ -34,11 +34,7 @@ class MakePageCommand extends MoonShineCommand
 
         $dir = $this->option('dir') ?: 'Pages';
 
-        $stubsPath->prependDir(
-            $this->getDirectory($dir),
-        )->prependNamespace(
-            moonshineConfig()->getNamespace($dir),
-        );
+        $stubsPath = $this->qualifyStubsDir($stubsPath, $dir);
 
         if (! $this->option('force') && ! $this->option('extends') && ! $this->option('crud')) {
             $types = [
@@ -70,7 +66,7 @@ class MakePageCommand extends MoonShineCommand
                 $stubsPath->prependDir(
                     $this->getDirectory("$dir/$name"),
                 )->prependNamespace(
-                    moonshineConfig()->getNamespace("$dir\\$name"),
+                    $this->getNamespace("$dir\\$name"),
                 );
 
                 $this->makePage($stubsPath, 'CrudPage', $type);

--- a/src/Laravel/src/Commands/MakeResourceCommand.php
+++ b/src/Laravel/src/Commands/MakeResourceCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'moonshine:resource')]
 class MakeResourceCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:resource {className?} {--type=} {--m|model=} {--t|title=} {--test} {--pest} {--p|policy}';
+    protected $signature = 'moonshine:resource {className?} {--type=} {--m|model=} {--t|title=} {--test} {--pest} {--p|policy} {--base-dir=} {--base-namespace=}';
 
     protected $description = 'Create resource';
 
@@ -42,11 +42,7 @@ class MakeResourceCommand extends MoonShineCommand
             ->remove('resource', false)
             ->value();
 
-        $stubsPath->prependDir(
-            $this->getDirectory('Resources'),
-        )->prependNamespace(
-            moonshineConfig()->getNamespace('Resources'),
-        );
+        $stubsPath = $this->qualifyStubsDir($stubsPath, 'Resources');
 
         $this->makeDir($stubsPath->dir);
 
@@ -95,7 +91,7 @@ class MakeResourceCommand extends MoonShineCommand
                 '--without-register' => true,
             ]);
 
-            $pageNamespace = moonshineConfig()->getNamespace("\Pages\\$name\\$name");
+            $pageNamespace = $this->getNamespace("\Pages\\$name\\$name");
 
             $replace += [
                 '{indexPage}' => "{$name}IndexPage",

--- a/src/Laravel/src/Commands/MakeTypeCastCommand.php
+++ b/src/Laravel/src/Commands/MakeTypeCastCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'moonshine:type-cast')]
 class MakeTypeCastCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:type-cast {className?}';
+    protected $signature = 'moonshine:type-cast {className?} {--base-dir=} {--base-namespace=}';
 
     protected $description = 'Create type cast class';
 

--- a/src/Laravel/src/Commands/MoonShineCommand.php
+++ b/src/Laravel/src/Commands/MoonShineCommand.php
@@ -184,7 +184,7 @@ abstract class MoonShineCommand extends Command
             ->trim('/')
             ->replace('/', '\\')
             ->explode('\\')
-            ->map(static fn(string $segment) => ucfirst($segment))
+            ->map(static fn(string $segment): string => ucfirst($segment))
             ->implode('\\');
 
         if($baseDir !== null && $baseNamespace === null) {

--- a/src/Laravel/src/Commands/MoonShineCommand.php
+++ b/src/Laravel/src/Commands/MoonShineCommand.php
@@ -179,19 +179,19 @@ abstract class MoonShineCommand extends Command
         $baseDir = $this->hasOption('base-dir') ? $this->option('base-dir') : null;
         $baseNamespace = $this->hasOption('base-namespace') ? $this->option('base-namespace') : null;
 
-        $toNamespace = static fn(string $str): string => str($str)
+        $toNamespace = static fn (string $str): string => str($str)
             ->trim('\\')
             ->trim('/')
             ->replace('/', '\\')
             ->explode('\\')
-            ->map(static fn(string $segment): string => ucfirst($segment))
+            ->map(static fn (string $segment): string => ucfirst($segment))
             ->implode('\\');
 
-        if($baseDir !== null && $baseNamespace === null) {
+        if ($baseDir !== null && $baseNamespace === null) {
             $baseNamespace = $toNamespace($baseDir);
         }
 
-        if($namespace === null) {
+        if ($namespace === null) {
             $namespace = $toNamespace($dir);
         }
 

--- a/src/Laravel/src/Commands/PublishCommand.php
+++ b/src/Laravel/src/Commands/PublishCommand.php
@@ -157,7 +157,7 @@ class PublishCommand extends MoonShineCommand
 
         $this->replaceInConfig(
             $configKey,
-            moonshineConfig()->getNamespace('\Forms\\' . $className) . "::class",
+            $this->getNamespace('\Forms\\' . $className) . "::class",
             $className
         );
     }
@@ -203,7 +203,7 @@ class PublishCommand extends MoonShineCommand
 
         $this->replaceInConfig(
             $configKey,
-            moonshineConfig()->getNamespace('\Pages\\' . $className) . "::class",
+            $this->getNamespace('\Pages\\' . $className) . "::class",
             $className
         );
     }
@@ -214,8 +214,8 @@ class PublishCommand extends MoonShineCommand
     private function copySystemClass(string $name, string $dir): array
     {
         $classPath = "src/$dir/$name.php";
-        $fullClassPath = moonshineConfig()->getDir("/$dir/$name.php");
-        $targetNamespace = moonshineConfig()->getNamespace("\\$dir");
+        $fullClassPath = $this->getDirectory("/$dir/$name.php");
+        $targetNamespace = $this->getNamespace("\\$dir");
 
         (new Filesystem())->put(
             $fullClassPath,

--- a/src/Laravel/src/DependencyInjection/MoonShineConfigurator.php
+++ b/src/Laravel/src/DependencyInjection/MoonShineConfigurator.php
@@ -40,14 +40,18 @@ final class MoonShineConfigurator implements ConfiguratorContract
             ->set('namespace', $namespace);
     }
 
-    public function getDir(string $path = ''): string
+    public function getDir(string $path = '', ?string $base = null): string
     {
-        return $this->get('dir') . '/' . trim($path, '/');
+        $base = $base ?? $this->get('dir');
+
+        return $base . '/' . trim($path, '/');
     }
 
-    public function getNamespace(string $path = ''): string
+    public function getNamespace(string $path = '', ?string $base = null): string
     {
-        return $this->get('namespace') . '\\' . trim($path, '\\');
+        $base = $base ?? $this->get('namespace');
+
+        return $base . '\\' . trim($path, '\\');
     }
 
     /**

--- a/src/Laravel/src/DependencyInjection/MoonShineConfigurator.php
+++ b/src/Laravel/src/DependencyInjection/MoonShineConfigurator.php
@@ -42,14 +42,14 @@ final class MoonShineConfigurator implements ConfiguratorContract
 
     public function getDir(string $path = '', ?string $base = null): string
     {
-        $base = $base ?? $this->get('dir');
+        $base ??= $this->get('dir');
 
         return $base . '/' . trim($path, '/');
     }
 
     public function getNamespace(string $path = '', ?string $base = null): string
     {
-        $base = $base ?? $this->get('namespace');
+        $base ??= $this->get('namespace');
 
         return $base . '\\' . trim($path, '\\');
     }


### PR DESCRIPTION
## What was changed

Ability to select base directory and namespace

```shell
php artisan moonshine:resource ArticleResource --type=1 --base-dir=/src/Domain/Article/MoonShine
```

*Result - src/Domain/Article/MoonShine/ArticleResource (Src\Domain\Article\MoonShine)*

```shell
php artisan moonshine:resource ArticleResource --type=1 --base-dir=/src/Domain/Article/MoonShine --base-dir=Domain\\Article\\MoonShine
```

*Result - src/Domain/Article/MoonShine/ArticleResource (Domain\Article\MoonShine)*

```shell
php artisan moonshine:resource ArticleResource --type=1 --base-dir=/src/Domain/Article/MoonShine --base-namespace=Domain/Article/MoonShine
```

*Result - src/Domain/Article/MoonShine/ArticleResource (Domain\Article\MoonShine)*

## Checklist

- Issue #1230
- Tested
    - [x] Tested manually
    - [x] Tests added
- [x] Documentation
