### PR TITLE
Added customization of the locale parameter name

### DIFF
--- a/src/Contracts/src/Core/DependencyInjection/ConfiguratorContract.php
+++ b/src/Contracts/src/Core/DependencyInjection/ConfiguratorContract.php
@@ -49,6 +49,8 @@ interface ConfiguratorContract extends ArrayAccess
 
     public function getLocale(): string;
 
+    public function getLocaleKey(): string;
+
     public function getDisk(): string;
 
     /**

--- a/src/Laravel/config/moonshine.php
+++ b/src/Laravel/config/moonshine.php
@@ -92,6 +92,7 @@ return [
 
     // Localizations
     'locale' => 'en',
+    'locale_key' => ChangeLocale::KEY,
     'locales' => [
         // en
     ],

--- a/src/Laravel/src/Components/Layout/Locales.php
+++ b/src/Laravel/src/Components/Layout/Locales.php
@@ -7,7 +7,6 @@ namespace MoonShine\Laravel\Components\Layout;
 use Illuminate\Support\Collection;
 use MoonShine\Core\Traits\WithCore;
 use MoonShine\Laravel\DependencyInjection\MoonShine;
-use MoonShine\Laravel\Http\Middleware\ChangeLocale;
 use MoonShine\UI\Components\MoonShineComponent;
 
 /**
@@ -29,7 +28,7 @@ final class Locales extends MoonShineComponent
         $this->locales = collect($this->getCore()->getConfig()->getLocales())
             ->mapWithKeys(fn (string $locale, int|string $code): array => [
                 $this->getCore()->getRequest()->getUrlWithQuery([
-                    ChangeLocale::KEY => is_numeric($code) ? $locale : $code,
+                    moonshineConfig()->getLocaleKey() => is_numeric($code) ? $locale : $code,
                 ]) => $locale,
             ]);
     }

--- a/src/Laravel/src/DependencyInjection/MoonShineConfigurator.php
+++ b/src/Laravel/src/DependencyInjection/MoonShineConfigurator.php
@@ -155,6 +155,11 @@ final class MoonShineConfigurator implements ConfiguratorContract
         return $this->get('locale', 'en');
     }
 
+    public function localeKey(string $name): self
+    {
+        return $this->set('locale_key', $name);
+    }
+
     public function getLocaleKey(): string
     {
         return $this->get('locale_key', ChangeLocale::KEY);

--- a/src/Laravel/src/DependencyInjection/MoonShineConfigurator.php
+++ b/src/Laravel/src/DependencyInjection/MoonShineConfigurator.php
@@ -14,6 +14,7 @@ use MoonShine\Contracts\Core\ResourceContract;
 use MoonShine\Contracts\UI\FormBuilderContract;
 use MoonShine\Laravel\Enums\Ability;
 use MoonShine\Laravel\Exceptions\MoonShineNotFoundException;
+use MoonShine\Laravel\Http\Middleware\ChangeLocale;
 use MoonShine\Laravel\Layouts\AppLayout;
 use MoonShine\UI\AbstractLayout;
 use Throwable;
@@ -152,6 +153,11 @@ final class MoonShineConfigurator implements ConfiguratorContract
     public function getLocale(): string
     {
         return $this->get('locale', 'en');
+    }
+
+    public function getLocaleKey(): string
+    {
+        return $this->get('locale_key', ChangeLocale::KEY);
     }
 
     public function getCacheDriver(): string

--- a/src/Laravel/src/Http/Middleware/ChangeLocale.php
+++ b/src/Laravel/src/Http/Middleware/ChangeLocale.php
@@ -14,9 +14,11 @@ final class ChangeLocale
 
     public function handle(Request $request, Closure $next): Response
     {
+        $key = moonshineConfig()->getLocaleKey();
+
         $locale = $request->input(
-            self::KEY,
-            session(self::KEY, moonshineConfig()->getLocale())
+            $key,
+            session($key, moonshineConfig()->getLocale())
         );
 
         $locale = strtolower((string) $locale);
@@ -30,8 +32,8 @@ final class ChangeLocale
             moonshineConfig()->locale($locale);
         }
 
-        if ($request->has(self::KEY)) {
-            session()->put(self::KEY, $locale);
+        if ($request->has($key)) {
+            session()->put($key, $locale);
         }
 
         return $next($request);

--- a/tests/Feature/LocalizationTest.php
+++ b/tests/Feature/LocalizationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use MoonShine\Laravel\Http\Middleware\ChangeLocale;
+
+uses()->group('core');
+uses()->group('localization');
+
+beforeEach(function () {
+    config()->set('moonshine.locales', ['en', 'foo']);
+
+    app('translator')->setLoaded([
+        'moonshine' => [
+            'ui' => [
+                'en'  => ['404' => 'Houston we have a problem page not found'],
+                'foo' => ['404' => 'Something message'],
+            ],
+        ],
+    ]);
+});
+
+it('checks the localization with the default key name', function () {
+    asAdmin()->get('/admin/foo')
+        ->assertSee('Houston we have a problem page not found')
+        ->assertDontSee('Something message')
+        ->assertNotFound();
+
+    asAdmin()->get('/admin/foo?' . http_build_query([ChangeLocale::KEY => 'foo']))
+        ->assertDontSee('Houston we have a problem page not found')
+        ->assertSee('Something message')
+        ->assertNotFound();
+});
+
+it('checks the localization with the custom key name', function () {
+    config()->set('moonshine.locale_key', 'qwerty');
+
+    asAdmin()->get('/admin/foo')
+        ->assertSee('Houston we have a problem page not found')
+        ->assertDontSee('Something message')
+        ->assertNotFound();
+
+    asAdmin()->get('/admin/foo?' . http_build_query([ChangeLocale::KEY => 'foo']))
+        ->assertSee('Houston we have a problem page not found')
+        ->assertDontSee('Something message')
+        ->assertNotFound();
+
+    asAdmin()->get('/admin/foo?' . http_build_query(['qwerty' => 'foo']))
+        ->assertDontSee('Houston we have a problem page not found')
+        ->assertSee('Something message')
+        ->assertNotFound();
+});


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added parameter name customization to set localization.

## Why?
At the moment, to change the name of the localization key you need to write your own handlers ignoring the “box” handlers, which is inconvenient.

PR proposes to add the ability to customize the key name while keeping backward compatibility as a constant.

The proposed version of the code will allow the administrator panel to more flexibly customize interaction with other parts of the application.

For example, at https://kvede.com the localization parameter is called `locale` and it is easier to write your own wrapper for the admin panel. After accepting the changes, all you have to do is to specify the new key name in the settings.

Also example: https://laravel-lang.com/configuration.html#routes

## Checklist

- Issue: https://github.com/moonshine-software/doc/pull/827
- Tested
    - [x] Tested manually
    - [x] Tests added
- [x] Documentation
