### PR TITLE
fix: change default search field

### DIFF
--- a/src/Laravel/src/Resources/ModelResource.php
+++ b/src/Laravel/src/Resources/ModelResource.php
@@ -243,4 +243,14 @@ abstract class ModelResource extends CrudResource implements
 
         return $item;
     }
+
+    /**
+     * @return string[]
+     */
+    protected function search(): array
+    {
+        return [
+            $this->getModel()->getKeyName(),
+        ];
+    }
 }


### PR DESCRIPTION
The problem is that if the _$primaryKey_ model does not have **id**, then the search in the resource breaks down, since the _search_ method uses the **id** field by default.

Проблема заключается в том, что если у модели _$primaryKey_ не **id**, то поиск в ресурсе ломается, так как у метода _search_ по умолчанию поиск по полю **id**.