### PR TITLE
Fix crash Index page with filtered data after reload

### DIFF
--- a/src/Laravel/src/Forms/FiltersForm.php
+++ b/src/Laravel/src/Forms/FiltersForm.php
@@ -7,6 +7,7 @@ namespace MoonShine\Laravel\Forms;
 use Illuminate\Support\Arr;
 use MoonShine\Contracts\UI\FormBuilderContract;
 use MoonShine\Contracts\UI\FormContract;
+use MoonShine\Core\TypeCasts\MixedDataCaster;
 use MoonShine\Laravel\Collections\Fields;
 use MoonShine\Laravel\Resources\CrudResource;
 use MoonShine\Support\AlpineJs;
@@ -58,7 +59,7 @@ final readonly class FiltersForm implements FormContract
 
         return FormBuilder::make($action, FormMethod::GET)
             ->name('filters')
-            ->fillCast($values, $resource->getCaster())
+            ->fillCast($values, new MixedDataCaster())
             ->fields(
                 $filters
                     ->when(


### PR DESCRIPTION
Fixed a bug that caused the page to crash after reloading the index resources page if the filter contains multiple values per item and identical model properties only accept one value.

## What was changed
ModelCaster was replaced by MixedDataCaster.

## Why?
The user cannot open the page in the admin area if he clicked on the link or refreshed the page.

## Checklist

- Issue #1486
- Tested
    - [x] Tested manually
    - [ ] Tests added
