### PR TITLE
feat(4.x): Async method improvements

### DIFF
--- a/src/Support/src/Attributes/AsyncMethod.php
+++ b/src/Support/src/Attributes/AsyncMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Support\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+final readonly class AsyncMethod
+{
+}

--- a/tests/Feature/Controllers/MethodControllerTest.php
+++ b/tests/Feature/Controllers/MethodControllerTest.php
@@ -15,3 +15,18 @@ it('get response', function () {
         ->assertOk()
     ;
 });
+
+it('get error response', function () {
+    asAdmin()->get($this->moonshineCore->getRouter()->to('method', [
+        'method' => 'testAsyncMethod2',
+        'resourceUri' => 'test-item-resource',
+        'pageUri' => 'index-page',
+        'var' => 'foo',
+    ]))
+        ->assertServerError()
+        ->assertJson([
+            'message' => 'testAsyncMethod2 does not exist',
+            'messageType' => 'error'
+        ])
+    ;
+});

--- a/tests/Fixtures/Resources/TestItemResource.php
+++ b/tests/Fixtures/Resources/TestItemResource.php
@@ -10,6 +10,7 @@ use MoonShine\Laravel\Fields\Relationships\MorphMany;
 use MoonShine\Laravel\Http\Responses\MoonShineJsonResponse;
 use MoonShine\Laravel\MoonShineRequest;
 use MoonShine\Laravel\QueryTags\QueryTag;
+use MoonShine\Support\Attributes\AsyncMethod;
 use MoonShine\Tests\Fixtures\Models\Category;
 use MoonShine\Tests\Fixtures\Models\Item;
 use MoonShine\UI\Components\Layout\Box;
@@ -130,9 +131,17 @@ class TestItemResource extends AbstractTestingResource
         return [];
     }
 
-    public function testAsyncMethod(MoonShineRequest $request): MoonShineJsonResponse
+    #[AsyncMethod]
+    public function testAsyncMethod(MoonShineRequest $request, MoonShineJsonResponse $response): MoonShineJsonResponse
     {
-        return MoonShineJsonResponse::make([
+        return $response->setData([
+            'var' => $request->input('var'),
+        ]);
+    }
+
+    public function testAsyncMethod2(MoonShineRequest $request, MoonShineJsonResponse $response): MoonShineJsonResponse
+    {
+        return $response->setData([
             'var' => $request->input('var'),
         ]);
     }


### PR DESCRIPTION
For security, only methods marked with the attribute will be accessible. Also, DI inside the method is now accessible. Responses have been improved and the page is a priority in method search.

```php
#[AsyncMethod]
public function goMethod(MoonShineRequest $request, MoonShineJsonResponse $response, TestService $service): MoonShineJsonResponse
{
    return $response->toast($service->handle($request->integer('var')));
}
```