### PR TITLE
fix: overflow-auto for content

### DIFF
--- a/src/Laravel/src/Layouts/AppLayout.php
+++ b/src/Laravel/src/Layouts/AppLayout.php
@@ -62,7 +62,7 @@ class AppLayout extends BaseLayout
 
                                 $this->getFooterComponent(),
                             ])->class('layout-page')->name(self::CONTENT_FRAGMENT_NAME),
-                        ])->class('flex grow')->customAttributes(['id' => self::CONTENT_ID]),
+                        ])->class('flex grow overflow-auto')->customAttributes(['id' => self::CONTENT_ID]),
                     ]),
                 ]),
             ])

--- a/src/Laravel/src/Layouts/CompactLayout.php
+++ b/src/Laravel/src/Layouts/CompactLayout.php
@@ -102,7 +102,7 @@ class CompactLayout extends AppLayout
 
                                 $this->getFooterComponent(),
                             ])->class('layout-page')->name(self::CONTENT_FRAGMENT_NAME),
-                        ])->class('flex grow')->customAttributes(['id' => self::CONTENT_ID]),
+                        ])->class('flex grow overflow-auto')->customAttributes(['id' => self::CONTENT_ID]),
                     ]),
                 ])->class('theme-minimalistic'),
             ])

--- a/src/UI/tailwind.config.js
+++ b/src/UI/tailwind.config.js
@@ -28,6 +28,7 @@ const clientSafeList = [
   'visible',
   '!hidden',
   '!block',
+  'overflow-auto',
   'pointer-events-auto',
   'opacity-0',
   'opacity-100',


### PR DESCRIPTION
## What was changed
added overflow-auto for content block

## Why?
![telegram-cloud-photo-size-5-6089214902544744555-y](https://github.com/user-attachments/assets/1d23e9f6-90c2-4de5-949e-fa871e2ac97b)

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Tests added
