### PR TITLE
fix: return method enum

### DIFF
--- a/src/Laravel/src/MoonShineRequest.php
+++ b/src/Laravel/src/MoonShineRequest.php
@@ -8,6 +8,8 @@ use Illuminate\Http\Request;
 use MoonShine\Contracts\Core\CrudResourceContract;
 use MoonShine\Laravel\Traits\Request\HasPageRequest;
 use MoonShine\Laravel\Traits\Request\HasResourceRequest;
+use MoonShine\Support\Enums\HttpMethod;
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 
 class MoonShineRequest extends Request
 {
@@ -87,5 +89,19 @@ class MoonShineRequest extends Request
             $this->route()?->gatherMiddleware() ?? [],
             true
         );
+    }
+
+    /**
+     * Get the request method.
+     *
+     * @return HttpMethod
+     */
+    public function method(): HttpMethod
+    {
+        try {
+        return HttpMethod::from(str($this->getMethod())->lower()->toString());
+        } catch (\TypeError $e) {
+            throw new SuspiciousOperationException('Invalid HTTP method', previous: $e);
+        }
     }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
MoonShineRequest()->method() выдает строку, при чем в начале выдавал строку маленькими буквами, потом заглавными. 

## Why?
В коде уже есть enum HttpMethod и логичнее, что должен выдаваться данный enum.

## Checklist

- Issue #<!-- add issue number here -->
- Tested
    - [v] Tested manually
    - [-] Tests added
- [?] Documentation <!--- Remove if not needed -->
