### PR TITLE
feat: Support \DateTimeImmutable and other datetime types in Date field

### DIFF
--- a/src/UI/src/Fields/Date.php
+++ b/src/UI/src/Fields/Date.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MoonShine\UI\Fields;
 
-use Illuminate\Support\Carbon;
+use DateTimeInterface;
 use MoonShine\UI\Contracts\DefaultValueTypes\CanBeString;
 use MoonShine\UI\Contracts\HasDefaultValueContract;
 use MoonShine\UI\Contracts\HasUpdateOnPreviewContract;
@@ -34,7 +34,7 @@ class Date extends Field implements HasDefaultValueContract, CanBeString, HasUpd
             return $this->isNullable() ? null : '';
         }
 
-        if ($value instanceof Carbon) {
+        if ($value instanceof DateTimeInterface) {
             return $value->format($this->getInputFormat());
         }
 
@@ -45,7 +45,7 @@ class Date extends Field implements HasDefaultValueContract, CanBeString, HasUpd
     {
         $value = $this->toFormattedValue();
 
-        if ($value instanceof Carbon) {
+        if ($value instanceof DateTimeInterface) {
             return $value->format($this->getFormat());
         }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Changed type check in \MoonShine\UI\Fields\Date from:
```php
if ($value instanceof Carbon) {
    //...
}
```
to
```php
if ($value instanceof DateTimeInterface) {
    //...
}
```

## Why?
I tried to create resource based on `\MoonShine\Laravel\Resources\CrudResource` and use DTO 's with `\DateTimeImmutable` properties. For example:
```php
final class Product
{
    public function __construct(
        public ?int $id = null,
        public ?\DateTimeImmutable $createdAt = null,
        public ?\DateTimeImmutable $publishDateStart = null,
        public ?\DateTimeImmutable $publishDateEnd = null,
        public ?string $name = null,
    )
    {
    }
}
```
```php
class ProductResource extends CrudResource
{
    //...
    protected function indexFields(): iterable
    {
        return [
            ID::make()->sortable(),
            Date::make('Created at', 'createdAt')
                ->format('d.m.Y')
                ->sortable(),
            DateRange::make('Publish dates')->fromTo('publishDateStart', 'publishDateEnd')->format('d.m.Y'),
            Text::make('Name', 'name'),
        ];
    }
    //..
}
```

Current behavior in preview mode is an exception `Object of class DateTimeImmutable could not be converted to string`.

Using `\DateTimeInterface` instead of Carbon for type checking in `\MoonShine\UI\Fields\Date::resolvePreview()` and `\MoonShine\UI\Fields\Date::resolveValue()` fix this. Also this provides to use any datetime classes which implements this interface.

`\MoonShine\UI\Fields\DateRange` has not this check and work perfect with any types.

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Tests added
- [ ] Documentation <!--- Remove if not needed -->
