### PR TITLE
feat: stop filtering json + number/checkbox cast

### DIFF
--- a/src/UI/src/Fields/Checkbox.php
+++ b/src/UI/src/Fields/Checkbox.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MoonShine\UI\Fields;
 
+use Closure;
 use Illuminate\Contracts\Support\Renderable;
 use MoonShine\Support\AlpineJs;
 use MoonShine\UI\Components\Boolean;
@@ -112,6 +113,25 @@ class Checkbox extends Field implements
         }
 
         return $additionally;
+    }
+
+    protected function resolveOnApply(): ?Closure
+    {
+        return function ($item) {
+            if($this->getOnValue() == $this->getRequestValue()) {
+                $value = $this->getOnValue();
+            } else {
+                $value = $this->getOffValue();
+            }
+
+            if(is_numeric($value)) {
+                $value = (int) $value;
+            }
+
+            data_set($item, $this->getColumn(), $value);
+
+            return $item;
+        };
     }
 
     protected function viewData(): array

--- a/src/UI/src/Fields/Json.php
+++ b/src/UI/src/Fields/Json.php
@@ -78,6 +78,8 @@ class Json extends Field implements
 
     protected null|TableBuilderContract|FieldsGroup $resolvedComponent = null;
 
+    protected bool $isFilterEmpty = true;
+
     /**
      * @throws Throwable
      */
@@ -503,8 +505,24 @@ class Json extends Field implements
         )->filter(fn ($value): bool => $this->filterEmpty($value))->toArray();
     }
 
+    public function isFilterEmpty(): bool
+    {
+        return $this->isFilterEmpty;
+    }
+
+    public function stopFilteringEmpty(): static
+    {
+        $this->isFilterEmpty = false;
+
+        return $this;
+    }
+
     private function filterEmpty(mixed $value): bool
     {
+        if(!$this->isFilterEmpty()) {
+            return true;
+        }
+
         if (is_iterable($value) && filled($value)) {
             return collect($value)
                 ->filter(fn ($v): bool => $this->filterEmpty($v))

--- a/src/UI/src/Fields/Number.php
+++ b/src/UI/src/Fields/Number.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MoonShine\UI\Fields;
 
+use Closure;
 use Illuminate\Contracts\Support\Renderable;
 use MoonShine\UI\Components\Rating;
 use MoonShine\UI\Contracts\DefaultValueTypes\CanBeNumeric;
@@ -51,6 +52,29 @@ class Number extends Field implements HasDefaultValueContract, CanBeNumeric, Has
         }
 
         return parent::resolvePreview();
+    }
+
+    protected function resolveOnApply(): ?Closure
+    {
+        return function ($item) {
+            $value = $this->getRequestValue();
+
+            if ($value === false && ! $this->isNullable()) {
+                return $item;
+            }
+
+            if ($value === false && $this->isNullable()) {
+                data_set($item, $this->getColumn(), null);
+
+                return $item;
+            }
+
+            $value = filter_var($value, FILTER_VALIDATE_FLOAT) ? (float) $value : (int) $value;
+
+            data_set($item, $this->getColumn(), $value);
+
+            return $item;
+        };
     }
 
     protected function viewData(): array

--- a/src/UI/src/Fields/Number.php
+++ b/src/UI/src/Fields/Number.php
@@ -69,7 +69,16 @@ class Number extends Field implements HasDefaultValueContract, CanBeNumeric, Has
                 return $item;
             }
 
-            $value = filter_var($value, FILTER_VALIDATE_FLOAT) ? (float) $value : (int) $value;
+            $value = is_string($value) ? str_replace(",", ".", $value) : $value;
+            $value = str_contains((string) $value, ".") ? (float) $value : (int) $value;
+
+            if(!\is_null($this->max) && $value > $this->max) {
+                $value = $this->max;
+            }
+
+            if(!\is_null($this->min) && $value < $this->min) {
+                $value = $this->min;
+            }
 
             data_set($item, $this->getColumn(), $value);
 

--- a/tests/Unit/Fields/CheckboxFieldTest.php
+++ b/tests/Unit/Fields/CheckboxFieldTest.php
@@ -123,7 +123,7 @@ describe('basic methods', function () {
         )
             ->toBeInstanceOf(Model::class)
             ->active
-            ->toBe($data['active']);
+            ->toBe(0);
     });
 });
 

--- a/tests/Unit/Fields/NumberFieldTest.php
+++ b/tests/Unit/Fields/NumberFieldTest.php
@@ -12,7 +12,7 @@ use MoonShine\UI\InputExtensions\InputNumberUpDown;
 uses()->group('fields');
 
 beforeEach(function (): void {
-    $this->field = Number::make('Rating');
+    $this->field = Number::make('Rating')->max(20)->min(0);
     $this->item = new class () extends Model {
         public int $rating = 3;
     };
@@ -68,8 +68,8 @@ it('preview with stars', function (): void {
         );
 });
 
-it('apply', function (): void {
-    $data = ['rating' => 5];
+it('apply', function ($rating, $toBe): void {
+    $data = ['rating' => $rating];
 
     fakeRequest(method: 'post', parameters: $data);
 
@@ -85,6 +85,13 @@ it('apply', function (): void {
     )
         ->toBeInstanceOf(Model::class)
         ->rating
-        ->toBe($data['rating'])
+        ->toBe($toBe)
     ;
-});
+})->with([
+    [5,5],
+    [5.5,5.5],
+    ["5.5",5.5],
+    ["5,5",5.5],
+    ["25",20],
+    ["-1",0],
+]);

--- a/tests/Unit/Fields/SwitcherFieldTest.php
+++ b/tests/Unit/Fields/SwitcherFieldTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Model;
+use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
 use MoonShine\UI\Components\Boolean;
 use MoonShine\UI\Fields\Checkbox;
 use MoonShine\UI\Fields\Switcher;
@@ -81,3 +82,35 @@ describe('basic methods', function () {
             ->applies($this->field);
     });
 });
+
+it('apply', function ($value, $toBe): void {
+    $data = ['active' => $value];
+
+    fakeRequest(method: 'post', parameters: $data);
+
+    expect(
+        $this->field->apply(
+            TestResourceBuilder::new()->fieldApply($this->field),
+            new class () extends Model {
+                protected $fillable = [
+                    'active',
+                ];
+            }
+        )
+    )
+        ->toBeInstanceOf(Model::class)
+        ->active
+        ->toBe($toBe)
+    ;
+})->with([
+    [0,0],
+    [1,1],
+    ["0",0],
+    ["1",1],
+    [null,0],
+    [false,0],
+    ["false",0],
+    ["",0],
+    [true,1],
+    ["true",0],
+]);


### PR DESCRIPTION
- Cast Number to int/float
- Cast Switcher to On/Off value
- Stop filtering for Json field. By default, the Json field filters all empty values, but this behavior can be disabled.

```php
Json::make()->stopFilteringEmpty()
```

## Checklist

- Issue #1632
- Tested
    - [x] Tested manually
    - [x] Tests added
- [ ] Documentation
