### PR TITLE
feat: Support external avatar URLs in Profile component

### DIFF
--- a/src/Laravel/src/Components/Layout/Profile.php
+++ b/src/Laravel/src/Components/Layout/Profile.php
@@ -103,9 +103,15 @@ final class Profile extends MoonShineComponent
 
         $avatar = $this->user?->{$userField};
 
-        return $avatar
-            ? Storage::disk(moonshineConfig()->getDisk())->url($avatar)
-            : $this->getAvatarPlaceholder();
+        if ($avatar === '') {
+            return $this->getAvatarPlaceholder();
+        }
+
+        if (str_starts_with($avatar, 'http://') || str_starts_with($avatar, 'https://')) {
+            return $avatar;
+        }
+
+        return Storage::disk(moonshineConfig()->getDisk())->url($avatar);
     }
 
     /**

--- a/src/Laravel/src/Components/Layout/Profile.php
+++ b/src/Laravel/src/Components/Layout/Profile.php
@@ -103,7 +103,7 @@ final class Profile extends MoonShineComponent
 
         $avatar = $this->user?->{$userField};
 
-        if ($avatar === '') {
+        if ($avatar === '' || $avatar === null) {
             return $this->getAvatarPlaceholder();
         }
 


### PR DESCRIPTION

## What was changed
In Profile component, the `getDefaultAvatar()` method was updated to check if the avatar string starts with http:// or https://; if so, it returns the URL as-is rather than passing it through Storage::disk()->url().

## Why?
By default, `Storage::disk(...)->url($avatar)` only works for paths stored on our configured filesystem, so supplying a “raw” external link (e.g. from Google) caused malformed URLs like `/storage/https://....` This change lets the Profile component detect external avatar links and render them directly, avoiding the incorrect prefix. It ensures that if a user’s avatar field contains a full URL, Moonshine’s Profile view will simply use that URL instead of trying to treat it as a local disk path.

## Checklist

- Issue #<!-- add issue number here -->
- Tested
    - [x] Tested manually
    - [ ] Tests added
