### PR TITLE
feat: Simulate now on

### DIFF
--- a/src/Laravel/src/Buttons/HasManyButton.php
+++ b/src/Laravel/src/Buttons/HasManyButton.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\Laravel\Buttons;
 
 use Illuminate\Database\Eloquent\Model;
+use MoonShine\Contracts\Core\CrudResourceContract;
 use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
 use MoonShine\Contracts\UI\ActionButtonContract;
 use MoonShine\Laravel\Enums\Ability;
@@ -27,8 +28,10 @@ final class HasManyButton
     ): ActionButtonContract {
         /** @var ModelResource $resource */
         $resource = $field->getResource()->stopGettingItemFromUrl();
-        $parentResource = moonshineRequest()->getResource();
-        $parentPage = moonshineRequest()->getPage();
+        /** @var ?CrudResourceContract $parentResource */
+        $parentResource = $field->getNowOnResource() ?? moonshineRequest()->getResource();
+        $parentPage = $field->getNowOnPage() ?? moonshineRequest()->getPage();
+        $itemID = data_get($field->getNowOnQueryParams(), 'resourceItem', moonshineRequest()->getItemID());
 
         if (! $resource->getFormPage()) {
             return ActionButton::emptyHidden();
@@ -36,7 +39,7 @@ final class HasManyButton
 
         $action = static fn (?Model $data) => $parentResource->getRoute(
             'has-many.form',
-            moonshineRequest()->getItemID(),
+            $itemID,
             [
                 'pageUri' => $parentPage->getUriKey(),
                 '_relation' => $field->getRelationName(),

--- a/src/Laravel/src/Fields/Relationships/HasMany.php
+++ b/src/Laravel/src/Fields/Relationships/HasMany.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\HasOneOrManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use MoonShine\Contracts\Core\CrudResourceContract;
 use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
 use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
 use MoonShine\Contracts\UI\ActionButtonContract;
@@ -125,9 +126,10 @@ class HasMany extends ModelRelationField implements HasFieldsContract, FieldWith
 
     public function getDefaultRedirect(Model|int|null|string $parentId): ?string
     {
-        return moonshineRequest()
-            ->getResource()
-            ?->getFormPageUrl($parentId);
+        /** @var ?CrudResourceContract $resource */
+        $resource = $this->getNowOnResource() ?? moonshineRequest()->getResource();
+
+        return $resource->getFormPageUrl($parentId);
     }
 
     /**
@@ -425,7 +427,9 @@ class HasMany extends ModelRelationField implements HasFieldsContract, FieldWith
         $asyncUrl = moonshineRouter()->getEndpoints()->withRelation(
             'has-many.list',
             resourceItem: $this->getRelatedModel()?->getKey(),
-            relation: $this->getRelationName()
+            relation: $this->getRelationName(),
+            resourceUri: $this->getNowOnResource()?->getUriKey(),
+            pageUri: $this->getNowOnPage()?->getUriKey()
         );
 
         return TableBuilder::make(items: $items)

--- a/src/Laravel/src/Fields/Relationships/HasOne.php
+++ b/src/Laravel/src/Fields/Relationships/HasOne.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
 use Illuminate\Database\Eloquent\Relations\HasOneOrManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
+use MoonShine\Contracts\Core\CrudResourceContract;
 use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
 use MoonShine\Contracts\UI\ComponentContract;
 use MoonShine\Contracts\UI\FieldContract;
@@ -181,9 +182,10 @@ class HasOne extends ModelRelationField implements HasFieldsContract, FieldWithC
 
     public function getDefaultRedirect(Model|int|null|string $parentId): ?string
     {
-        return moonshineRequest()
-            ->getResource()
-            ?->getFormPageUrl($parentId);
+        /** @var ?CrudResourceContract $resource */
+        $resource = $this->getNowOnResource() ?? moonshineRequest()->getResource();
+
+        return $resource->getFormPageUrl($parentId);
     }
 
     /**
@@ -219,7 +221,7 @@ class HasOne extends ModelRelationField implements HasFieldsContract, FieldWithC
         $resource = $this->getResource()->stopGettingItemFromUrl();
 
         /** @var ?ModelResource $parentResource */
-        $parentResource = moonshineRequest()->getResource();
+        $parentResource = $this->getNowOnResource() ?? moonshineRequest()->getResource();
 
         $item = $this->toValue();
 

--- a/src/Laravel/src/Pages/Page.php
+++ b/src/Laravel/src/Pages/Page.php
@@ -8,6 +8,9 @@ use Closure;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\View\View;
 use MoonShine\Contracts\Core\CrudResourceContract;
+use MoonShine\Contracts\Core\DependencyInjection\CoreContract;
+use MoonShine\Contracts\Core\PageContract;
+use MoonShine\Contracts\Core\ResourceContract;
 use MoonShine\Core\Pages\Page as CorePage;
 use MoonShine\Laravel\Contracts\WithResponseModifierContract;
 use MoonShine\Laravel\DependencyInjection\MoonShine;
@@ -29,9 +32,24 @@ abstract class Page extends CorePage implements WithResponseModifierContract
             oops404();
         }
 
+        $this->simulateRoute();
+    }
+
+    public function simulateRoute(?PageContract $page = null, ?ResourceContract $resource = null): static
+    {
         request()
             ->route()
-            ?->setParameter('pageUri', $this->getUriKey());
+            ?->setParameter('pageUri', ($page ?? $this)->getUriKey());
+
+        if(!\is_null($resource)) {
+            $this->setResource($resource);
+
+            request()
+                ->route()
+                ?->setParameter('resourceUri', $resource->getUriKey());
+        }
+
+        return $this;
     }
 
     protected function prepareRender(Renderable|Closure|string $view): Renderable|Closure|string
@@ -41,6 +59,11 @@ abstract class Page extends CorePage implements WithResponseModifierContract
             moonshineRequest()->isFragmentLoad(),
             moonshineRequest()->getFragmentLoad(),
         );
+    }
+
+    public function nowOn(): static
+    {
+        return $this;
     }
 
     public function isResponseModified(): bool

--- a/src/Laravel/src/Traits/Fields/BelongsToOrManyCreatable.php
+++ b/src/Laravel/src/Traits/Fields/BelongsToOrManyCreatable.php
@@ -57,10 +57,14 @@ trait BelongsToOrManyCreatable
 
     public function getFragmentUrl(): string
     {
+        $resource = $this->getNowOnResource() ?? moonshineRequest()->getResource();
+        $page = $this->getNowOnPage() ?? moonshineRequest()->getPage();
+        $itemID = data_get($this->getNowOnQueryParams(), 'resourceItem', moonshineRequest()->getItemID());
+
         return $this->creatableFragmentUrl ?? toPage(
-            page: moonshineRequest()->getPage(),
-            resource: moonshineRequest()->getResource(),
-            params: ['resourceItem' => moonshineRequest()->getItemID()],
+            page: $page,
+            resource: $resource,
+            params: ['resourceItem' => $itemID],
             fragment: $this->getRelationName()
         );
     }

--- a/src/Laravel/src/Traits/Fields/WithAsyncSearch.php
+++ b/src/Laravel/src/Traits/Fields/WithAsyncSearch.php
@@ -131,10 +131,11 @@ trait WithAsyncSearch
         }
 
         $resourceUri = $this->getNowOnResource()?->getUriKey() ?? moonshineRequest()->getResourceUri();
+        $itemID = data_get($this->getNowOnQueryParams(), 'resourceItem', moonshineRequest()->getItemID());
 
         return moonshineRouter()->getEndpoints()->withRelation(
             'async-search',
-            resourceItem: moonshineRequest()->getItemID(),
+            resourceItem: $itemID,
             relation: $this->getRelationName(),
             resourceUri: $resourceUri,
             parentField: $parentName,

--- a/src/Laravel/src/Traits/Fields/WithRelatedLink.php
+++ b/src/Laravel/src/Traits/Fields/WithRelatedLink.php
@@ -63,7 +63,9 @@ trait WithRelatedLink
             return $this->parentRelationName;
         }
 
-        $relationName = str((string) moonshineRequest()->getResourceUri())
+        $resource = $this->getNowOnResource() ?? moonshineRequest()->getResource();
+
+        $relationName = str((string) $resource?->getUriKey())
             ->remove('-resource')
             ->replace('-', '_');
 


### PR DESCRIPTION
You can render system pages that need a resource and a page in the URL on arbitrary routes by simulating their URLs

```php
class HomeController extends Controller
{
    public function __invoke(FormArticlePage $page, ArticleResource $resource)
    {
        return $page->simulateRoute($page, $resource)->loaded();
    }
}
```

NowOn also improved

```php
HasMany::make('Comments', resource: CommentResource::class)
    ->creatable()
    ->nowOn($resource->getFormPage(), $resource, ['resourceItem' => $item->getKey()])
    ->fillCast($item, new ModelCaster(Article::class)),
```