### PR TITLE
feat: HasMany -> disableOutside

### DIFF
--- a/src/Laravel/src/Fields/Relationships/HasMany.php
+++ b/src/Laravel/src/Fields/Relationships/HasMany.php
@@ -89,6 +89,13 @@ class HasMany extends ModelRelationField implements HasFieldsContract, FieldWith
 
     protected null|TableBuilderContract|FormBuilderContract|ActionButtonContract $resolvedComponent = null;
 
+    public function disableOutside(): static
+    {
+        $this->outsideComponent = false;
+
+        return $this->searchable(false);
+    }
+
     public function withoutModals(): static
     {
         $this->withoutModals = true;
@@ -257,6 +264,10 @@ class HasMany extends ModelRelationField implements HasFieldsContract, FieldWith
     public function searchable(Closure|bool|null $condition = null): static
     {
         $this->isSearchable = value($condition, $this) ?? true;
+
+        if($this->isOutsideComponent()) {
+            $this->isSearchable = false;
+        }
 
         return $this;
     }


### PR DESCRIPTION
By default, the HasMany field is displayed outside the form, but this behavior can now be disabled

> [!NOTE]
> searchable is not supported in this mode

```php
HasMany::make('Comments')->disableOutside(),
```