### PR TITLE
feat: Autoload menu

### DIFF
--- a/.meta-storm.xml
+++ b/.meta-storm.xml
@@ -63,6 +63,30 @@
             <stopCompletion />
         </classMethod>
 
+        <classConstructor
+            class="\MoonShine\Support\Attributes\Icon"
+            argument="0"
+        >
+            <files extension="blade.php" xpath="$project/vendor/moonshine/moonshine/src/UI/resources/views/icons"/>
+            <stopCompletion />
+        </classConstructor>
+
+        <classConstructor
+            class="\MoonShine\MenuManager\Attributes\Group"
+            argument="1"
+        >
+            <files extension="blade.php" xpath="$project/vendor/moonshine/moonshine/src/UI/resources/views/icons"/>
+            <stopCompletion />
+        </classConstructor>
+
+        <classConstructor
+            class="\MoonShine\MenuManager\Attributes\CanSee"
+            argument="0"
+        >
+            <methods xpath="$containingClass" private="false" protected="false" static="false" />
+            <stopCompletion />
+        </classConstructor>
+
         <classMethod
             class="\MoonShine\AssetManager\InlineJs"
             method="make"

--- a/src/Contracts/src/MenuManager/MenuAutoloaderContract.php
+++ b/src/Contracts/src/MenuManager/MenuAutoloaderContract.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Contracts\MenuManager;
+
+interface MenuAutoloaderContract
+{
+    public function toArray(): array;
+
+    public function resolve(?array $cached = null): array;
+}

--- a/src/Core/src/Collections/OptimizerCollection.php
+++ b/src/Core/src/Collections/OptimizerCollection.php
@@ -11,6 +11,7 @@ use MoonShine\Contracts\Core\DependencyInjection\ConfiguratorContract;
 use MoonShine\Contracts\Core\DependencyInjection\OptimizerCollectionContract;
 use MoonShine\Contracts\Core\PageContract;
 use MoonShine\Contracts\Core\ResourceContract;
+use MoonShine\Contracts\MenuManager\MenuElementContract;
 use ReflectionClass;
 use ReflectionException;
 
@@ -24,6 +25,7 @@ final class OptimizerCollection implements OptimizerCollectionContract
     protected array $groups = [
         PageContract::class,
         ResourceContract::class,
+        MenuElementContract::class,
     ];
 
     /**

--- a/src/Laravel/src/Commands/InstallCommand.php
+++ b/src/Laravel/src/Commands/InstallCommand.php
@@ -279,6 +279,7 @@ class InstallCommand extends MoonShineCommand
             'className' => 'Dashboard',
             '--force' => true,
             '--without-register' => true,
+            '--skip-menu' => true,
         ]);
 
         $this->replaceInConfig(

--- a/src/Laravel/src/Commands/MakePageCommand.php
+++ b/src/Laravel/src/Commands/MakePageCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand(name: 'moonshine:page')]
 class MakePageCommand extends MoonShineCommand
 {
-    protected $signature = 'moonshine:page {className?} {--force} {--without-register} {--crud} {--dir=} {--extends=} {--base-dir=} {--base-namespace=}';
+    protected $signature = 'moonshine:page {className?} {--force} {--without-register} {--skip-menu} {--crud} {--dir=} {--extends=} {--base-dir=} {--base-namespace=}';
 
     protected $description = 'Create page';
 
@@ -92,11 +92,18 @@ class MakePageCommand extends MoonShineCommand
 
         $this->makeDir($stubsPath->dir);
 
+        $uses = '';
+
+        if($this->option('skip-menu')) {
+            $uses = '#[\MoonShine\MenuManager\Attributes\SkipMenu]';
+        }
+
         $this->copyStub($stub, $stubsPath->getPath(), [
             '{namespace}' => $stubsPath->namespace,
             'DummyClass' => $stubsPath->name,
             'DummyTitle' => $stubsPath->name,
             '{extendShort}' => $extends,
+            '{uses}' => $uses,
         ]);
 
         $this->wasCreatedInfo($stubsPath);

--- a/src/Laravel/src/Pages/Dashboard.php
+++ b/src/Laravel/src/Pages/Dashboard.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace MoonShine\Laravel\Pages;
 
 use MoonShine\Contracts\UI\ComponentContract;
+use MoonShine\MenuManager\Attributes\SkipMenu;
 
+#[SkipMenu]
 /**
  * @extends Page<null>
  */

--- a/src/Laravel/src/Pages/ErrorPage.php
+++ b/src/Laravel/src/Pages/ErrorPage.php
@@ -6,8 +6,10 @@ namespace MoonShine\Laravel\Pages;
 
 use MoonShine\Contracts\UI\ComponentContract;
 use MoonShine\Laravel\Layouts\BlankLayout;
+use MoonShine\MenuManager\Attributes\SkipMenu;
 use MoonShine\UI\Components\FlexibleRender;
 
+#[SkipMenu]
 /**
  * @method static static make(int $code, string $message)
  * @extends Page<null>

--- a/src/Laravel/src/Pages/LoginPage.php
+++ b/src/Laravel/src/Pages/LoginPage.php
@@ -7,7 +7,9 @@ namespace MoonShine\Laravel\Pages;
 use MoonShine\Contracts\UI\ComponentContract;
 use MoonShine\Laravel\Forms\LoginForm;
 use MoonShine\Laravel\Layouts\LoginLayout;
+use MoonShine\MenuManager\Attributes\SkipMenu;
 
+#[SkipMenu]
 /**
  * @extends Page<null>
  */

--- a/src/Laravel/src/Pages/ProfilePage.php
+++ b/src/Laravel/src/Pages/ProfilePage.php
@@ -12,6 +12,7 @@ use MoonShine\Laravel\Http\Controllers\ProfileController;
 use MoonShine\Laravel\MoonShineAuth;
 use MoonShine\Laravel\Traits\WithComponentsPusher;
 use MoonShine\Laravel\TypeCasts\ModelCaster;
+use MoonShine\MenuManager\Attributes\SkipMenu;
 use MoonShine\UI\Components\FormBuilder;
 use MoonShine\UI\Components\Heading;
 use MoonShine\UI\Components\Layout\Box;
@@ -23,6 +24,7 @@ use MoonShine\UI\Fields\Password;
 use MoonShine\UI\Fields\PasswordRepeat;
 use MoonShine\UI\Fields\Text;
 
+#[SkipMenu]
 /**
  * @extends Page<null>
  */

--- a/src/Laravel/src/Providers/MoonShineServiceProvider.php
+++ b/src/Laravel/src/Providers/MoonShineServiceProvider.php
@@ -26,6 +26,7 @@ use MoonShine\Contracts\Core\DependencyInjection\RouterContract;
 use MoonShine\Contracts\Core\DependencyInjection\StorageContract;
 use MoonShine\Contracts\Core\DependencyInjection\TranslatorContract;
 use MoonShine\Contracts\Core\DependencyInjection\ViewRendererContract;
+use MoonShine\Contracts\MenuManager\MenuAutoloaderContract;
 use MoonShine\Contracts\MenuManager\MenuManagerContract;
 use MoonShine\Core\Collections\OptimizerCollection;
 use MoonShine\Core\Core;
@@ -71,6 +72,7 @@ use MoonShine\Laravel\Notifications\MoonShineMemoryNotification;
 use MoonShine\Laravel\Notifications\MoonShineNotification;
 use MoonShine\Laravel\Resources\ModelResource;
 use MoonShine\Laravel\Storage\LaravelStorage;
+use MoonShine\Laravel\Support\MenuAutoloader;
 use MoonShine\MenuManager\MenuManager;
 use MoonShine\UI\Applies\AppliesRegister;
 use MoonShine\UI\Fields\Checkbox;
@@ -151,6 +153,7 @@ final class MoonShineServiceProvider extends ServiceProvider
         $this->app->singleton(AssetResolverContract::class, AssetResolver::class);
         $this->app->{app()->runningUnitTests() ? 'bind' : 'singleton'}(ConfiguratorContract::class, MoonShineConfigurator::class);
         $this->app->singleton(AppliesRegisterContract::class, AppliesRegister::class);
+        $this->app->singleton(MenuAutoloaderContract::class, MenuAutoloader::class);
         $this->app->singleton(
             MoonShineNotificationContract::class,
             moonshineConfig()->isUseDatabaseNotifications() ? MoonShineNotification::class : MoonShineMemoryNotification::class

--- a/src/Laravel/src/Resources/MoonShineUserResource.php
+++ b/src/Laravel/src/Resources/MoonShineUserResource.php
@@ -10,6 +10,7 @@ use MoonShine\Laravel\Enums\Action;
 use MoonShine\Laravel\Fields\Relationships\BelongsTo;
 use MoonShine\Laravel\Models\MoonshineUser;
 use MoonShine\Laravel\Models\MoonshineUserRole;
+use MoonShine\MenuManager\Attributes\Group;
 use MoonShine\Support\Attributes\Icon;
 use MoonShine\Support\Enums\Color;
 use MoonShine\Support\ListOf;
@@ -27,6 +28,7 @@ use MoonShine\UI\Fields\PasswordRepeat;
 use MoonShine\UI\Fields\Text;
 
 #[Icon('users')]
+#[Group('moonshine::ui.resource.system', 'users', translatable: true)]
 /**
  * @extends ModelResource<MoonshineUser>
  */

--- a/src/Laravel/src/Resources/MoonShineUserResource.php
+++ b/src/Laravel/src/Resources/MoonShineUserResource.php
@@ -11,6 +11,7 @@ use MoonShine\Laravel\Fields\Relationships\BelongsTo;
 use MoonShine\Laravel\Models\MoonshineUser;
 use MoonShine\Laravel\Models\MoonshineUserRole;
 use MoonShine\MenuManager\Attributes\Group;
+use MoonShine\MenuManager\Attributes\Order;
 use MoonShine\Support\Attributes\Icon;
 use MoonShine\Support\Enums\Color;
 use MoonShine\Support\ListOf;
@@ -29,6 +30,7 @@ use MoonShine\UI\Fields\Text;
 
 #[Icon('users')]
 #[Group('moonshine::ui.resource.system', 'users', translatable: true)]
+#[Order(1)]
 /**
  * @extends ModelResource<MoonshineUser>
  */

--- a/src/Laravel/src/Resources/MoonShineUserRoleResource.php
+++ b/src/Laravel/src/Resources/MoonShineUserRoleResource.php
@@ -7,6 +7,7 @@ namespace MoonShine\Laravel\Resources;
 use MoonShine\Laravel\Enums\Action;
 use MoonShine\Laravel\Models\MoonshineUserRole;
 use MoonShine\MenuManager\Attributes\Group;
+use MoonShine\MenuManager\Attributes\Order;
 use MoonShine\Support\Attributes\Icon;
 use MoonShine\Support\ListOf;
 use MoonShine\UI\Components\Layout\Box;
@@ -15,6 +16,7 @@ use MoonShine\UI\Fields\Text;
 
 #[Icon('bookmark')]
 #[Group('moonshine::ui.resource.system', 'users', translatable: true)]
+#[Order(1)]
 /**
  * @extends ModelResource<MoonshineUserRole>
  */

--- a/src/Laravel/src/Resources/MoonShineUserRoleResource.php
+++ b/src/Laravel/src/Resources/MoonShineUserRoleResource.php
@@ -6,6 +6,7 @@ namespace MoonShine\Laravel\Resources;
 
 use MoonShine\Laravel\Enums\Action;
 use MoonShine\Laravel\Models\MoonshineUserRole;
+use MoonShine\MenuManager\Attributes\Group;
 use MoonShine\Support\Attributes\Icon;
 use MoonShine\Support\ListOf;
 use MoonShine\UI\Components\Layout\Box;
@@ -13,6 +14,7 @@ use MoonShine\UI\Fields\ID;
 use MoonShine\UI\Fields\Text;
 
 #[Icon('bookmark')]
+#[Group('moonshine::ui.resource.system', 'users', translatable: true)]
 /**
  * @extends ModelResource<MoonshineUserRole>
  */

--- a/src/Laravel/src/Support/MenuAutoloader.php
+++ b/src/Laravel/src/Support/MenuAutoloader.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Laravel\Support;
+
+use Closure;
+use Leeto\FastAttributes\Attributes;
+use MoonShine\Contracts\Core\CrudPageContract;
+use MoonShine\Contracts\Core\DependencyInjection\CoreContract;
+use MoonShine\Contracts\Core\PageContract;
+use MoonShine\Contracts\Core\ResourceContract;
+use MoonShine\Contracts\MenuManager\MenuAutoloaderContract;
+use MoonShine\Contracts\MenuManager\MenuElementContract;
+use MoonShine\Contracts\MenuManager\MenuFillerContract;
+use MoonShine\Laravel\DependencyInjection\MoonShine;
+use MoonShine\MenuManager\Attributes\CanSee;
+use MoonShine\MenuManager\Attributes\Group;
+use MoonShine\MenuManager\Attributes\SkipMenu;
+use MoonShine\MenuManager\MenuGroup;
+use MoonShine\MenuManager\MenuItem;
+
+/**
+ * @phpstan-type PSMenuItem array{
+ *      filler: class-string<MenuFillerContract>,
+ *      canSee: null|string,
+ *  }
+ *
+ * @phpstan-type PSMenuGroup array{
+ *       label: string,
+ *       class: class-string<MenuFillerContract>,
+ *       icon: string|null,
+ *       canSee: null|string,
+ *       translatable: bool,
+ *   }
+ *
+ * @phpstan-type PSMenu array{
+ *      string,
+ *      PSMenuItem|array{
+ *           group: PSMenuGroup,
+ *           items: list<PSMenuItem>,
+ *      }
+ *  }
+ */
+final readonly class MenuAutoloader implements MenuAutoloaderContract
+{
+    /**
+     * @param  MoonShine  $core
+     */
+    public function __construct(private CoreContract $core) {}
+
+    /**
+     * @return PSMenu
+     */
+    public function toArray(): array
+    {
+        $items = [];
+
+        $resolveItems = static function (
+            MenuFillerContract $item,
+            &$items,
+        ): void {
+            $skip = Attributes::for($item, SkipMenu::class)->class();
+
+            if (! \is_null($skip->first())) {
+                return;
+            }
+
+            $group = Attributes::for($item, Group::class)->class()->first();
+            $canSee = Attributes::for($item, CanSee::class)->class()->first();
+
+            $label = $group?->label;
+            $icon = $group?->icon;
+
+            $namespace = get_class($item);
+            $data = ['filler' => $namespace, 'canSee' => $canSee?->method];
+
+            if ($label !== null) {
+                $existsGroup = $items[$label] ?? null;
+                $items[$label] = [
+                    'group' => ['class' => $namespace, 'label' => $label, 'icon' => $icon, 'canSee' => $canSee?->method, 'translatable' => $group?->translatable],
+                    'items' => \is_null($existsGroup)
+                        ? [$data]
+                        : [
+                            ...$existsGroup['items'],
+                            $data,
+                        ],
+                ];
+
+                return;
+            }
+
+            $items[$namespace] = $data;
+        };
+
+        foreach ($this->core->getResources()->toArray() as $item) {
+            $resolveItems($item, $items);
+        }
+
+        $excludePages = static fn(PageContract $page) => ! $page instanceof CrudPageContract;
+
+        foreach ($this->core->getPages()->filter($excludePages)->toArray() as $item) {
+            $resolveItems($item, $items);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param  PSMenu|null  $cached
+     *
+     * @return MenuElementContract[]
+     */
+    public function resolve(?array $cached = null): array
+    {
+        return $this->generateMenu($cached ?? $this->toArray());
+    }
+
+    /**
+     * @param  PSMenu|list<PSMenuItem>  $data
+     *
+     * @return list<MenuElementContract>
+     */
+    private function generateMenu(array $data): array
+    {
+        $menu = [];
+
+        foreach ($data as $item) {
+            if (isset($item['group'])) {
+                $group = $item['group'];
+                $menu[] = MenuGroup::make(
+                    $group['translatable'] ? __($group['label']) : $group['label'],
+                    $this->generateMenu($item['items']),
+                    $group['icon'],
+                )->when($group['canSee'], fn(MenuGroup $ctx) => $ctx->canSee($this->canSee($group['class'], $group['canSee'])));
+                continue;
+            }
+
+            $menu[] = $this->toMenuItem(...$item);
+        }
+
+        return $menu;
+    }
+
+    /**
+     * @param  class-string<MenuFillerContract&(PageContract|ResourceContract)>  $filler
+     */
+    private function toMenuItem(string $filler, ?string $icon = null, ?string $canSee = null): MenuItem
+    {
+        $resolved = app($filler);
+        $label = $resolved->getTitle();
+
+        return MenuItem::make($label, $filler, $icon)
+            ->when($canSee, fn(MenuItem $item) => $item->canSee($this->canSee($resolved, $canSee)));
+    }
+
+    /**
+     * @param  MenuFillerContract|class-string<MenuFillerContract>  $filler
+     */
+    private function canSee(string|MenuFillerContract $filler, string $method): Closure
+    {
+        if(is_string($filler)) {
+            $filler = app($filler);
+        }
+
+        return static fn() => $filler->{$method}();
+    }
+}

--- a/src/Laravel/stubs/CrudPage.stub
+++ b/src/Laravel/stubs/CrudPage.stub
@@ -8,6 +8,7 @@ use MoonShine\Laravel\Pages\Crud\{extendShort};
 use MoonShine\Contracts\UI\ComponentContract;
 use MoonShine\Contracts\UI\FieldContract;
 use Throwable;
+{uses}
 
 class DummyClass extends {extendShort}
 {

--- a/src/Laravel/stubs/Page.stub
+++ b/src/Laravel/stubs/Page.stub
@@ -6,6 +6,7 @@ namespace {namespace};
 
 use MoonShine\Laravel\Pages\Page;
 use MoonShine\Contracts\UI\ComponentContract;
+{uses}
 
 class DummyClass extends Page
 {

--- a/src/MenuManager/src/Attributes/CanSee.php
+++ b/src/MenuManager/src/Attributes/CanSee.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\MenuManager\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class CanSee
+{
+    public function __construct(
+        public string $method,
+    ) {}
+}

--- a/src/MenuManager/src/Attributes/Group.php
+++ b/src/MenuManager/src/Attributes/Group.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\MenuManager\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class Group
+{
+    public function __construct(
+        public string $label,
+        public ?string $icon = null,
+        public bool $translatable = false,
+    ) {}
+}

--- a/src/MenuManager/src/Attributes/Order.php
+++ b/src/MenuManager/src/Attributes/Order.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\MenuManager\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class Order
+{
+    public function __construct(
+        public int $value
+    ) {}
+}

--- a/src/MenuManager/src/Attributes/SkipMenu.php
+++ b/src/MenuManager/src/Attributes/SkipMenu.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\MenuManager\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class SkipMenu
+{
+}

--- a/src/MenuManager/src/MenuElement.php
+++ b/src/MenuManager/src/MenuElement.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\MenuManager;
 
 use Closure;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use MoonShine\Contracts\Core\HasViewRendererContract;
 use MoonShine\Contracts\MenuManager\MenuElementContract;
@@ -27,6 +28,7 @@ abstract class MenuElement implements MenuElementContract, HasViewRendererContra
     use HasCanSee;
     use WithLabel;
     use WithViewRenderer;
+    use Conditionable;
 
     private bool $topMode = false;
 

--- a/src/UI/src/AbstractLayout.php
+++ b/src/UI/src/AbstractLayout.php
@@ -10,6 +10,8 @@ use MoonShine\Contracts\AssetManager\AssetManagerContract;
 use MoonShine\Contracts\ColorManager\ColorManagerContract;
 use MoonShine\Contracts\Core\DependencyInjection\CoreContract;
 use MoonShine\Contracts\Core\PageContract;
+use MoonShine\Contracts\MenuManager\MenuAutoloaderContract;
+use MoonShine\Contracts\MenuManager\MenuElementContract;
 use MoonShine\Contracts\MenuManager\MenuManagerContract;
 use MoonShine\Contracts\UI\LayoutContract;
 use MoonShine\UI\Components\Layout\{Layout};
@@ -30,6 +32,7 @@ abstract class AbstractLayout implements LayoutContract
         protected readonly AssetManagerContract $assetManager,
         protected readonly ColorManagerContract $colorManager,
         protected readonly MenuManagerContract $menuManager,
+        protected readonly MenuAutoloaderContract $menuAutoloader,
     ) {
         $this->getAssetManager()->add(
             $this->assets(),
@@ -123,6 +126,18 @@ abstract class AbstractLayout implements LayoutContract
     protected function menu(): array
     {
         return [];
+    }
+
+    /**
+     * @return list<MenuElementContract>
+     */
+    protected function autoloadMenu(): array
+    {
+        $data = $this->getCore()->getOptimizer()->hasType(MenuElementContract::class)
+            ? $this->getCore()->getOptimizer()->getType(MenuElementContract::class)
+            : null;
+
+        return $this->menuAutoloader->resolve($data);
     }
 
     abstract public function build(): Layout;

--- a/tests/Feature/MenuAutoloaderTest.php
+++ b/tests/Feature/MenuAutoloaderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use MoonShine\Contracts\MenuManager\MenuAutoloaderContract;
+use MoonShine\Contracts\MenuManager\MenuElementContract;
+use MoonShine\Laravel\Resources\MoonShineUserResource;
+use MoonShine\MenuManager\MenuGroup;
+
+uses()->group('menu-autoloader');
+
+it('resolve', function () {
+    $autoloader = app(MenuAutoloaderContract::class);
+    $items = $autoloader->resolve();
+    $group = $items[0];
+    $filler = $group->getItems()[0]->getFiller();
+
+    expect($items)
+        ->toContainOnlyInstancesOf(MenuElementContract::class)
+        ->and($group)
+        ->toBeInstanceOf(MenuGroup::class)
+        ->and($filler)
+        ->toBeInstanceOf(MoonShineUserResource::class)
+    ;
+});
+
+it('resolve cached', function () {
+    $autoloader = app(MenuAutoloaderContract::class);
+    $cached = $autoloader->toArray();
+    $items = $autoloader->resolve($cached);
+    $group = $items[0];
+    $filler = $group->getItems()[0]->getFiller();
+
+    expect($items)
+        ->toContainOnlyInstancesOf(MenuElementContract::class)
+        ->and($group)
+        ->toBeInstanceOf(MenuGroup::class)
+        ->and($filler)
+        ->toBeInstanceOf(MoonShineUserResource::class)
+    ;
+});
+
+it('to array', function () {
+    $autoloader = app(MenuAutoloaderContract::class);
+    $items = $autoloader->toArray();
+    $snapshot = [
+        'position' => 1,
+        'group' => [
+            'class' => 'MoonShine\Laravel\Resources\MoonShineUserRoleResource',
+            'label' => 'moonshine::ui.resource.system',
+            'icon' => 'users',
+            'canSee' => null,
+            'translatable' => true,
+        ],
+        'items' => [
+            0 => [
+                'filler' => 'MoonShine\Laravel\Resources\MoonShineUserResource',
+                'canSee' => null,
+                'position' => 1,
+            ],
+            1 => [
+                'filler' => 'MoonShine\Laravel\Resources\MoonShineUserRoleResource',
+                'canSee' => null,
+                'position' => 1,
+            ],
+        ]
+    ];
+
+    $group = $items[0];
+
+    expect($group)
+        ->toMatchArray($snapshot)
+    ;
+});


### PR DESCRIPTION
# Menu autoload

Continuing the feature #1552 

The feature allows you to automatically load the menu based on your resources and pages, adjust groups and much more you can do through attributes

### Before 

```php
class AppLayout extends BaseLayout
{
    /**
     * @return list<MenuElementContract>
     */
    protected function menu(): array
    {
        return [
            MenuGroup::make(static fn () => __('moonshine::ui.resource.system'), [
                MenuItem::make(
                    static fn () => __('moonshine::ui.resource.admins_title'),
                    MoonShineUserResource::class
                ),
                MenuItem::make(
                    static fn () => __('moonshine::ui.resource.role_title'),
                    MoonShineUserRoleResource::class
                ),
            ]),
        ];
    }
}
```

### After 

```php
final class MoonShineLayout extends AppLayout
{
    protected function menu(): array
    {
        return $this->autoloadMenu();
    }
}
```

The method is to perform the download, but to speed up the process you can use the optimize command and then the menu generation will occur from the cache

### If you need to skip a page or resource in the menu, use the SkipMenu attribute.

```php
#[SkipMenu]
class ProfilePage extends Page {}
```

### If you need to wrap pages or resources into groups, use the Group attribute, the items will be grouped by name. You also have options with a group icon and a flag to translate the label or not

```php
#[Group('moonshine::ui.profile', 'users', translatable: true)]
class ProfilePage extends Page {}
```

### If you need to display a menu item with a condition, use the CanSee attribute

```php
#[CanSee(method: 'someMethod')]
class ArticleResource extends ModelResource
{
    public function someMethod(): bool
    {
        return false;
    }
}
```

### If you need ordering menu

```php
#[Order(1)]
class ArticleResource extends ModelResource
{
}
```