### PR TITLE
feat: HtmlMode parameter to html() method

### DIFF
--- a/src/Laravel/src/Http/Responses/MoonShineJsonResponse.php
+++ b/src/Laravel/src/Http/Responses/MoonShineJsonResponse.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Traits\Conditionable;
 use MoonShine\Support\AlpineJs;
 use MoonShine\Support\Enums\ToastType;
 use MoonShine\Support\Traits\Makeable;
+use MoonShine\UI\Enums\HtmlMode;
 
 /** @method static static make(array $data = []) */
 final class MoonShineJsonResponse extends JsonResponse
@@ -52,9 +53,9 @@ final class MoonShineJsonResponse extends JsonResponse
         return $this->mergeJsonData(['events' => AlpineJs::prepareEvents($events)]);
     }
 
-    public function html(string|array $value): self
+    public function html(string|array $value, HtmlMode $htmlMode = HtmlMode::INNER_HTML): self
     {
-        return $this->mergeJsonData(['html' => $value]);
+        return $this->mergeJsonData(['html' => $value, 'html_mode' => $htmlMode->value]);
     }
 
     /**

--- a/src/Laravel/src/Http/Responses/MoonShineJsonResponse.php
+++ b/src/Laravel/src/Http/Responses/MoonShineJsonResponse.php
@@ -55,7 +55,7 @@ final class MoonShineJsonResponse extends JsonResponse
 
     public function html(string|array $value, HtmlMode $htmlMode = HtmlMode::INNER_HTML): self
     {
-        return $this->mergeJsonData(['html' => $value, 'html_mode' => $htmlMode->value]);
+        return $this->mergeJsonData(['html' => $value, 'htmlMode' => $htmlMode->value]);
     }
 
     public function htmlData(string|array $value, string $selector, HtmlMode $htmlMode = HtmlMode::INNER_HTML): self

--- a/src/Laravel/src/Http/Responses/MoonShineJsonResponse.php
+++ b/src/Laravel/src/Http/Responses/MoonShineJsonResponse.php
@@ -53,12 +53,12 @@ final class MoonShineJsonResponse extends JsonResponse
         return $this->mergeJsonData(['events' => AlpineJs::prepareEvents($events)]);
     }
 
-    public function html(string|array $value, HtmlMode $htmlMode = HtmlMode::INNER_HTML): self
+    public function html(string|array $value, HtmlMode $mode = HtmlMode::INNER_HTML): self
     {
-        return $this->mergeJsonData(['html' => $value, 'htmlMode' => $htmlMode->value]);
+        return $this->mergeJsonData(['html' => $value, 'htmlMode' => $mode->value]);
     }
 
-    public function htmlData(string|array $value, string $selector, HtmlMode $htmlMode = HtmlMode::INNER_HTML): self
+    public function htmlData(string|array $value, string $selector, HtmlMode $mode = HtmlMode::INNER_HTML): self
     {
         if(! isset($this->jsonData['htmlData']))  {
             $this->jsonData['htmlData'] = [];
@@ -67,7 +67,7 @@ final class MoonShineJsonResponse extends JsonResponse
         $this->jsonData['htmlData'][] = [
             'html' => $value,
             'selector' => $selector,
-            'htmlMode' => $htmlMode->value
+            'htmlMode' => $mode->value
         ];
 
         return $this->setData($this->jsonData);

--- a/src/Laravel/src/Http/Responses/MoonShineJsonResponse.php
+++ b/src/Laravel/src/Http/Responses/MoonShineJsonResponse.php
@@ -58,6 +58,21 @@ final class MoonShineJsonResponse extends JsonResponse
         return $this->mergeJsonData(['html' => $value, 'html_mode' => $htmlMode->value]);
     }
 
+    public function htmlData(string|array $value, string $selector, HtmlMode $htmlMode = HtmlMode::INNER_HTML): self
+    {
+        if(! isset($this->jsonData['htmlData']))  {
+            $this->jsonData['htmlData'] = [];
+        }
+
+        $this->jsonData['htmlData'][] = [
+            'html' => $value,
+            'selector' => $selector,
+            'htmlMode' => $htmlMode->value
+        ];
+
+        return $this->setData($this->jsonData);
+    }
+
     /**
      * @param  array<string, string>  $value
      */

--- a/src/UI/resources/js/Request/Core.js
+++ b/src/UI/resources/js/Request/Core.js
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import {ComponentRequestData} from '../DTOs/ComponentRequestData.js'
 import {dispatchEvents} from '../Support/DispatchEvents.js'
+import {HtmlMode} from "../Support/HtmlMode.js";
 
 export default async function request(
   t,
@@ -65,10 +66,22 @@ export default async function request(
         selectors.forEach(function (selector) {
           let elements = document.querySelectorAll(selector)
           elements.forEach(element => {
-            element.innerHTML =
-              data.html && typeof data.html === 'object'
+            let htmlMode = HtmlMode.INNER_HTML
+            if(data.html_mode !== null) {
+              htmlMode = data.html_mode
+            }
+
+            const resultHtml = data.html && typeof data.html === 'object'
                 ? (data.html[selector] ?? data.html)
                 : (data.html ?? data)
+
+            if(htmlMode === HtmlMode.INNER_HTML) {
+              element.innerHTML = resultHtml
+            } else if(htmlMode === HtmlMode.OUTER_HTML) {
+              element.outerHTML = resultHtml
+            } else {
+              element.insertAdjacentHTML(htmlMode, resultHtml)
+            }
           })
         })
       }

--- a/src/UI/resources/js/Request/Core.js
+++ b/src/UI/resources/js/Request/Core.js
@@ -64,9 +64,6 @@ export default async function request(
         data.htmlData.forEach(function (htmlDataItem) {
           let selectors = htmlDataItem.selector.split(',')
           selectors.forEach(function (selector) {
-
-            console.log('selector', selector)
-
             let elements = document.querySelectorAll(selector)
             elements.forEach(element => {
               htmlReplace(
@@ -85,9 +82,6 @@ export default async function request(
       if (componentRequestData.selector) {
         let selectors = componentRequestData.selector.split(',')
         selectors.forEach(function (selector) {
-
-          console.log('selector2', selector)
-
           let elements = document.querySelectorAll(selector)
           elements.forEach(element => {
               htmlReplace(
@@ -275,9 +269,6 @@ function htmlReplace(html, mode, selector, element) {
   if(mode !== undefined) {
     htmlMode = mode
   }
-
-  console.log('html r', html)
-
   if(htmlMode === HtmlMode.INNER_HTML) {
     element.innerHTML = html
   } else if(htmlMode === HtmlMode.OUTER_HTML) {

--- a/src/UI/resources/js/Request/Core.js
+++ b/src/UI/resources/js/Request/Core.js
@@ -60,28 +60,44 @@ export default async function request(
         return
       }
 
-      if (componentRequestData.selector) {
-        const selectors = componentRequestData.selector.split(',')
+      if(data.htmlData) {
+        data.htmlData.forEach(function (htmlDataItem) {
+          let selectors = htmlDataItem.selector.split(',')
+          selectors.forEach(function (selector) {
 
+            console.log('selector', selector)
+
+            let elements = document.querySelectorAll(selector)
+            elements.forEach(element => {
+              htmlReplace(
+                  htmlDataItem.html && typeof htmlDataItem.html === 'object'
+                      ? (htmlDataItem.html[selector] ?? htmlDataItem.html)
+                      : htmlDataItem.html,
+                  htmlDataItem.htmlMode,
+                  selector,
+                  element
+              )
+            })
+          })
+        })
+      }
+
+      if (componentRequestData.selector) {
+        let selectors = componentRequestData.selector.split(',')
         selectors.forEach(function (selector) {
+
+          console.log('selector2', selector)
+
           let elements = document.querySelectorAll(selector)
           elements.forEach(element => {
-            let htmlMode = HtmlMode.INNER_HTML
-            if(data.html_mode !== undefined) {
-              htmlMode = data.html_mode
-            }
-
-            const resultHtml = data.html && typeof data.html === 'object'
-                ? (data.html[selector] ?? data.html)
-                : (data.html ?? data)
-
-            if(htmlMode === HtmlMode.INNER_HTML) {
-              element.innerHTML = resultHtml
-            } else if(htmlMode === HtmlMode.OUTER_HTML) {
-              element.outerHTML = resultHtml
-            } else {
-              element.insertAdjacentHTML(htmlMode, resultHtml)
-            }
+              htmlReplace(
+                  data.html && typeof data.html === 'object'
+                      ? (data.html[selector] ?? data.html)
+                      : (data.html ?? data),
+                  data.htmlMode,
+                  selector,
+                  element
+              )
           })
         })
       }
@@ -252,4 +268,21 @@ function downloadFile(fileName, data) {
   document.body.appendChild(a)
   a.click()
   window.URL.revokeObjectURL(url)
+}
+
+function htmlReplace(html, mode, selector, element) {
+  let htmlMode = HtmlMode.INNER_HTML
+  if(mode !== undefined) {
+    htmlMode = mode
+  }
+
+  console.log('html r', html)
+
+  if(htmlMode === HtmlMode.INNER_HTML) {
+    element.innerHTML = html
+  } else if(htmlMode === HtmlMode.OUTER_HTML) {
+    element.outerHTML = html
+  } else {
+    element.insertAdjacentHTML(htmlMode, html)
+  }
 }

--- a/src/UI/resources/js/Request/Core.js
+++ b/src/UI/resources/js/Request/Core.js
@@ -67,7 +67,7 @@ export default async function request(
           let elements = document.querySelectorAll(selector)
           elements.forEach(element => {
             let htmlMode = HtmlMode.INNER_HTML
-            if(data.html_mode !== null) {
+            if(data.html_mode !== undefined) {
               htmlMode = data.html_mode
             }
 

--- a/src/UI/resources/js/Support/HtmlMode.js
+++ b/src/UI/resources/js/Support/HtmlMode.js
@@ -1,0 +1,13 @@
+export const HtmlMode = {
+    INNER_HTML: 'inner_html',
+
+    OUTER_HTML: 'outer_html',
+
+    BEFORE_BEGIN: 'beforebegin',
+
+    AFTER_BEGIN: 'afterbegin',
+
+    BEFORE_END: 'beforeend',
+
+    AFTER_END: 'afterend',
+};

--- a/src/UI/src/Enums/HtmlMode.php
+++ b/src/UI/src/Enums/HtmlMode.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\UI\Enums;
+
+enum HtmlMode: string
+{
+    case INNER_HTML = 'inner_html';
+
+    case OUTER_HTML = 'outer_html';
+
+    case BEFORE_BEGIN = 'beforebegin';
+
+    case AFTER_BEGIN = 'afterbegin';
+
+    case BEFORE_END = 'beforeend';
+
+    case AFTER_END = 'afterend';
+}


### PR DESCRIPTION
## What was changed
 - The new HtmlMode parameter has been added to the MoonShineJsonResponse html() method.
 - New htmlData method for MoonShineJsonResponse for editing DOM
 
## Why?
Previously, when replacing HTML, only the innerHtml method was used, now you can use all replacement options

## Example
```php
public function formFields(): iterable
{
    return [
        ...$this->indexFields(),
        ActionButton::make('Add')
            ->method('addHtml', selector: '#selector1'),

        Div::make()->customAttributes([
            'id' => 'selector1'
        ]),
        Div::make()->customAttributes([
            'id' => 'selector2'
        ]),
        Div::make()->customAttributes([
            'id' => 'selector3'
        ])
    ];
}

public function addHtml(): MoonShineJsonResponse
{
    return MoonShineJsonResponse::make()
        ->html((string) Text::make('Zero'), HtmlMode::OUTER_HTML) // add to #selector1
        ->htmlData((string) Text::make('One'), '#selector2')
        ->htmlData((string) Text::make('Two'), '#selector3', HtmlMode::BEFORE_END)
    ;
}
```

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Tests added
- [ ] Documentation
