### PR TITLE
feat: OptionImage

### DIFF
--- a/src/Support/src/DTOs/Select/OptionImage.php
+++ b/src/Support/src/DTOs/Select/OptionImage.php
@@ -9,14 +9,14 @@ use Illuminate\Contracts\Support\Arrayable;
 final readonly class OptionImage implements Arrayable
 {
     public function __construct(
-        private ?string $src = null,
+        private string $src,
         private int $width = 10,
         private int $height = 10,
         private string $objectFit = 'cover',
     ) {
     }
 
-    public function getSrc(): ?string
+    public function getSrc(): string
     {
         return $this->src;
     }

--- a/src/Support/src/DTOs/Select/OptionImage.php
+++ b/src/Support/src/DTOs/Select/OptionImage.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Support\DTOs\Select;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+final readonly class OptionImage implements Arrayable
+{
+    public function __construct(
+        private ?string $src = null,
+        private int $width = 10,
+        private int $height = 10,
+        private string $objectFit = 'cover',
+    ) {
+    }
+
+    public function getSrc(): ?string
+    {
+        return $this->src;
+    }
+
+    public function getWidth(): int
+    {
+        return $this->width;
+    }
+
+    public function getHeight(): int
+    {
+        return $this->height;
+    }
+
+    public function getObjectFit(): string
+    {
+        return $this->objectFit;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'src' => $this->getSrc(),
+            'width' => $this->getWidth(),
+            'height' => $this->getHeight(),
+            'objectFit' => $this->getObjectFit(),
+        ];
+    }
+}

--- a/src/Support/src/DTOs/Select/OptionImage.php
+++ b/src/Support/src/DTOs/Select/OptionImage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\Support\DTOs\Select;
 
 use Illuminate\Contracts\Support\Arrayable;
+use MoonShine\Support\Enums\ObjectFit;
 
 final readonly class OptionImage implements Arrayable
 {
@@ -12,7 +13,7 @@ final readonly class OptionImage implements Arrayable
         private string $src,
         private int $width = 10,
         private int $height = 10,
-        private string $objectFit = 'cover',
+        private ObjectFit $objectFit = ObjectFit::COVER,
     ) {
     }
 
@@ -33,7 +34,7 @@ final readonly class OptionImage implements Arrayable
 
     public function getObjectFit(): string
     {
-        return $this->objectFit;
+        return $this->objectFit->value;
     }
 
     public function toArray(): array

--- a/src/Support/src/DTOs/Select/OptionProperty.php
+++ b/src/Support/src/DTOs/Select/OptionProperty.php
@@ -9,19 +9,25 @@ use Illuminate\Contracts\Support\Arrayable;
 final readonly class OptionProperty implements Arrayable
 {
     public function __construct(
-        private ?string $image = null,
+	    private null|string|OptionImage $image = null,
     ) {
     }
 
-    public function getImage(): ?string
+    public function getImage(): null|string|OptionImage
     {
         return $this->image;
     }
 
     public function toArray(): array
     {
-        return [
-            'image' => $this->getImage(),
-        ];
+	    $image = $this->getImage();
+
+	    if ($image instanceof OptionImage) {
+		    $image = $image->toArray();
+	    }
+
+	    return [
+		    'image' => $image,
+	    ];
     }
 }

--- a/src/Support/src/DTOs/Select/Options.php
+++ b/src/Support/src/DTOs/Select/Options.php
@@ -76,7 +76,7 @@ final readonly class Options implements Arrayable
 
         $properties = $this->normalizeProperties($properties);
 
-        return new OptionProperty(...$properties ?? []);
+        return new OptionProperty(...$properties);
     }
 
     /**

--- a/src/Support/src/DTOs/Select/Options.php
+++ b/src/Support/src/DTOs/Select/Options.php
@@ -73,6 +73,10 @@ final readonly class Options implements Arrayable
             return $properties;
         }
 
+	    if (isset($properties['image']) && ! $properties['image'] instanceof OptionImage) {
+		    $properties['image'] = new OptionImage($properties['image']);
+	    }
+
         return new OptionProperty(...$properties ?? []);
     }
 

--- a/src/Support/src/DTOs/Select/Options.php
+++ b/src/Support/src/DTOs/Select/Options.php
@@ -74,7 +74,7 @@ final readonly class Options implements Arrayable
             return $properties;
         }
 
-        $this->normalizeProperties($properties);
+        $properties = $this->normalizeProperties($properties);
 
         return new OptionProperty(...$properties ?? []);
     }
@@ -148,25 +148,27 @@ final readonly class Options implements Arrayable
         ];
     }
 
-    private function normalizeProperties(mixed &$properties): void
+    private function normalizeProperties(array $properties): array
     {
         if (! isset($properties['image']) || $properties['image'] instanceof OptionImage) {
-            return;
+            return $properties;
         }
 
         $imageData = $properties['image'];
 
-        $properties['image'] = match (true) {
-            is_array($imageData) => new OptionImage(
-                src: $imageData['src'] ?? '',
-                width: $imageData['width'] ?? null,
-                height: $imageData['height'] ?? null,
-                objectFit: isset($imageData['objectFit'])
-                    ? ObjectFit::from($imageData['objectFit'])
-                    : null
-            ),
-            is_string($imageData) => new OptionImage($imageData),
-            default => throw new \InvalidArgumentException('Invalid image type'),
-        };
+        if (is_string($imageData)) {
+            $properties['image'] = new OptionImage($imageData);
+
+            return $properties;
+        }
+
+        $properties['image'] = new OptionImage(
+            $imageData['src'] ?? '',
+            $imageData['width'] ?? null,
+            $imageData['height'] ?? null,
+            isset($imageData['objectFit']) ? ObjectFit::from($imageData['objectFit']) : null
+        );
+
+        return $properties;
     }
 }

--- a/src/Support/src/DTOs/Select/Options.php
+++ b/src/Support/src/DTOs/Select/Options.php
@@ -166,7 +166,7 @@ final readonly class Options implements Arrayable
                     : null
             ),
             is_string($imageData) => new OptionImage($imageData),
-            default => throw new InvalidArgumentException('Invalid image type'),
+            default => throw new \InvalidArgumentException('Invalid image type'),
         };
     }
 }

--- a/src/Support/src/Enums/ObjectFit.php
+++ b/src/Support/src/Enums/ObjectFit.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Support\Enums;
+
+enum ObjectFit: string
+{
+    case CONTAIN = 'contain';
+    case COVER = 'cover';
+    case FILL = 'fill';
+    case NONE = 'none';
+    case SCALE_DOWN = 'scale-down';
+}

--- a/src/UI/resources/js/Components/Select.js
+++ b/src/UI/resources/js/Components/Select.js
@@ -113,9 +113,27 @@ export default (asyncUrl = '') => ({
       },
       searchResultLimit: 100,
       callbackOnCreateTemplates: function (strToEl, escapeForTemplate) {
+        function normalizeImageData(image) {
+          if (typeof image === 'string') {
+            return {
+              src: image,
+              width: 10,
+              height: 10,
+              objectFit: 'cover'
+            };
+          }
+
+          return {
+            src: image?.src ?? '',
+            width: image?.width ?? 10,
+            height: image?.height ?? 10,
+            objectFit: image?.objectFit ?? 'cover'
+          };
+        }
+
         return {
           item: ({classNames}, data, removeItemButton) => {
-            const { src: imgSrc, width, height, objectFit } = data.customProperties?.image;
+            const { src: imgSrc, width, height, objectFit } = normalizeImageData(data.customProperties?.image);
 
             return strToEl(`
               <div class="${classNames.item} ${
@@ -149,7 +167,7 @@ export default (asyncUrl = '') => ({
             `)
           },
           choice: ({classNames}, data) => {
-            const { src: imgSrc, width, height, objectFit } = data.customProperties?.image;
+            const { src: imgSrc, width, height, objectFit } = normalizeImageData(data.customProperties?.image);
 
             return strToEl(`
               <div class="flex gap-x-2 items-center ${classNames.item} ${classNames.itemChoice} ${

--- a/src/UI/resources/js/Components/Select.js
+++ b/src/UI/resources/js/Components/Select.js
@@ -115,11 +115,7 @@ export default (asyncUrl = '') => ({
       callbackOnCreateTemplates: function (strToEl, escapeForTemplate) {
         return {
           item: ({classNames}, data, removeItemButton) => {
-            const image = data.customProperties?.image;
-            const imgSrc = image?.src ?? image;
-            const width = image?.width;
-            const height = image?.height;
-            const objectFit = image?.objectFit;
+            const { src: imgSrc, width, height, objectFit } = data.customProperties?.image;
 
             return strToEl(`
               <div class="${classNames.item} ${
@@ -153,11 +149,7 @@ export default (asyncUrl = '') => ({
             `)
           },
           choice: ({classNames}, data) => {
-            const image = data.customProperties?.image;
-            const imgSrc = image?.src ?? image;
-            const width = image?.width;
-            const height = image?.height;
-            const objectFit = image?.objectFit;
+            const { src: imgSrc, width, height, objectFit } = data.customProperties?.image;
 
             return strToEl(`
               <div class="flex gap-x-2 items-center ${classNames.item} ${classNames.itemChoice} ${

--- a/src/UI/resources/js/Components/Select.js
+++ b/src/UI/resources/js/Components/Select.js
@@ -115,7 +115,11 @@ export default (asyncUrl = '') => ({
       callbackOnCreateTemplates: function (strToEl, escapeForTemplate) {
         return {
           item: ({classNames}, data, removeItemButton) => {
-            const image = data.customProperties?.image
+            const image = data.customProperties?.image;
+            const imgSrc = image?.src ?? image;
+            const width = image?.width;
+            const height = image?.height;
+            const objectFit = image?.objectFit;
 
             return strToEl(`
               <div class="${classNames.item} ${
@@ -127,10 +131,10 @@ export default (asyncUrl = '') => ({
               }>
                 <div class="flex gap-x-2 items-center">
                   ${
-                    image
-                      ? '<div class="zoom-in h-10 w-10 overflow-hidden rounded-md">' +
-                        '<img class="h-full w-full object-cover" src="' +
-                        escapeForTemplate(this.config.allowHTML, image) +
+                    imgSrc
+                      ? '<div class="zoom-in h-' + height + ' w-' + width + ' overflow-hidden rounded-md">' +
+                        '<img class="h-full w-full object-' + objectFit + '" src="' +
+                        escapeForTemplate(this.config.allowHTML, imgSrc) +
                         '" alt=""></div>'
                       : ''
                   }
@@ -149,7 +153,11 @@ export default (asyncUrl = '') => ({
             `)
           },
           choice: ({classNames}, data) => {
-            const image = data.customProperties?.image
+            const image = data.customProperties?.image;
+            const imgSrc = image?.src ?? image;
+            const width = image?.width;
+            const height = image?.height;
+            const objectFit = image?.objectFit;
 
             return strToEl(`
               <div class="flex gap-x-2 items-center ${classNames.item} ${classNames.itemChoice} ${
@@ -165,10 +173,10 @@ export default (asyncUrl = '') => ({
               }>
                 <div class="flex gap-x-2 items-center">
                   ${
-                    image
-                      ? '<div class="zoom-in h-10 w-10 overflow-hidden rounded-md">' +
-                        '<img class="h-full w-full object-cover" src="' +
-                        escapeForTemplate(this.config.allowHTML, image) +
+                    imgSrc
+                      ? '<div class="zoom-in h-' + height + ' w-' + width + ' overflow-hidden rounded-md">' +
+                        '<img class="h-full w-full object-' + objectFit + '" src="' +
+                        escapeForTemplate(this.config.allowHTML, imgSrc) +
                         '" alt=""></div>'
                       : ''
                   }

--- a/tests/Unit/Fields/SelectFieldTest.php
+++ b/tests/Unit/Fields/SelectFieldTest.php
@@ -211,6 +211,32 @@ describe('select field with images (passed via arrays)', function () {
             'objectFit' => ObjectFit::COVER->value
         ]);
     });
+
+    it('renders images passed via OptionImage object', function () {
+        $field = Select::make('Select field with images')
+            ->options([
+                1 => 'Option 1',
+                2 => 'Option 2',
+            ])
+            ->optionProperties(fn() => [
+                1 => ['image' => new OptionImage('image1.jpg', 6, 6, ObjectFit::FILL)],
+                2 => ['image' => new OptionImage('image2.png')],
+            ]);
+
+        $result = $field->toArray();
+
+        expect($result['values'][1]['properties']['image'])->toBe([
+            'src' => 'image1.jpg',
+            'width' => 6,
+            'height' => 6,
+            'objectFit' => ObjectFit::FILL->value
+        ])->and($result['values'][2]['properties']['image'])->toBe([
+            'src' => 'image2.png',
+            'width' => 10,
+            'height' => 10,
+            'objectFit' => ObjectFit::COVER->value
+        ]);
+    });
 });
 
 describe('select field with images (passed via Options object)', function () {

--- a/tests/Unit/Fields/SelectFieldTest.php
+++ b/tests/Unit/Fields/SelectFieldTest.php
@@ -185,11 +185,72 @@ describe('basic methods', function () {
     });
 });
 
-describe('select field with images', function () {
-    beforeEach(function (): void {
-        $optionsWithImages = new Options([
+describe('select field with images (passed via arrays)', function () {
+    it('renders images passed as strings', function () {
+        $field = Select::make('Select field with images')
+            ->options([
+                1 => 'Option 1',
+                2 => 'Option 2',
+            ])
+            ->optionProperties(fn() => [
+                1 => ['image' => 'image1.jpg'],
+                2 => ['image' => 'image2.png'],
+            ]);
+
+        $result = $field->toArray();
+
+        expect($result['values'][1]['properties']['image'])->toBe([
+            'src' => 'image1.jpg',
+            'width' => 10,
+            'height' => 10,
+            'objectFit' => ObjectFit::COVER->value
+        ])->and($result['values'][2]['properties']['image'])->toBe([
+            'src' => 'image2.png',
+            'width' => 10,
+            'height' => 10,
+            'objectFit' => ObjectFit::COVER->value
+        ]);
+    });
+});
+
+describe('select field with images (passed via Options object)', function () {
+    it('renders images passed as strings', function () {
+        $options = new Options([
             new Option(
-                'Image 1',
+                'Option 1',
+                '1',
+                properties: new OptionProperty('image1.jpg')
+            ),
+            new Option(
+                'Option 2',
+                '2',
+                true,
+                properties: new OptionProperty('image2.png')
+            )
+        ]);
+
+        $field = Select::make('Select field with images')
+            ->options($options);
+
+        $result = $field->toArray();
+
+        expect($result['values'][1]['properties']['image'])->toBe([
+            'src' => 'image1.jpg',
+            'width' => 10,
+            'height' => 10,
+            'objectFit' => ObjectFit::COVER->value
+        ])->and($result['values'][2]['properties']['image'])->toBe([
+            'src' => 'image2.png',
+            'width' => 10,
+            'height' => 10,
+            'objectFit' => ObjectFit::COVER->value
+        ]);
+    });
+
+    it('renders images passed via OptionImage', function () {
+        $options = new Options([
+            new Option(
+                'Option 1',
                 '1',
                 properties: new OptionProperty(
                     new OptionImage(
@@ -201,7 +262,7 @@ describe('select field with images', function () {
                 )
             ),
             new Option(
-                'Image 2',
+                'Option 2',
                 '2',
                 properties: new OptionProperty(
                     new OptionImage(
@@ -213,36 +274,40 @@ describe('select field with images', function () {
             )
         ]);
 
-        $this->fieldWithImages = Select::make('Select field with images')
-            ->options($optionsWithImages)
+        $field = Select::make('Select field with images')
+            ->options($options)
             ->default('2')
             ->multiple();
-    });
 
-    it('renders images in options', function () {
-        $result = $this->fieldWithImages->toArray();
+        $result = $field->toArray();
 
         expect($result['values'][1]['properties']['image'])->toBe([
             'src' => 'image1.jpg',
             'width' => 5,
             'height' => 5,
-            'objectFit' => 'cover'
+            'objectFit' => ObjectFit::COVER->value
         ])->and($result['values'][2]['properties']['image'])->toBe([
             'src' => 'image2.png',
             'width' => 8,
             'height' => 10,
-            'objectFit' => 'contain'
+            'objectFit' => ObjectFit::CONTAIN->value
         ]);
     });
 
-    it('handles invalid image types', function () {
-        $field = Select::make('Invalid images')
-            ->options([
-                1 => 'invalid_string_image',
-                new \stdClass()
-            ]);
+    it('handles empty images', function () {
+        $options = new Options([
+            new Option(
+                'Option 1',
+                '1',
+                properties: new OptionProperty()
+            )
+        ]);
 
-        expect(fn() => $field->previewMode())
-            ->not()->toThrow(Exception::class);
+        $field = Select::make('Select field with images')
+            ->options($options);
+
+        $result = $field->toArray();
+
+        expect($result['values'][1]['properties']['image'])->toBeNull();
     });
 });


### PR DESCRIPTION
## What was changed

Улучшаем стили для оформления картинок внутри Select, потому что используемые по умолчанию (`h-10 w-10` для `div`, и `object-cover` для `img`) великоваты.

Этот PR даёт возможность указывать свои высоту, ширину и вариацию `object-` для картинок. Совместимость с предыдущим вариантом сохранена.

Чтобы начать использовать новые значения, вместо прежнего варианта, с указанием только ссылки на изображение, можно указывать высоту, ширину и objectFit.

## Why?

На примере поля [MoonShine FontAwesome Field](https://github.com/dragomano/moonshine-fontawesome-field), вот как выглядит список с иконками (они слишком большие):

![sshot-22](https://github.com/user-attachments/assets/2be86027-fa83-4271-a389-e0b16e4e0869)

А вот как он выглядит после внесения предоставленных правок:

![sshot-21](https://github.com/user-attachments/assets/840186cb-5b3f-446e-8d3b-122d7b564d29)

Изменения в самом MoonShine FontAwesome Field:

До:

```php
fn($item) => [
    'image' => sprintf($link, $this->getDirectoryFromStyle($item), $this->getShortName($item)),
],
```

После:

```php
fn($item) => [
    'image' => new OptionImage(
        sprintf($link, $this->getDirectoryFromStyle($item), $this->getShortName($item)),
        6,
        6,
        'contain'
    )
],
```

### На примере другого списка

До правок:

![sshot-19](https://github.com/user-attachments/assets/a3b69b7c-be54-479b-be0a-a4c190df4fe1)

После правок:

![sshot-20](https://github.com/user-attachments/assets/819920e8-9f4d-4117-a937-c14371940c06)

## Checklist

- Issue #1554 
- Tested
    - [x] Tested manually
    - [x] Tests added
- [x] Documentation