### PR TITLE
fix: TResource generics fix for Page classes

### DIFF
--- a/src/Core/src/Pages/Page.php
+++ b/src/Core/src/Pages/Page.php
@@ -23,7 +23,7 @@ use MoonShine\Support\Enums\PageType;
 
 /**
  * @template TCore of Core
- * @template TResource of ResourceContract
+ * @template TResource of ResourceContract|null
  */
 abstract class Page implements PageContract
 {

--- a/src/Core/src/Traits/HasResource.php
+++ b/src/Core/src/Traits/HasResource.php
@@ -8,23 +8,23 @@ use MoonShine\Contracts\Core\ResourceContract;
 use MoonShine\Core\Exceptions\ResourceException;
 
 /**
- * @template T of ResourceContract
- * @template PT of ResourceContract
+ * @template T of ResourceContract|null
+ * @template PT of ResourceContract|null
  */
 trait HasResource
 {
     /**
-     * @var ?T
+     * @var T
      */
     protected ?ResourceContract $resource = null;
 
     /**
-     * @var ?PT
+     * @var PT
      */
     protected ?ResourceContract $parentResource = null;
 
     /**
-     * @return ?PT
+     * @return PT
      */
     public function getParentResource(): ?ResourceContract
     {
@@ -34,7 +34,7 @@ trait HasResource
     /**
      * @param PT $resource
      */
-    public function setParentResource(ResourceContract $resource): static
+    public function setParentResource(?ResourceContract $resource): static
     {
         $this->parentResource = $resource;
 

--- a/src/Laravel/src/Pages/Page.php
+++ b/src/Laravel/src/Pages/Page.php
@@ -17,7 +17,7 @@ use MoonShine\Laravel\Http\Responses\MoonShineJsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @template TResource of CrudResourceContract
+ * @template TResource of CrudResourceContract|null
  * @extends CorePage<MoonShine, TResource>
  */
 abstract class Page extends CorePage implements WithResponseModifierContract


### PR DESCRIPTION
## What was changed
TResource can now be null

## Why?
Because the page may not have a resource
