### PR TITLE
3.x issue 1635

### DIFF
--- a/src/UI/resources/css/components/tables.css
+++ b/src/UI/resources/css/components/tables.css
@@ -81,7 +81,7 @@ table {
     }
     td,
     th {
-      @apply max-w-lg whitespace-nowrap px-5 py-3 first:rounded-l-lg last:rounded-r-lg dark:border-dark-300 lg:whitespace-normal;
+      @apply px-5 py-3 first:rounded-l-lg last:rounded-r-lg dark:border-dark-300;
     }
   }
 
@@ -91,13 +91,29 @@ table {
     }
     td:not([class$='-bulk-actions']),
     th {
-      @apply max-w-lg whitespace-nowrap px-5 py-3 first:rounded-l-lg last:rounded-r-lg dark:border-dark-300 lg:whitespace-normal;
+      @apply px-5 py-3 first:rounded-l-lg last:rounded-r-lg dark:border-dark-300;
     }
   }
 
   td,
   th {
-    @apply bg-inherit;
+    @apply relative bg-inherit max-w-md whitespace-nowrap overflow-hidden;
+
+    &.fit-content {
+      @apply min-w-fit;
+    }
+
+    &.min-content {
+      @apply whitespace-normal min-w-96;
+    }
+  }
+
+  .text-ellipsis {
+    @apply whitespace-nowrap overflow-hidden;
+  }
+
+  .text-clamp {
+    @apply line-clamp-3 md:line-clamp-none;
   }
 
   &[data-click-action] {

--- a/src/UI/resources/js/Components/TableBuilder.js
+++ b/src/UI/resources/js/Components/TableBuilder.js
@@ -77,6 +77,8 @@ export default (
           this.initStickyColumns()
         })
       }
+
+      this.$nextTick().then(() => this.initCellWidth())
     }
 
     if (this.container?.dataset?.lazy) {
@@ -84,6 +86,26 @@ export default (
       this.container.removeAttribute('data-lazy')
 
       this.$nextTick(() => dispatchEvents(event, 'success', this))
+    }
+  },
+  initCellWidth() {
+    if (!this.table || !this.table.classList.contains('table-list')) return
+
+    const cells = this.table.querySelectorAll('th, td')
+
+    cells.forEach(cell => {
+      if (cell.closest('table') === this.table) {
+        this.updateCellWidth(cell)
+      }
+    })
+  },
+  updateCellWidth(cell) {
+    if (!cell) return
+
+    if (cell.scrollWidth <= cell.clientWidth) {
+      cell.classList.add("fit-content")
+    } else {
+      cell.classList.add("min-content")
     }
   },
   add(force = false) {

--- a/src/UI/resources/views/components/url.blade.php
+++ b/src/UI/resources/views/components/url.blade.php
@@ -7,15 +7,18 @@
 ])
 <a href="{{ $href }}"
    {{ $attributes->merge([
-        'class' => 'inline-flex items-center gap-1',
+        'class' => 'inline-flex items-center gap-1 max-w-full',
    ]) }}
     @if($blank) target="_blank" @endif
 >
     @if(!$withoutIcon && $icon)
         <x-moonshine::icon
+            class="shrink-0"
             :icon="$icon"
         />
     @endif
 
-    {!! $value ?? $slot !!}
+    <div class="text-ellipsis overflow-hidden">
+        {!! $value ?? $slot !!}
+    </div>
 </a>

--- a/src/UI/src/Fields/Text.php
+++ b/src/UI/src/Fields/Text.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\UI\Fields;
 
 use Illuminate\Contracts\Support\Renderable;
+use MoonShine\UI\Components\Layout\Div;
 use MoonShine\UI\Contracts\DefaultValueTypes\CanBeString;
 use MoonShine\UI\Contracts\HasDefaultValueContract;
 use MoonShine\UI\Contracts\HasUpdateOnPreviewContract;
@@ -48,9 +49,13 @@ class Text extends Field implements HasDefaultValueContract, CanBeString, HasUpd
 
     protected function resolvePreview(): Renderable|string
     {
-        return $this->isUnescape()
-            ? parent::resolvePreview()
-            : $this->escapeValue((string) parent::resolvePreview());
+        return Div::make([
+            $this->isUnescape()
+                ? parent::resolvePreview()
+                : $this->escapeValue((string) parent::resolvePreview())
+        ])
+            ->class('text-ellipsis')
+            ->render();
     }
 
     protected function viewData(): array

--- a/src/UI/src/Fields/Text.php
+++ b/src/UI/src/Fields/Text.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\UI\Fields;
 
 use Illuminate\Contracts\Support\Renderable;
-use MoonShine\UI\Components\Layout\Div;
+use Illuminate\Support\Str;
 use MoonShine\UI\Contracts\DefaultValueTypes\CanBeString;
 use MoonShine\UI\Contracts\HasDefaultValueContract;
 use MoonShine\UI\Contracts\HasUpdateOnPreviewContract;
@@ -49,13 +49,13 @@ class Text extends Field implements HasDefaultValueContract, CanBeString, HasUpd
 
     protected function resolvePreview(): Renderable|string
     {
-        return Div::make([
+        return Str::wrap(
             $this->isUnescape()
                 ? parent::resolvePreview()
-                : $this->escapeValue((string) parent::resolvePreview())
-        ])
-            ->class('text-ellipsis')
-            ->render();
+                : $this->escapeValue((string) parent::resolvePreview()),
+            '<div class="text-ellipsis">',
+            '</div>'
+        );
     }
 
     protected function viewData(): array

--- a/src/UI/src/Fields/Textarea.php
+++ b/src/UI/src/Fields/Textarea.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\UI\Fields;
 
 use Illuminate\Contracts\Support\Renderable;
+use MoonShine\UI\Components\Layout\Div;
 use MoonShine\UI\Contracts\DefaultValueTypes\CanBeString;
 use MoonShine\UI\Contracts\HasDefaultValueContract;
 use MoonShine\UI\Traits\Fields\HasPlaceholder;
@@ -21,8 +22,12 @@ class Textarea extends Field implements HasDefaultValueContract, CanBeString
 
     protected function resolvePreview(): Renderable|string
     {
-        return $this->isUnescape()
-            ? parent::resolvePreview()
-            : $this->escapeValue((string) parent::resolvePreview());
+        return Div::make([
+            $this->isUnescape()
+                ? parent::resolvePreview()
+                : $this->escapeValue((string) parent::resolvePreview())
+    ])
+        ->class('text-clamp')
+        ->render();
     }
 }

--- a/src/UI/src/Fields/Textarea.php
+++ b/src/UI/src/Fields/Textarea.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\UI\Fields;
 
 use Illuminate\Contracts\Support\Renderable;
-use MoonShine\UI\Components\Layout\Div;
+use Illuminate\Support\Str;
 use MoonShine\UI\Contracts\DefaultValueTypes\CanBeString;
 use MoonShine\UI\Contracts\HasDefaultValueContract;
 use MoonShine\UI\Traits\Fields\HasPlaceholder;
@@ -22,12 +22,12 @@ class Textarea extends Field implements HasDefaultValueContract, CanBeString
 
     protected function resolvePreview(): Renderable|string
     {
-        return Div::make([
+        return Str::wrap(
             $this->isUnescape()
                 ? parent::resolvePreview()
-                : $this->escapeValue((string) parent::resolvePreview())
-    ])
-        ->class('text-clamp')
-        ->render();
+                : $this->escapeValue((string) parent::resolvePreview()),
+            '<div class="text-clamp">',
+            '</div>'
+        );
     }
 }

--- a/src/UI/tailwind.config.js
+++ b/src/UI/tailwind.config.js
@@ -25,6 +25,7 @@ const vendorSafeList = [
 ]
 const clientSafeList = [
   'visible',
+  'text-ellipsis',
   '!hidden',
   '!block',
   'overflow-auto',

--- a/src/UI/tailwind.config.js
+++ b/src/UI/tailwind.config.js
@@ -25,7 +25,6 @@ const vendorSafeList = [
 ]
 const clientSafeList = [
   'visible',
-  'text-ellipsis',
   '!hidden',
   '!block',
   'overflow-auto',

--- a/tests/Unit/Fields/TextFieldTest.php
+++ b/tests/Unit/Fields/TextFieldTest.php
@@ -74,7 +74,7 @@ it('visual states', function () {
     expect((string) $field->render())
         ->toContain('input', 'type="text"')
         ->and((string) $field->flushRenderCache()->previewMode()->render())
-        ->toBe('&lt;p&gt;Hello world&lt;/p&gt;')
+        ->toBe('<div class="text-ellipsis">&lt;p&gt;Hello world&lt;/p&gt;</div>')
         ->and((string) $field->flushRenderCache()->rawMode()->render())
         ->toBe('<p>Hello world</p>')
         ->and((string) $field->flushRenderCache()->defaultMode()->rawMode()->previewMode()->render())


### PR DESCRIPTION
## What was changed
- [x] Table cells at low resolutions stop adding word wrap, at higher resolutions it becomes normal
mobile:
![Снимок экрана 2025-03-17 в 16 03 43](https://github.com/user-attachments/assets/2882044c-9daf-4b07-910a-00a06896afe7)
desktop:
![Снимок экрана 2025-03-17 в 16 03 22](https://github.com/user-attachments/assets/76b080d7-f37d-4a63-ac42-84c469c4f251)

- [x] Icon size in Url field
![Снимок экрана 2025-03-17 в 16 03 05](https://github.com/user-attachments/assets/97746f18-69f6-4200-ae7f-c12ee2f29b9f)


## Checklist

- Issue #1635
- Tested
    - [x] Tested manually
    - [ ] Tests added
