### PR TITLE
fix sticky buttons

### DIFF
--- a/src/UI/resources/js/Components/TableBuilder.js
+++ b/src/UI/resources/js/Components/TableBuilder.js
@@ -329,12 +329,25 @@ export default (
    *
    */
   updateStickyColumns() {
-    const trs = Array.from(this.table?.querySelectorAll('tr') || [])
+    const trs = [];
+    if (this.table) {
+      if (this.table.tBodies.length > 0) {
+        trs.push(...Array.from(this.table.tBodies[0].rows));
+      }
+      if (this.table.tHead) {
+        trs.push(...Array.from(this.table.tHead.rows));
+      }
+      if (this.table.tFoot) {
+        trs.push(...Array.from(this.table.tFoot.rows));
+      }
+    }
     const trsWithStickyCol = trs.filter(tr => tr.querySelector(`.${this.stickyColClass}`))
     if (trsWithStickyCol.length < 1) return
 
     const refRow = trsWithStickyCol[0]
-    const refRowCells = Array.from(refRow.querySelectorAll('td,th') || [])
+    const refRowCells = Array.from(refRow.children).filter(child =>
+      child.tagName === 'TD' || child.tagName === 'TH'
+    );
     const otherRows = trs.filter(tr => tr !== refRow)
 
     const stickyCells = refRowCells.filter(cell => cell.classList.contains(this.stickyColClass))
@@ -365,7 +378,9 @@ export default (
 
     // Apply the same values to TD cells
     otherRows.forEach(row => {
-      const cells = row.querySelectorAll('td')
+      const cells = Array.from(row.children).filter(child =>
+        child.tagName === 'TD' || child.tagName === 'TH'
+      );
       stickyCells.forEach(stCell => {
         const index = refRowCells.indexOf(stCell)
         const cell = cells[index]


### PR DESCRIPTION
## Why?
When a table contains a nested table sticky buttons stop working

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Tests added
