### PR TITLE
force dark theme sidebars, topbar and mobilebar

### DIFF
--- a/src/Laravel/src/Layouts/AppLayout.php
+++ b/src/Laravel/src/Layouts/AppLayout.php
@@ -49,7 +49,7 @@ class AppLayout extends BaseLayout
                 Body::make([
                     Wrapper::make([
                         // $this->getTopBarComponent(),
-                        $this->getSidebarComponent()->class('dark'),
+                        $this->getSidebarComponent(),
 
                         Div::make([
                             Fragment::make([

--- a/src/Laravel/src/Layouts/AppLayout.php
+++ b/src/Laravel/src/Layouts/AppLayout.php
@@ -49,7 +49,7 @@ class AppLayout extends BaseLayout
                 Body::make([
                     Wrapper::make([
                         // $this->getTopBarComponent(),
-                        $this->getSidebarComponent(),
+                        $this->getSidebarComponent()->class('dark'),
 
                         Div::make([
                             Fragment::make([

--- a/src/UI/resources/css/base/layout.css
+++ b/src/UI/resources/css/base/layout.css
@@ -93,6 +93,10 @@
     @apply fixed inset-y-0 left-5 z-[101] box-content flex shrink-0 flex-col justify-between lg:pt-6;
     height: calc(100vh - 4rem);
 
+    & > * {
+      @apply text-gray-800 dark:text-slate-300;
+    }
+
     .search-wrapper {
       @apply mt-4 lg:pr-4 xl:pr-5;
 

--- a/src/UI/resources/css/base/layout.css
+++ b/src/UI/resources/css/base/layout.css
@@ -3,6 +3,14 @@
   &-wrapper {
     @apply relative flex min-h-screen flex-col gap-y-5 py-3 transition-all md:p-5 lg:flex-row lg:p-6;
 
+    .layout-menu,
+    .layout-menu-horizontal,
+    .layout-menu-mobile {
+      & > * {
+        @apply text-gray-800 dark:text-slate-300;
+      }
+    }
+
     .layout-menu-horizontal ~ .layout-menu,
     .layout-menu ~ .layout-menu-horizontal {
       @apply mobile:!hidden;
@@ -92,10 +100,6 @@
   &-menu {
     @apply fixed inset-y-0 left-5 z-[101] box-content flex shrink-0 flex-col justify-between lg:pt-6;
     height: calc(100vh - 4rem);
-
-    & > * {
-      @apply text-gray-800 dark:text-slate-300;
-    }
 
     .search-wrapper .search-form-field {
       @apply focus:ring-0;

--- a/src/UI/resources/css/base/layout.css
+++ b/src/UI/resources/css/base/layout.css
@@ -97,12 +97,8 @@
       @apply text-gray-800 dark:text-slate-300;
     }
 
-    .search-wrapper {
-      @apply mt-4 lg:pr-4 xl:pr-5;
-
-      .search-form-show {
-        @apply text-white;
-      }
+    .search-wrapper .search-form-field {
+      @apply focus:ring-0;
     }
   }
 

--- a/src/UI/resources/css/components/menu.css
+++ b/src/UI/resources/css/components/menu.css
@@ -482,100 +482,98 @@
       }
 
       &-item {
-        @apply relative rounded-lg text-white transition-all current:bg-menu-current-bg current:font-medium current:text-menu-current-color current:opacity-100 current:transition-none current:dark:font-normal;
         &._is-active {
-          &::before,
-          &::after {
-            @apply absolute -right-5 z-1 hidden h-4 w-4 bg-slate-50 dark:bg-dark-700;
-            content: '';
-            mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='259.51' height='259.52' viewBox='0 0 259.51 259.52'%3E%3Cpath d='M8659.507,423.965c-.167-2.608.05-5.319-.19-8.211-.084-1.012-.031-2.15-.118-3.12-.113-1.25-.1-2.682-.236-4.061-.172-1.722-.179-3.757-.365-5.394-.328-2.889-.478-5.857-.854-8.61-.509-3.714-.825-7.252-1.38-10.543-.934-5.535-2.009-11.312-3.189-16.692-.855-3.9-1.772-7.416-2.752-11.2-1.1-4.256-2.394-8.149-3.687-12.381-1.1-3.615-2.366-6.893-3.623-10.493-1.3-3.739-2.917-7.26-4.284-10.7-1.708-4.295-3.674-8.078-5.485-12.023-1.145-2.493-2.5-4.932-3.727-7.387-1.318-2.646-2.9-5.214-4.152-7.518-1.716-3.16-3.517-5.946-5.274-8.873-1.692-2.818-3.589-5.645-5.355-8.334-2.326-3.542-4.637-6.581-7.039-9.848-2.064-2.809-4.017-5.255-6.088-7.828-2.394-2.974-4.937-5.936-7.292-8.589-3.027-3.411-6.049-6.744-9.055-9.763-2.4-2.412-4.776-4.822-7.108-6.975-3-2.767-5.836-5.471-8.692-7.854-3.332-2.779-6.657-5.663-9.815-8.028-2.958-2.216-5.784-4.613-8.7-6.6-3.161-2.159-6.251-4.414-9.219-6.254-3.814-2.365-7.533-4.882-11.168-6.89-4.213-2.327-8.513-4.909-12.478-6.834-4.61-2.239-9.234-4.619-13.51-6.416-4.1-1.725-8.11-3.505-11.874-4.888-4.5-1.652-8.506-3.191-12.584-4.47-6.045-1.9-12.071-3.678-17.431-5-9.228-2.284-17.608-3.757-24.951-4.9-7.123-1.112-13.437-1.64-18.271-2.035l-2.405-.2c-1.638-.136-3.508-.237-4.633-.3a115.051,115.051,0,0,0-12.526-.227h259.51Z' transform='translate(-8399.997 -164.445)'/%3E%3C/svg%3E%0A");
-            mask-size: cover;
-          }
-          &::before {
-            @apply bottom-full rotate-180 scale-x-[-1];
-          }
-          &::after {
-            @apply top-full;
-          }
-          .menu-inner-link {
-            @apply text-menu-current-color hover:text-menu-current-color;
-            &::after {
-              @apply hidden;
-            }
+          > .menu-inner-link,
+          > .menu-inner-button {
+            @apply rounded-lg bg-slate-50 font-medium text-black opacity-100 dark:bg-dark-300 dark:font-normal dark:text-white lg:text-black lg:hover:text-inherit dark:lg:text-white;
           }
         }
       }
+
       &-link,
       &-button {
         @apply relative flex items-center gap-x-2.5 rounded-lg px-4 py-3 text-xs font-normal text-menu-link outline-none hover:bg-menu-hover/5 hover:text-menu-hover;
+
         &._is-active {
           @apply bg-menu-active-bg text-menu-active-color;
+
           .menu-inner-arrow {
             @apply scale-y-[-1];
           }
         }
+
+        > div,
         > svg {
           @apply h-6 w-6;
         }
       }
+
       &-link {
         &::after {
           content: '';
           @apply absolute inset-y-0 -right-5 hidden w-5 bg-slate-50 dark:bg-dark-700;
         }
       }
+
       &-button {
         @apply w-full;
       }
+
       &-text {
         @apply grow truncate text-left;
       }
+
       &-counter {
-        @apply h-6 shrink-0 truncate rounded-md bg-primary px-1.5 text-center text-[12px] font-medium leading-6 text-white;
+        @apply h-6 shrink-0 truncate rounded-md bg-primary px-1.5 text-center text-[12px] font-medium leading-6 text-white lg:absolute lg:-right-2 lg:top-0.5 lg:z-1 lg:max-w-[64px] lg:scale-90 xl:static xl:-right-1 xl:top-0 xl:max-w-[120px] xl:scale-100;
       }
+
       &-arrow {
         @apply transition-transform;
+
+        > div,
         > svg {
           @apply h-4 w-4;
         }
       }
+
       &-text,
       &-arrow {
-        @apply block;
+        @apply block lg:hidden xl:block;
       }
 
       /* Dropdown Menu */
       &-dropdown {
-        @apply mt-2 flex flex-col gap-y-1 rounded-lg bg-menu-dropdown-bg px-1 py-1.5;
-        .menu-inner-item {
-          &::before,
-          &::after {
-            @apply -right-6;
-          }
-        }
+        @apply mt-2 flex flex-col gap-y-2 rounded-lg bg-menu-dropdown-bg p-1;
+
         .menu-inner-link,
         .menu-inner-button {
-          &::after {
-            @apply -right-6 w-6;
-          }
-          @apply px-3.5 text-2xs;
+          @apply p-2.5 text-2xs;
+
+          > div,
           > svg {
             @apply h-5 w-5;
           }
         }
+
         .menu-inner-counter {
-          @apply h-5 bg-secondary text-[11px] leading-5;
+          @apply h-5 bg-secondary text-[11px] leading-5 lg:right-0 lg:top-0.5 lg:max-w-[48px] xl:right-1 xl:max-w-[120px];
         }
+
         .menu-inner-divider {
           @apply -ml-3.5;
+        }
+
+        .menu-inner-dropdown {
+          @apply mb-2 border-b border-t border-dashed border-slate-500 px-0;
         }
       }
 
       /* Divider */
       &-divider {
         @apply relative my-2 -ml-4 flex items-center pl-4 pr-0.5 text-slate-400 before:h-[1px] before:min-w-[16px] before:grow before:bg-slate-500;
+
         > span {
-          @apply relative z-1 block w-full truncate pl-2.5;
+          @apply relative z-1 block w-full truncate pl-2.5 lg:hidden xl:block;
         }
       }
     }

--- a/src/UI/resources/views/components/menu/group.blade.php
+++ b/src/UI/resources/views/components/menu/group.blade.php
@@ -39,7 +39,6 @@
             <x-moonshine::icon
                 icon="chevron-down"
                 size="6"
-                color="gray"
             />
         </span>
     </button>


### PR DESCRIPTION
Force dark theme for SideBar, TopBar and MobilBar

```php
$this->getSidebarComponent()->class('dark'),
$this->getTopBarComponent()->class('dark'),
MobileBar::make([
    // ...
])->class('dark'),
```


before:
![Снимок экрана 2025-03-10 в 17 47 16](https://github.com/user-attachments/assets/7d11cbf4-ab5d-454a-b6f1-ea26a9f96b39)

after:
![Снимок экрана 2025-03-10 в 17 47 31](https://github.com/user-attachments/assets/946c8e36-b39b-4c77-85a0-3b40de725f9f)


## Checklist
- Tested
    - [x] Tested manually
    - [ ] Tests added
