### PR TITLE
Fix/paginator named parameter

### DIFF
--- a/src/Laravel/src/TypeCasts/PaginatorCaster.php
+++ b/src/Laravel/src/TypeCasts/PaginatorCaster.php
@@ -45,6 +45,7 @@ final readonly class PaginatorCaster implements PaginatorCasterContract
         $data['from'] ??= 1;
         $data['to'] ??= 1;
 
+
         // Fix for Laravel 12 & PHP 8.2
         unset($data['currentPageUrl']);
 

--- a/src/Laravel/src/TypeCasts/PaginatorCaster.php
+++ b/src/Laravel/src/TypeCasts/PaginatorCaster.php
@@ -45,6 +45,9 @@ final readonly class PaginatorCaster implements PaginatorCasterContract
         $data['from'] ??= 1;
         $data['to'] ??= 1;
 
+        // Fix for Laravel 12 & PHP 8.2
+        unset($data['currentPageUrl']);
+
         return new Paginator(...$data);
     }
 }


### PR DESCRIPTION
### What this PR does:
Fixes a fatal error in PHP 8.2 when using `PaginatorCaster`, due to `currentPageUrl` being passed as a named parameter to `Paginator`.

### Solution:
Unset `currentPageUrl` before calling the constructor:
```php
unset($data['currentPageUrl']);
return new Paginator(...$data);