### PR TITLE
feat: ActionButton hotkeys

### DIFF
--- a/src/Contracts/src/UI/ActionButtonContract.php
+++ b/src/Contracts/src/UI/ActionButtonContract.php
@@ -99,6 +99,8 @@ interface ActionButtonContract extends
 
     public function isAsync(): bool;
 
+    public function content(Closure|string $content): static;
+
     public function badge(Closure|string|int|float|null $value): static;
 
     public function primary(Closure|bool|null $condition = null): static;

--- a/src/Contracts/src/UI/FormBuilderContract.php
+++ b/src/Contracts/src/UI/FormBuilderContract.php
@@ -19,7 +19,7 @@ interface FormBuilderContract extends
 {
     public function action(string $action): self;
 
-    public function submit(string $label, array $attributes = []): self;
+    public function submit(?string $label = null, array $attributes = [], ?ActionButtonContract $button = null): self;
 
     /**
      * @param  Closure(mixed $values, FieldsContract $fields): bool  $apply

--- a/src/UI/resources/js/Components/ActionButton.js
+++ b/src/UI/resources/js/Components/ActionButton.js
@@ -24,12 +24,24 @@ export default () => ({
     const el = this.$el
     const btnText = this.btnText
 
-    this.$watch('loading', function (value) {
+    this.$watch('loading', function(value) {
       el.setAttribute('style', 'opacity:' + (value ? '.5' : '1'))
       el.innerHTML = value
         ? '<div class="spinner spinner--primary spinner-sm"></div>' + btnText
         : btnText
     })
+
+    if (this.$el.dataset.hotKeys) {
+      const hotkeys = this.$el.dataset.hotKeys
+        .split(',')
+        .map(s => s.trim())
+
+      if(modal = this.$el.closest('.modal')) {
+        this._modalHotkey(modal, hotkeys)
+      } else {
+        document.addEventListener('keydown', (event) => this._hotKey(event, hotkeys))
+      }
+    }
   },
 
   dispatchEvents(componentEvent, exclude = null, extra = {}) {
@@ -84,5 +96,44 @@ export default () => ({
       .withErrorCallback(stopLoading)
 
     request(this, this.url, this.method, body, {}, componentRequestData)
+  },
+  _hotKey(event, hotKeys) {
+    const normalizedHotkey = hotKeys.map(k => k.toLowerCase());
+
+    const pressed = []
+
+    if (event.shiftKey) pressed.push('shift')
+    if (event.ctrlKey) pressed.push('ctrl')
+    if (event.altKey) pressed.push('alt')
+    if (event.metaKey) pressed.push('meta') // mac cmd
+
+    if (!['shift', 'ctrl', 'alt', 'meta'].includes(
+      event.key.toLowerCase())) {
+      pressed.push(event.key.toLowerCase())
+    }
+
+    const match = normalizedHotkey.every(k => pressed.includes(k)) &&
+      pressed.length === normalizedHotkey.length
+
+    if (match) {
+      event.preventDefault()
+      this.$el.click()
+    }
+  },
+  _modalHotkey(modal, hotKeys) {
+    const handler = (event) => this._hotKey(event, hotKeys)
+
+    const observer = new MutationObserver(() => {
+      if(getComputedStyle(modal).display === 'none') {
+        document.removeEventListener('keydown', handler)
+      } else {
+        document.addEventListener('keydown', handler)
+      }
+    })
+
+    observer.observe(modal, {
+      attributes: true,
+      attributeFilter: ['style']
+    })
   },
 })

--- a/src/UI/resources/js/Components/FormBuilder.js
+++ b/src/UI/resources/js/Components/FormBuilder.js
@@ -316,8 +316,8 @@ export default (name = '', initData = {}, reactive = {}) => ({
 function submitState(form, loading = true, reset = false) {
   clearErrors(form)
 
-  const button = form.querySelector('.js-form-submit-button')
-  const loader = form.querySelector('.js-form-submit-button-loader')
+  const button = form.querySelector('[type="submit"]')
+  const loader = button.querySelector('.js-form-submit-button-loader')
 
   if (!button) {
     return

--- a/src/UI/resources/views/components/action-button.blade.php
+++ b/src/UI/resources/views/components/action-button.blade.php
@@ -7,15 +7,33 @@
     'component' => null,
     'badge' => false,
 ])
-<x-moonshine::link-button
-    :attributes="$attributes"
-    :href="$url"
-    :badge="$badge"
->
-    <x-slot:icon>{!! $icon !!}</x-slot:icon>
+@if($attributes->get('type') === 'submit')
+    <x-moonshine::form.button
+        :attributes="$attributes"
+    >
+        {!! $slot !!}
 
-    {!! $label !!}
-</x-moonshine::link-button>
+        <x-slot:icon>{!! $icon !!}</x-slot:icon>
+
+        {!! $label !!}
+
+        @if($badge !== false)
+            <x-moonshine::badge color="">{{ $badge }}</x-moonshine::badge>
+        @endif
+    </x-moonshine::form.button>
+@else
+    <x-moonshine::link-button
+        :attributes="$attributes"
+        :href="$url"
+        :badge="$badge"
+    >
+        {!! $slot !!}
+
+        <x-slot:icon>{!! $icon !!}</x-slot:icon>
+
+        {!! $label !!}
+    </x-moonshine::link-button>
+@endif
 
 @if($hasComponent)
     <template x-teleport="body">

--- a/src/UI/resources/views/components/form/builder.blade.php
+++ b/src/UI/resources/views/components/form/builder.blade.php
@@ -2,12 +2,11 @@
     'name' => '',
     'precognitive' => false,
     'hideSubmit' => false,
-    'submitLabel' => '',
     'fields' => [],
+    'submit' => '',
     'buttons' => [],
     'errors' => [],
     'errorsAbove' => true,
-    'submitAttributes' => null,
 ])
 @if($errorsAbove)
     <x-moonshine::form.all-errors :errors="$errors" />
@@ -24,28 +23,7 @@
     />
 
     <x-slot:buttons>
-        @if(!($hideSubmit ?? false))
-        <x-moonshine::form.button
-                :attributes="$submitAttributes?->merge([
-                'class' => 'js-form-submit-button',
-                'type' => 'submit'
-            ])"
-        >
-            <x-moonshine::spinner
-                    color="secondary"
-                    class="js-form-submit-button-loader"
-                    style="display: none;"
-            />
-
-            {{ $submitLabel }}
-        </x-moonshine::form.button>
-        @else
-            <button type="submit" class="js-form-submit-button" style="display: none;">
-                <x-moonshine::spinner
-                    class="js-form-submit-button-loader"
-                />
-            </button>
-        @endif
+        {!! $submit !!}
 
         @if($buttons->isNotEmpty())
             <x-moonshine::action-group

--- a/src/UI/src/Components/ActionButton.php
+++ b/src/UI/src/Components/ActionButton.php
@@ -19,6 +19,7 @@ use MoonShine\UI\Traits\ActionButton\InDropdownOrLine;
 use MoonShine\UI\Traits\ActionButton\WithModal;
 use MoonShine\UI\Traits\ActionButton\WithOffCanvas;
 use MoonShine\UI\Traits\Components\WithComponents;
+use MoonShine\UI\Traits\Components\WithSlotContent;
 use MoonShine\UI\Traits\WithBadge;
 use MoonShine\UI\Traits\WithIcon;
 use MoonShine\UI\Traits\WithLabel;
@@ -40,6 +41,7 @@ class ActionButton extends MoonShineComponent implements
     use WithModal;
     use InDropdownOrLine;
     use WithComponents;
+    use WithSlotContent;
 
     protected string $view = 'moonshine::components.action-button';
 
@@ -201,6 +203,35 @@ class ActionButton extends MoonShineComponent implements
              )",
             'prevent',
         );
+    }
+
+    /**
+     * @param non-empty-array<string> $keys
+     */
+    public function hotKeys(array $keys, bool $withBadge = false): static
+    {
+        $hotKeys = implode(',', $keys);
+        $badge = $withBadge ? str($hotKeys)
+            ->explode(',')
+            ->map(function (string $key) {
+                $key = trim($key);
+                $map = [
+                    'meta' => '⌘',
+                    'shift' => '⇧',
+                    'control' => '^',
+                    'alt' => '⌥',
+                    'backspace' => '⌫',
+                    'enter' => '⏎',
+                ];
+
+                return ucfirst($map[$key] ?? $key);
+            })
+            ->implode('+') : null;
+
+        return $this->customAttributes([
+            'x-data' => 'actionButton',
+            'data-hot-keys' => $hotKeys,
+        ])->badge($badge);
     }
 
     public function download(): static
@@ -466,6 +497,7 @@ class ActionButton extends MoonShineComponent implements
             'url' => $this->getUrl(),
             'icon' => $this->getIcon(4),
             'badge' => $this->hasBadge() ? $this->getBadge() : false,
+            'slot' => $this->getSlot(),
         ];
     }
 }

--- a/src/UI/src/Components/ActionButton.php
+++ b/src/UI/src/Components/ActionButton.php
@@ -222,6 +222,7 @@ class ActionButton extends MoonShineComponent implements
                     'alt' => '⌥',
                     'backspace' => '⌫',
                     'enter' => '⏎',
+                    'escape' => 'esc',
                 ];
 
                 return ucfirst($map[$key] ?? $key);

--- a/src/UI/src/Components/FormBuilder.php
+++ b/src/UI/src/Components/FormBuilder.php
@@ -10,6 +10,7 @@ use MoonShine\Contracts\Core\CrudResourceContract;
 use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
 use MoonShine\Contracts\Core\PageContract;
 use MoonShine\Contracts\Core\TypeCasts\DataCasterContract;
+use MoonShine\Contracts\UI\ActionButtonContract;
 use MoonShine\Contracts\UI\Collection\ActionButtonsContract;
 use MoonShine\Contracts\UI\ComponentAttributesBagContract;
 use MoonShine\Contracts\UI\ComponentContract;
@@ -18,7 +19,6 @@ use MoonShine\Contracts\UI\FormBuilderContract;
 use MoonShine\Contracts\UI\HasCasterContract;
 use MoonShine\Contracts\UI\HasFieldsContract;
 use MoonShine\Support\AlpineJs;
-use MoonShine\Support\Components\MoonShineComponentAttributeBag;
 use MoonShine\Support\DTOs\AsyncCallback;
 use MoonShine\Support\Enums\FormMethod;
 use MoonShine\Support\Enums\JsEvent;
@@ -66,13 +66,11 @@ final class FormBuilder extends MoonShineComponent implements
 
     protected bool $isPrecognitive = false;
 
-    protected ?string $submitLabel = null;
-
     protected bool $hideSubmit = false;
 
     protected bool $errorsAbove = true;
 
-    protected ComponentAttributesBagContract $submitAttributes;
+    protected ?ActionButtonContract $submit = null;
 
     protected ?Closure $onBeforeFieldsRender = null;
 
@@ -82,16 +80,12 @@ final class FormBuilder extends MoonShineComponent implements
         protected string $action = '',
         protected FormMethod $method = FormMethod::POST,
         FieldsContract|iterable $fields = [],
-        mixed $values = []
+        mixed $values = [],
     ) {
         parent::__construct();
 
         $this->fields($fields);
         $this->fill($values);
-
-        $this->submitAttributes = new MoonShineComponentAttributeBag([
-            'type' => 'submit',
-        ]);
 
         $this->customAttributes(array_filter([
             'action' => $this->action,
@@ -133,7 +127,7 @@ final class FormBuilder extends MoonShineComponent implements
 
         $fields->fill(
             $casted->toArray(),
-            $casted
+            $casted,
         );
 
         $fields->prepareAttributes();
@@ -202,13 +196,13 @@ final class FormBuilder extends MoonShineComponent implements
             $message,
             params: ['resourceItem' => $resource?->getItemID()],
             page: $page,
-            resource: $resource
+            resource: $resource,
         );
 
         return $this->action($asyncUrl)->async(
             $asyncUrl,
             events: $events,
-            callback: $callback
+            callback: $callback,
         );
     }
 
@@ -294,24 +288,37 @@ final class FormBuilder extends MoonShineComponent implements
         return $this->hideSubmit;
     }
 
-    public function submit(string $label, array $attributes = []): self
+    public function submit(?string $label = null, array $attributes = [], ?ActionButtonContract $button = null): self
     {
-        $this->submitLabel = $label;
-        $this->submitAttributes->setAttributes(
-            $attributes + $this->submitAttributes->getAttributes()
-        );
+        $this->submit = $button ?: $this->getSubmit();
+
+        if(!\is_null($label) && \is_null($button)) {
+            $this->submit = $this->getSubmit()->setLabel($label);
+        }
+
+        if($attributes !== [] && \is_null($button)) {
+            $this->submit = $this->getSubmit()->customAttributes($attributes);
+        }
 
         return $this;
     }
 
-    public function getSubmitAttributes(): ComponentAttributesBagContract
+    public function getSubmit(): ActionButtonContract
     {
-        return $this->submitAttributes;
-    }
+        $submit = $this->submit ?: ActionButton::make(
+            $this->getCore()->getTranslator()->get('moonshine::ui.save'),
+        );
 
-    public function getSubmitLabel(): string
-    {
-        return $this->submitLabel ?? $this->getCore()->getTranslator()->get('moonshine::ui.save');
+        if($this->isHideSubmit()) {
+            $submit->style('display: none');
+        }
+
+        return $submit->customAttributes([
+            'type' => 'submit',
+        ])->content(fn(): Spinner => Spinner::make()
+            ->class('js-form-submit-button-loader')
+            ->style('display: none')
+        );
     }
 
     public function errorsAbove(bool $enable = true): self
@@ -368,7 +375,7 @@ final class FormBuilder extends MoonShineComponent implements
         bool $throw = false,
     ): bool {
         $values = $this->castData(
-            $this->getValues()
+            $this->getValues(),
         )->getOriginal();
 
         if (\is_null($default)) {
@@ -390,7 +397,7 @@ final class FormBuilder extends MoonShineComponent implements
                 ->getPreparedFields()
                 ->onlyFields(withApplyWrappers: true)
                 ->exceptElements(
-                    fn (ComponentContract $element): bool => $element instanceof FieldContract && \in_array($element->getColumn(), $this->getExcludedFields(), true)
+                    fn (ComponentContract $element): bool => $element instanceof FieldContract && \in_array($element->getColumn(), $this->getExcludedFields(), true),
                 );
 
             $values = \is_null($before) ? $values : $before($values);
@@ -455,10 +462,10 @@ final class FormBuilder extends MoonShineComponent implements
 
         $onlyFields = $fields->onlyFields();
         $onlyFields->each(
-            fn (FieldContract $field): FieldContract => $field->formName($this->getName())
+            fn (FieldContract $field): FieldContract => $field->formName($this->getName()),
         );
         $fields->prepend(
-            Hidden::make('_component_name')->formName($this->getName())->setValue($this->getName())
+            Hidden::make('_component_name')->formName($this->getName())->setValue($this->getName()),
         );
 
         $reactiveFields = $onlyFields->reactiveFields()
@@ -494,7 +501,7 @@ final class FormBuilder extends MoonShineComponent implements
 
         if ($this->isAsync()) {
             $this->action(
-                $this->getAction() ?: $this->getAsyncUrl()
+                $this->getAction() ?: $this->getAsyncUrl(),
             );
             $this->customAttributes([
                 'x-on:submit.prevent' => 'async(`' . $this->getAsyncEvents(
@@ -513,8 +520,7 @@ final class FormBuilder extends MoonShineComponent implements
             'asyncUrl' => $this->getAsyncUrl(),
             'buttons' => $this->getButtons(),
             'hideSubmit' => $this->isHideSubmit(),
-            'submitLabel' => $this->getSubmitLabel(),
-            'submitAttributes' => $this->getSubmitAttributes(),
+            'submit' => $this->getSubmit(),
             'errors' => $this->getCore()->getRequest()->getFormErrors($this->getName()),
             'errorsAbove' => $this->hasErrorsAbove(),
         ];

--- a/src/UI/src/Traits/ActionButton/WithModal.php
+++ b/src/UI/src/Traits/ActionButton/WithModal.php
@@ -13,6 +13,7 @@ use MoonShine\Support\AlpineJs;
 use MoonShine\Support\Enums\FormMethod;
 use MoonShine\Support\Enums\HttpMethod;
 use MoonShine\Support\Enums\JsEvent;
+use MoonShine\UI\Components\ActionButton;
 use MoonShine\UI\Components\FormBuilder;
 use MoonShine\UI\Components\Heading;
 use MoonShine\UI\Components\Modal;
@@ -125,10 +126,11 @@ trait WithModal
                 $async,
                 static fn (FormBuilderContract $form): FormBuilderContract => $form->async(events: $events, callback: $callback)
             )->submit(
-                \is_null($button)
-                    ? $ctx->getCore()->getTranslator()->get('moonshine::ui.confirm')
-                    : value($button, $item),
-                ['class' => 'btn-secondary']
+                button: ActionButton::make(
+                    \is_null($button)
+                        ? $ctx->getCore()->getTranslator()->get('moonshine::ui.confirm')
+                        : value($button, $item)
+                )->error()
             )->when(
                 ! \is_null($formBuilder),
                 static fn (FormBuilderContract $form): FormBuilderContract => $formBuilder($form, $item)


### PR DESCRIPTION
```php
ActionButton::make('Test')
    ->hotKeys(['shift', 'k', 'meta'], true)
    ->onClick(fn() => 'alert(1)'),

ActionButton::make('Test 1')
    ->method('toast1')
    ->withConfirm(
        formBuilder: fn(FormBuilder $form) => $form
            ->submit(button: ActionButton::make('Удалить')->error()->hotKeys(['shift', 'k', 'meta'], true))
    )
    ->hotKeys(['shift', '1', 'meta'], true),

ActionButton::make('Test 2')
    ->method('toast2')
    ->withConfirm()
    ->hotKeys(['shift', '2', 'meta'], true),
```

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Tests added
- [ ] Documentation 
