### PR TITLE
feat: Get bulk row method

### DIFF
--- a/src/UI/src/Components/Table/TableBuilder.php
+++ b/src/UI/src/Components/Table/TableBuilder.php
@@ -559,7 +559,7 @@ final class TableBuilder extends IterableComponent implements
             return null;
         }
 
-        $buttons = is_null($modifyButtons) ? $this->getBulkButtons() : $modifyButtons($this->getBulkButtons());
+        $buttons = \is_null($modifyButtons) ? $this->getBulkButtons() : $modifyButtons($this->getBulkButtons());
 
         $cells = TableCells::make()->pushCellWhen(
             ! $this->isPreview(),


### PR DESCRIPTION
## What was changed

```php
protected function thead(): null|TableRowsContract|Closure
{
    return fn(TableRow $default, TableBuilder $table) => TableRows::make([
        $table->getBulkRow(fn(ActionButtons $buttons) => ActionButtons::make([
            $this->getMassDeleteButton(modalName: 'resource-mass-delete-modal-head')
        ])),
        $default,
    ]);
}
```

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Tests added
- [ ] Documentation
