### PR TITLE
feat: TextWrap

### DIFF
--- a/src/Contracts/src/UI/FieldContract.php
+++ b/src/Contracts/src/UI/FieldContract.php
@@ -11,6 +11,7 @@ use MoonShine\Contracts\Core\PageContract;
 use MoonShine\Contracts\Core\ResourceContract;
 use MoonShine\Support\DTOs\AsyncCallback;
 use MoonShine\Support\Enums\HttpMethod;
+use MoonShine\Support\Enums\TextWrap;
 
 /**
  * @mixin Conditionable
@@ -66,6 +67,10 @@ interface FieldContract extends
     public function beforeLabel(): static;
 
     public function isBeforeLabel(): bool;
+
+    public function textWrap(TextWrap $wrap): static;
+
+    public function withoutTextWrap(): static;
 
     public function onChangeMethod(
         string $method,

--- a/src/Support/src/Enums/TextWrap.php
+++ b/src/Support/src/Enums/TextWrap.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Support\Enums;
+
+enum TextWrap: string
+{
+    case CLAMP = 'clamp';
+
+    case ELLIPSIS = 'ellipsis';
+}

--- a/src/UI/src/Fields/Field.php
+++ b/src/UI/src/Fields/Field.php
@@ -6,6 +6,7 @@ namespace MoonShine\UI\Fields;
 
 use Closure;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Str;
 use MoonShine\Contracts\Core\PageContract;
 use MoonShine\Contracts\Core\ResourceContract;
 use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
@@ -13,6 +14,7 @@ use MoonShine\Contracts\UI\FieldContract;
 use MoonShine\Support\AlpineJs;
 use MoonShine\Support\DTOs\AsyncCallback;
 use MoonShine\Support\Enums\HttpMethod;
+use MoonShine\Support\Enums\TextWrap;
 use MoonShine\UI\Components\Badge;
 use MoonShine\UI\Components\Link;
 use MoonShine\UI\Traits\Fields\Reactivity;
@@ -66,6 +68,8 @@ abstract class Field extends FormElement implements FieldContract
     protected bool $isInsideLabel = false;
 
     protected ?Closure $onChangeUrl = null;
+
+    protected ?TextWrap $textWrap = null;
 
     public function defaultMode(): static
     {
@@ -386,6 +390,30 @@ abstract class Field extends FormElement implements FieldContract
         return ! \is_null($this->renderCallback);
     }
 
+    public function textWrap(TextWrap $wrap): static
+    {
+        $this->textWrap = $wrap;
+
+        return $this;
+    }
+
+    public function getTextWrap(): ?TextWrap
+    {
+        return $this->textWrap;
+    }
+
+    public function hasTextWrap(): bool
+    {
+        return $this->textWrap !== null;
+    }
+
+    public function withoutTextWrap(): static
+    {
+        $this->textWrap = null;
+
+        return $this;
+    }
+
     public function preview(): Renderable|string
     {
         if ($this->isRawMode()) {
@@ -401,8 +429,17 @@ abstract class Field extends FormElement implements FieldContract
         }
 
         $preview = $this->resolvePreview();
+        $decorated = $this->previewDecoration($preview);
 
-        return $this->previewDecoration($preview);
+        if($this->hasTextWrap()) {
+            return Str::wrap(
+                (string) $decorated,
+                '<div class="text-'.$this->getTextWrap()->value.'">',
+                '</div>'
+            );
+        }
+
+        return $decorated;
     }
 
     protected function resolvePreview(): Renderable|string

--- a/src/UI/src/Fields/Password.php
+++ b/src/UI/src/Fields/Password.php
@@ -6,12 +6,15 @@ namespace MoonShine\UI\Fields;
 
 use Closure;
 use Illuminate\Contracts\Hashing\Hasher;
+use MoonShine\Support\Enums\TextWrap;
 
 class Password extends Text
 {
     protected string $type = 'password';
 
     protected bool $hasOld = false;
+
+    protected ?TextWrap $textWrap = null;
 
     protected function resolvePreview(): string
     {

--- a/src/UI/src/Fields/Text.php
+++ b/src/UI/src/Fields/Text.php
@@ -6,6 +6,7 @@ namespace MoonShine\UI\Fields;
 
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Str;
+use MoonShine\Support\Enums\TextWrap;
 use MoonShine\UI\Contracts\DefaultValueTypes\CanBeString;
 use MoonShine\UI\Contracts\HasDefaultValueContract;
 use MoonShine\UI\Contracts\HasUpdateOnPreviewContract;
@@ -26,6 +27,8 @@ class Text extends Field implements HasDefaultValueContract, CanBeString, HasUpd
     use WithEscapedValue;
 
     protected string $view = 'moonshine::fields.input';
+
+    protected ?TextWrap $textWrap = TextWrap::ELLIPSIS;
 
     protected string $type = 'text';
 
@@ -49,13 +52,9 @@ class Text extends Field implements HasDefaultValueContract, CanBeString, HasUpd
 
     protected function resolvePreview(): Renderable|string
     {
-        return Str::wrap(
-            $this->isUnescape()
-                ? parent::resolvePreview()
-                : $this->escapeValue((string) parent::resolvePreview()),
-            '<div class="text-ellipsis">',
-            '</div>'
-        );
+        return $this->isUnescape()
+            ? parent::resolvePreview()
+            : $this->escapeValue((string) parent::resolvePreview());
     }
 
     protected function viewData(): array

--- a/src/UI/src/Fields/Textarea.php
+++ b/src/UI/src/Fields/Textarea.php
@@ -6,6 +6,7 @@ namespace MoonShine\UI\Fields;
 
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Support\Str;
+use MoonShine\Support\Enums\TextWrap;
 use MoonShine\UI\Contracts\DefaultValueTypes\CanBeString;
 use MoonShine\UI\Contracts\HasDefaultValueContract;
 use MoonShine\UI\Traits\Fields\HasPlaceholder;
@@ -20,14 +21,12 @@ class Textarea extends Field implements HasDefaultValueContract, CanBeString
 
     protected string $view = 'moonshine::fields.textarea';
 
+    protected ?TextWrap $textWrap = TextWrap::CLAMP;
+
     protected function resolvePreview(): Renderable|string
     {
-        return Str::wrap(
-            $this->isUnescape()
-                ? parent::resolvePreview()
-                : $this->escapeValue((string) parent::resolvePreview()),
-            '<div class="text-clamp">',
-            '</div>'
-        );
+        return $this->isUnescape()
+            ? parent::resolvePreview()
+            : $this->escapeValue((string) parent::resolvePreview());
     }
 }

--- a/src/UI/src/Fields/Url.php
+++ b/src/UI/src/Fields/Url.php
@@ -6,6 +6,7 @@ namespace MoonShine\UI\Fields;
 
 use Closure;
 use Illuminate\Contracts\Support\Renderable;
+use MoonShine\Support\Enums\TextWrap;
 use MoonShine\UI\Components\Url as UrlComponent;
 
 class Url extends Text
@@ -15,6 +16,8 @@ class Url extends Text
     protected ?Closure $titleCallback = null;
 
     protected bool $blank = false;
+
+    protected ?TextWrap $textWrap = null;
 
     public function title(Closure $callback): static
     {

--- a/tests/Unit/Fields/TextFieldTest.php
+++ b/tests/Unit/Fields/TextFieldTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Model;
+use MoonShine\Support\Enums\TextWrap;
 use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
 use MoonShine\UI\Fields\Field;
 use MoonShine\UI\Fields\FormElement;
@@ -123,5 +124,17 @@ it('add/remove classes', function () {
     expect(str($field->getAttributes()->get('class'))->explode(' '))
         ->toContainEqual('form-control', 'btn-primary', 'btn-primaries', 'btn-primary-lg')
         ->not->toContainEqual('primary')
+    ;
+});
+
+it('text wrap', function () {
+    $field = Text::make('Field name')->previewMode();
+
+    expect($field->render())
+        ->toContain('div class="text-ellipsis">')
+        ->and($field->flushRenderCache()->textWrap(TextWrap::CLAMP)->render())
+        ->toContain('div class="text-clamp">')
+        ->and($field->flushRenderCache()->withoutTextWrap()->render())
+        ->not->toContain('div class="text-clamp">', 'div class="text-ellipsis">')
     ;
 });


### PR DESCRIPTION
## TextWrap

If the fields in the preview mode do not fit into the area allocated to them by width, they go beyond its limits, but this behavior can be controlled through a new method, specifying how exactly to crop the text

### Clamp

```php
Text::make('Field')->textWrap(TextWrap::CLAMP)
```

### Ellipsis

```php
Text::make('Field')->textWrap(TextWrap::ELLIPSIS)
```

### Disable

```php
Text::make('Field')->withoutTextWrap()
```

> [!NOTE]
> By default the Text field has Elipsis and Textarea Clamp