### PR TITLE
feat: horizontal mode for BelongsToMany

### DIFF
--- a/src/Laravel/src/Fields/Relationships/BelongsToMany.php
+++ b/src/Laravel/src/Fields/Relationships/BelongsToMany.php
@@ -22,6 +22,7 @@ use MoonShine\Laravel\Contracts\Fields\HasAsyncSearchContract;
 use MoonShine\Laravel\Contracts\Fields\HasPivotContract;
 use MoonShine\Laravel\Contracts\Fields\HasRelatedValuesContact;
 use MoonShine\Laravel\Traits\Fields\BelongsToOrManyCreatable;
+use MoonShine\Laravel\Traits\Fields\HasHorizontalMode;
 use MoonShine\Laravel\Traits\Fields\HasTreeMode;
 use MoonShine\Laravel\Traits\Fields\WithAsyncSearch;
 use MoonShine\Laravel\Traits\Fields\WithRelatedLink;
@@ -65,6 +66,7 @@ class BelongsToMany extends ModelRelationField implements
     use HasPlaceholder;
     use WithRelatedLink;
     use BelongsToOrManyCreatable;
+    use HasHorizontalMode;
 
     protected string $view = 'moonshine::fields.relationships.belongs-to-many';
 
@@ -282,7 +284,7 @@ class BelongsToMany extends ModelRelationField implements
             return $this->getValues()->toArray();
         }
 
-        if ($this->isTree()) {
+        if ($this->isTree() || $this->isHorizontalMode()) {
             return $this->getKeys();
         }
 
@@ -479,7 +481,7 @@ class BelongsToMany extends ModelRelationField implements
     {
         $requestValues = collect($this->getRequestValue() ?: []);
 
-        if ($this->isSelectMode() || $this->isTree()) {
+        if ($this->isSelectMode() || $this->isTree() || $this->isHorizontalMode()) {
             return $requestValues;
         }
 
@@ -515,7 +517,7 @@ class BelongsToMany extends ModelRelationField implements
 
         $checkedKeys = $this->getCheckedKeys();
 
-        if ($this->isSelectMode() || $this->isTree() || $this->getFields()->isEmpty()) {
+        if ($this->isSelectMode() || $this->isTree() || $this->isHorizontalMode() || $this->getFields()->isEmpty()) {
             $item->{$this->getRelationName()}()->sync($checkedKeys);
 
             return $data;
@@ -620,6 +622,7 @@ class BelongsToMany extends ModelRelationField implements
     {
         $viewData = [
             'isTreeMode' => $this->isTree(),
+            'isHorizontalMode' => $this->isHorizontalMode(),
             'isSelectMode' => $this->isSelectMode(),
             'isAsyncSearch' => $this->isAsyncSearch(),
             'asyncSearchUrl' => $this->isAsyncSearch() ? $this->getAsyncSearchUrl() : '',
@@ -646,6 +649,14 @@ class BelongsToMany extends ModelRelationField implements
             return [
                 ...$viewData,
                 'treeHtml' => $this->toTreeHtml(),
+            ];
+        }
+
+
+        if ($this->isHorizontalMode()) {
+            return [
+                ...$viewData,
+                'listHtml' => $this->toListHtml(),
             ];
         }
 

--- a/src/Laravel/src/Traits/Fields/HasHorizontalMode.php
+++ b/src/Laravel/src/Traits/Fields/HasHorizontalMode.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Laravel\Traits\Fields;
+
+
+use Illuminate\Support\Collection;
+use Closure;
+use MoonShine\UI\Fields\Checkbox;
+use Throwable;
+
+trait HasHorizontalMode
+{
+    protected bool $isHorizontal = false;
+    protected string $listHtml = '';
+    protected string $minColWidth = '200px';
+    protected string $maxColWidth = '1fr';
+
+    public function horizontalMode(Closure|bool|null $condition = null, string $minColWidth = '200px', string $maxColWidth = '1fr'): static
+    {
+        $this->isHorizontal = value($condition, $this) ?? true;
+
+        if ($this->isHorizontalMode()) {
+            $this->minColWidth = $minColWidth;
+            $this->maxColWidth = $maxColWidth;
+        }
+
+        return $this;
+    }
+
+    public function isHorizontalMode(): bool
+    {
+        return $this->isHorizontal;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function toListHtml(): string
+    {
+        $data = $this->resolveValuesQuery()
+            ->get();
+
+        $this->listHtml = '';
+
+        return $this->buildList($data);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    protected function buildList(Collection $data): string
+    {
+        foreach ($data as $item) {
+            $label = $this->getColumnOrFormattedValue($item, data_get($item, $this->getResourceColumn()));
+
+            $element = Checkbox::make($label)
+                ->formName($this->getFormName())
+                ->simpleMode()
+                ->customAttributes($this->getAttributes()->jsonSerialize())
+                ->customAttributes($this->getReactiveAttributes())
+                ->setNameAttribute($this->getNameAttribute((string) $item->getKey()))
+                ->setValue($item->getKey());
+
+            $this->listHtml .= str((string) $element)->wrap("<li>","</li>");
+        }
+
+        return str($this->listHtml)->wrap(
+            "<ul class='horizontal-list' style='grid-template-columns: repeat(auto-fill, minmax($this->minColWidth, $this->maxColWidth))'>",
+            "</ul>"
+        )->value();
+    }
+}

--- a/src/UI/resources/css/base/common.css
+++ b/src/UI/resources/css/base/common.css
@@ -163,6 +163,19 @@ ul.tree-list {
   }
 }
 
+/* Checkboxes horizontal */
+ul.horizontal-list {
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  @apply grid items-center;
+  li {
+    @apply pe-2 pb-2;
+
+    .form-group {
+      @apply flex-nowrap;
+    }
+  }
+}
+
 /* Images in a row */
 .images-row {
   @apply flex;

--- a/src/UI/resources/views/fields/relationships/belongs-to-many.blade.php
+++ b/src/UI/resources/views/fields/relationships/belongs-to-many.blade.php
@@ -8,7 +8,9 @@
     'isAsyncSearch' => false,
     'isSelectMode' => false,
     'isTreeMode' => false,
+    'isHorizontalMode' => false,
     'treeHtml' => '',
+    'listHtml' => '',
     'asyncSearchUrl' => '',
     'isCreatable' => false,
     'createButton' => '',
@@ -45,6 +47,10 @@
             @elseif($isTreeMode)
                 <div x-data="belongsToMany" x-init='tree(@json($keys))'>
                     {!! $treeHtml !!}
+                </div>
+            @elseif($isHorizontalMode)
+                <div x-data="belongsToMany" x-init='tree(@json($keys))'>
+                    {!! $listHtml !!}
                 </div>
             @else
                 @if($isAsyncSearch)


### PR DESCRIPTION
## Why?
Adds the ability to display elements in the BelongsToMany field in horizontal mode. You can now choose between vertical and horizontal display, which improves the user interface and makes it more flexible.

```php
horizontalMode(Closure|bool|null $condition = null, string $minColWidth = '200px', string $maxColWidth = '1fr')
```
- `$condition` -  (optional) condition for setting the field to horizontal mode,
- `$minColWidth` -  (optional) min column width,
- `$maxColWidth` -  (optional) max column width.

```php
BelongsToMany::make('Categories')
    ->horizontalMode(true, minColWidth: '100px', maxColWidth: '33%')
```

before:
![Снимок экрана 2025-02-24 в 11 17 51](https://github.com/user-attachments/assets/ddb62fbc-eb8a-4569-9d81-f79574a819b6)

after:
![Снимок экрана 2025-02-24 в 11 16 56](https://github.com/user-attachments/assets/29bb1016-88ae-40ed-8232-3e8855e8fe2d)

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Tests added
- [ ] Documentation
