### PR TITLE
feat(4.x) model-resource-handlers

### DIFF
--- a/src/Laravel/src/Attributes/DestroyHandler.php
+++ b/src/Laravel/src/Attributes/DestroyHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Laravel\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class DestroyHandler
+{
+    /**
+     * @param  class-string  $service
+     * @param  ?string  $method
+     */
+    public function __construct(
+        public string $service,
+        public ?string $method = null,
+    ) {}
+}

--- a/src/Laravel/src/Attributes/MassDestroyHandler.php
+++ b/src/Laravel/src/Attributes/MassDestroyHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Laravel\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class MassDestroyHandler
+{
+    /**
+     * @param  class-string  $service
+     * @param  ?string  $method
+     */
+    public function __construct(
+        public string $service,
+        public ?string $method = null,
+    ) {}
+}

--- a/src/Laravel/src/Attributes/SaveHandler.php
+++ b/src/Laravel/src/Attributes/SaveHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Laravel\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class SaveHandler
+{
+    /**
+     * @param  class-string  $service
+     * @param  ?string  $method
+     */
+    public function __construct(
+        public string $service,
+        public ?string $method = null,
+    ) {}
+}

--- a/src/Laravel/src/Fields/Relationships/BelongsTo.php
+++ b/src/Laravel/src/Fields/Relationships/BelongsTo.php
@@ -116,6 +116,12 @@ class BelongsTo extends ModelRelationField implements
                 return $item;
             }
 
+            if(self::$silentApply) {
+                data_set($item, $this->getColumn(), $value);
+
+                return $item;
+            }
+
             if ($value === false && $this->isNullable()) {
                 return $item
                     ->{$this

--- a/src/Laravel/src/Fields/Relationships/BelongsToMany.php
+++ b/src/Laravel/src/Fields/Relationships/BelongsToMany.php
@@ -516,11 +516,18 @@ class BelongsToMany extends ModelRelationField implements
         $item = $data;
 
         $checkedKeys = $this->getCheckedKeys();
+        $simpleSync = $this->isSelectMode() || $this->isTree() || $this->isHorizontalMode() || $this->getFields()->isEmpty();
 
-        if ($this->isSelectMode() || $this->isTree() || $this->isHorizontalMode() || $this->getFields()->isEmpty()) {
+        if ($simpleSync && self::$silentApply === true) {
+            data_set($item, $this->getRelationName(), $checkedKeys);
+
+            return $item;
+        }
+
+        if ($simpleSync && self::$silentApply === false) {
             $item->{$this->getRelationName()}()->sync($checkedKeys);
 
-            return $data;
+            return $item;
         }
 
         $applyValues = [];
@@ -549,9 +556,13 @@ class BelongsToMany extends ModelRelationField implements
             }
         }
 
-        $item->{$this->getRelationName()}()->sync($applyValues);
+        if (self::$silentApply === true) {
+            data_set($item, $this->getRelationName(), $applyValues);
+        } else {
+            $item->{$this->getRelationName()}()->sync($applyValues);
+        }
 
-        return $data;
+        return $item;
     }
 
     /**

--- a/src/Laravel/src/Fields/Relationships/RelationRepeater.php
+++ b/src/Laravel/src/Fields/Relationships/RelationRepeater.php
@@ -7,6 +7,7 @@ namespace MoonShine\Laravel\Fields\Relationships;
 use Closure;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
 use MoonShine\Contracts\UI\ActionButtonContract;
@@ -474,9 +475,15 @@ class RelationRepeater extends ModelRelationField implements
         );
     }
 
-    private function saveRelation(array $items, mixed $model)
+    private function saveRelation(array $items, Model $model): Model
     {
         $items = collect($items);
+
+        if(self::$silentApply === true) {
+            data_set($model, $this->getRelationName(), $items);
+
+            return $model;
+        }
 
         $relationName = $this->getColumn();
 

--- a/src/Laravel/src/Resources/ModelResource.php
+++ b/src/Laravel/src/Resources/ModelResource.php
@@ -139,9 +139,7 @@ abstract class ModelResource extends CrudResource implements WithQueryBuilderCon
             ->whereIn($this->getDataInstance()->getKeyName(), $ids)
             ->get()
             ->each(function (mixed $item): bool {
-                $item = $this->beforeDeleting($item);
-
-                return (bool) tap($item->delete(), fn (): mixed => $this->afterDeleted($item));
+                return $this->delete($item);
             });
 
         $this->afterMassDeleted($ids);

--- a/src/Laravel/src/Resources/ModelResource.php
+++ b/src/Laravel/src/Resources/ModelResource.php
@@ -9,10 +9,14 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\Facades\Gate;
+use Leeto\FastAttributes\Attributes;
 use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
 use MoonShine\Contracts\Core\TypeCasts\DataCasterContract;
 use MoonShine\Contracts\UI\FieldContract;
 use MoonShine\Core\Exceptions\ResourceException;
+use MoonShine\Laravel\Attributes\DestroyHandler;
+use MoonShine\Laravel\Attributes\MassDestroyHandler;
+use MoonShine\Laravel\Attributes\SaveHandler;
 use MoonShine\Laravel\Collections\Fields;
 use MoonShine\Laravel\Contracts\Fields\HasOutsideSwitcherContract;
 use MoonShine\Laravel\Contracts\Page\DetailPageContract;
@@ -24,6 +28,7 @@ use MoonShine\Laravel\MoonShineAuth;
 use MoonShine\Laravel\Traits\Resource\ResourceModelQuery;
 use MoonShine\Laravel\TypeCasts\ModelCaster;
 use MoonShine\Support\Enums\Ability;
+use MoonShine\UI\Fields\Field;
 use Throwable;
 
 /**
@@ -117,6 +122,16 @@ abstract class ModelResource extends CrudResource implements WithQueryBuilderCon
      */
     public function massDelete(array $ids): void
     {
+        if($handler = Attributes::for($this, MassDestroyHandler::class)->first()) {
+            $service = $this->getCore()->getContainer($handler->service);
+
+            $handler->method === null
+                ? $service($ids)
+                : $service->{$handler->method}($ids);
+
+            return;
+        }
+
         $this->beforeMassDeleting($ids);
 
         $this->getDataInstance()
@@ -139,11 +154,19 @@ abstract class ModelResource extends CrudResource implements WithQueryBuilderCon
      */
     public function delete(mixed $item, ?FieldsContract $fields = null): bool
     {
-        $item = $this->beforeDeleting($item);
-
         $fields ??= $this->getFormFields()->onlyFields(withApplyWrappers: true);
 
         $fields->fill($item->toArray(), $this->getCaster()->cast($item));
+
+        if($handler = Attributes::for($this, DestroyHandler::class)->first()) {
+            $service = $this->getCore()->getContainer($handler->service);
+
+            return $handler->method === null
+                ? $service($item)
+                : $service->{$handler->method}($item);
+        }
+
+        $item = $this->beforeDeleting($item);
 
         $relationDestroyer = static function (ModelRelationField $field) use ($item): void {
             $relationItems = $item->{$field->getRelationName()};
@@ -151,7 +174,7 @@ abstract class ModelResource extends CrudResource implements WithQueryBuilderCon
             ! $field->isToOne() ?: $relationItems = collect([$relationItems]);
 
             $relationItems->each(
-                static fn (mixed $relationItem): mixed => $field->afterDestroy($relationItem)
+                static fn (mixed $relationItem): mixed => $field->afterDestroy($relationItem),
             );
         };
 
@@ -188,6 +211,13 @@ abstract class ModelResource extends CrudResource implements WithQueryBuilderCon
 
         $fields->fill($item->toArray(), $this->getCaster()->cast($item));
 
+        if($handler = Attributes::for($this, SaveHandler::class)->first()) {
+            $item = $this->resolveSaveHandler($handler, $item, $fields);
+            $this->setItem($item);
+
+            return $item;
+        }
+
         try {
             $fields->each(static fn (FieldContract $field): mixed => $field->beforeApply($item));
 
@@ -214,6 +244,30 @@ abstract class ModelResource extends CrudResource implements WithQueryBuilderCon
         $this->setItem($item);
 
         return $item;
+    }
+
+    /**
+     * @param TData $item
+     * @param Fields $fields
+     * @return TData
+     */
+    private function resolveSaveHandler(SaveHandler $handler, mixed $item, FieldsContract $fields): mixed
+    {
+        $service = $this->getCore()->getContainer($handler->service);
+        $resource = $this;
+
+        $initial = clone $item;
+        $data = Field::silentApply(static function () use($item, $fields, $resource): array {
+            $fields->each(static fn (FieldContract $field): mixed => $field->beforeApply($item));
+            $fields->each(static fn (FieldContract $field): mixed => $field->apply($resource->fieldApply($field), $item));
+            $fields->each(static fn (FieldContract $field): mixed => $field->afterApply($item));
+
+            return $item->toArray();
+        });
+
+        return $handler->method === null
+            ? $service($initial, $data)
+            : $service->{$handler->method}($initial, $data);
     }
 
     public function fieldApply(FieldContract $field): Closure

--- a/src/UI/src/Traits/Fields/Applies.php
+++ b/src/UI/src/Traits/Fields/Applies.php
@@ -12,6 +12,8 @@ use MoonShine\Contracts\UI\FormElementContract;
 
 trait Applies
 {
+    protected static bool $silentApply = false;
+
     protected ?Closure $canApply = null;
 
     protected ?Closure $onApply = null;
@@ -23,6 +25,25 @@ trait Applies
     protected ?Closure $onAfterDestroy = null;
 
     protected ?Closure $onRefreshAfterApply = null;
+
+    /**
+     * Using a field without side effects (for example, maintaining relationships)
+     *
+     * @template D of mixed
+     * @param  Closure(): D  $callback
+     *
+     * @return D
+     */
+    public static function silentApply(Closure $callback): mixed
+    {
+        self::$silentApply = true;
+
+        $data = $callback();
+
+        self::$silentApply = false;
+
+        return $data;
+    }
 
     public function refreshAfterApply(?Closure $callback = null): static
     {

--- a/tests/Feature/Fields/ApplyFieldTest.php
+++ b/tests/Feature/Fields/ApplyFieldTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use MoonShine\Contracts\UI\FieldContract;
+use MoonShine\Laravel\Collections\Fields;
+use MoonShine\Laravel\Fields\Relationships\BelongsTo;
+use MoonShine\Laravel\Fields\Relationships\BelongsToMany;
+use MoonShine\Laravel\Models\MoonshineUser;
+use MoonShine\Laravel\Resources\MoonShineUserRoleResource;
+use MoonShine\Tests\Fixtures\Resources\TestCategoryResource;
+use MoonShine\UI\Fields\Email;
+use MoonShine\UI\Fields\Field;
+use MoonShine\UI\Fields\Json;
+use MoonShine\UI\Fields\Text;
+
+uses()->group('fields');
+
+beforeEach(function (): void {
+    $this->fields = Fields::make([
+        Text::make('Title'),
+        Json::make('Data')->fields([
+            Text::make('Title'),
+        ]),
+    ]);
+
+    $this->item = MoonshineUser::factory()->createOne();
+
+    $this->relationFields = Fields::make([
+        Email::make('Email', 'email'),
+        BelongsTo::make('Role', 'moonshineUserRole', resource: MoonShineUserRoleResource::class),
+    ]);
+});
+
+it('primitive values', function (): void {
+    $data = [];
+    $requestData = [
+        'title' => 'Hello world',
+        'data' => [
+            ['title' => 'Inner Hello world']
+        ]
+    ];
+
+    fakeRequest(parameters: $requestData);
+
+    $data = Field::silentApply(function () use (&$data) {
+        $this->fields->onlyFields()->each(function (FieldContract $field) use (&$data): void {
+            $data = $field->apply(fn($d, $v, FieldContract $ctx) => data_set($d, $ctx->getColumn(), $v), $data);
+        });
+
+        return $data;
+    });
+
+
+    expect($data)->toBe($requestData);
+});
+
+it('relation belongsTo values', function (): void {
+    $data = $this->item;
+    $requestData = [
+        'email' => 'test@example.com',
+        'moonshine_user_role_id' => '10',
+    ];
+
+    fakeRequest(parameters: $requestData);
+
+    $data = Field::silentApply(function () use (&$data) {
+        $this->relationFields->onlyFields()->each(function (FieldContract $field) use (&$data): void {
+            $field->apply(fn($d, $v, FieldContract $ctx) => data_set($d, $ctx->getColumn(), $v), $data);
+        });
+
+        return $data;
+    });
+
+    expect($data->only('email', 'moonshine_user_role_id'))->toBe($requestData);
+});
+
+it('relation belongsToMany simple values', function (): void {
+    $data = createItem();
+    $fields = Fields::make([
+        Text::make('Name'),
+        BelongsToMany::make('Categories', resource: TestCategoryResource::class)
+            ->selectMode(),
+    ]);
+    $requestData = [
+        'name' => 'Danil',
+        'categories' => ['1','2','3','4','5'],
+    ];
+
+    fakeRequest(parameters: $requestData);
+
+    $data = Field::silentApply(function () use (&$data, $fields) {
+        $fields->onlyFields()->each(function (FieldContract $field) use (&$data): void {
+            $data = $field->beforeApply($data);
+            $data = $field->apply(fn($d, $v, FieldContract $ctx) => data_set($d, $ctx->getColumn(), $v), $data);
+            $data = $field->afterApply($data);
+        });
+
+        return $data;
+    });
+
+    $result = $data->only('name', 'categories');
+    $result['categories'] = $result['categories']->toArray();
+
+    expect($result)->toBe($requestData);
+});
+
+it('relation belongsToMany default values', function (): void {
+    $data = createItem();
+    $fields = Fields::make([
+        Text::make('Name'),
+        BelongsToMany::make('Categories', resource: TestCategoryResource::class)
+            ->fields([
+                Text::make('pivot_1', 'pivot_1'),
+                Text::make('pivot_2', 'pivot_2'),
+                Text::make('pivot_3', 'pivot_3'),
+            ]),
+    ]);
+    $requestData = [
+        'name' => 'Danil',
+        'categories' => ['1' => '1','2' => '2'],
+        'categories_pivot' => [
+            '1' => [
+                'pivot' => [
+                    'pivot_1' => '1',
+                    'pivot_2' => '2',
+                    'pivot_3' => '3',
+                ]
+            ],
+            '2' => [
+                'pivot' => [
+                    'pivot_1' => '4',
+                    'pivot_2' => '5',
+                    'pivot_3' => '6',
+                ]
+            ]
+        ],
+    ];
+
+    fakeRequest(parameters: $requestData);
+
+    $data = Field::silentApply(function () use (&$data, $fields) {
+        $fields->onlyFields()->each(function (FieldContract $field) use (&$data): void {
+            $data = $field->beforeApply($data);
+            $data = $field->apply(fn($d, $v, FieldContract $ctx) => data_set($d, $ctx->getColumn(), $v), $data);
+            $data = $field->afterApply($data);
+        });
+
+        return $data;
+    });
+
+    $result = $data->only('name', 'categories');
+
+    expect($result)->toBe([
+        'name' => 'Danil',
+        'categories' => [
+            '1' => [
+                'pivot_1' => '1',
+                'pivot_2' => '2',
+                'pivot_3' => '3',
+            ],
+            '2' => [
+                'pivot_1' => '4',
+                'pivot_2' => '5',
+                'pivot_3' => '6',
+            ]
+        ]
+    ]);
+});
+


### PR DESCRIPTION
now you can redefine the main crud operations and move them to your services. there will be no side effects when applying fields, you will receive modified data from the request and that's it

```php
#[DestroyHandler(MoonShineUserRoleDestroyHandler::class)]
#[MassDestroyHandler(MoonShineUserRoleDestroyHandler::class)]
#[SaveHandler(MoonShineUserRoleSaveHandler::class)]
class MoonShineUserRoleResource extends ModelResource
```

```php
#[DestroyHandler(MoonShineUserRoleHandlers::class, 'destroy')]
#[MassDestroyHandler(MoonShineUserRoleHandlers::class, 'massDestroy')]
#[SaveHandler(MoonShineUserRoleHandlers::class, 'save')]
class MoonShineUserRoleResource extends ModelResource
```


```php
final readonly class MoonShineUserRoleHandlers
{
    public function save(MoonshineUserRole $model, array $data): MoonshineUserRole
    {
        $model->fill($data);
        $model->save();

        return $model;
    }

    public function destroy(MoonshineUserRole $model): bool
    {
        return $model->delete();
    }

    public function massDestroy(array $ids): void
    {
        foreach ($ids as $id) {
            MoonshineUserRole::query()->whereKey($id)->delete();
        }
    }
}
```