### PR TITLE
feat(4.x): MenuFiller improvements

### DIFF
--- a/src/Contracts/src/MenuManager/MenuFillerContract.php
+++ b/src/Contracts/src/MenuManager/MenuFillerContract.php
@@ -6,7 +6,23 @@ namespace MoonShine\Contracts\MenuManager;
 
 interface MenuFillerContract
 {
+    public function getTitle(): string;
+
     public function getUrl(): string;
 
+    public function getBadge(): ?string;
+
+    public function getGroup(): ?string;
+
+    public function getGroupIcon(): ?string;
+
     public function isActive(): bool;
+
+    public function skipMenu(): bool;
+
+    public function canSee(): bool;
+
+    public function getIcon(): ?string;
+
+    public function getPosition(): int;
 }

--- a/src/Contracts/src/UI/ActionButtonContract.php
+++ b/src/Contracts/src/UI/ActionButtonContract.php
@@ -13,8 +13,8 @@ use MoonShine\Support\DTOs\AsyncCallback;
 use MoonShine\Support\Enums\HttpMethod;
 
 /**
- * @template TModal of  ComponentContract
- * @template TOffCanvas of  ComponentContract
+ * @template TModal of  ComponentContract = ComponentContract
+ * @template TOffCanvas of  ComponentContract = ComponentContract
  *
  * @extends HasModalContract<TModal>
  * @extends HasOffCanvasContract<TOffCanvas>

--- a/src/Contracts/src/UI/HasLabelContract.php
+++ b/src/Contracts/src/UI/HasLabelContract.php
@@ -8,6 +8,8 @@ use Closure;
 
 interface HasLabelContract
 {
+    public function hasLabel(): bool;
+
     public function getLabel(): string;
 
     public function setLabel(Closure|string $label): static;

--- a/src/Core/src/Pages/Page.php
+++ b/src/Core/src/Pages/Page.php
@@ -20,6 +20,7 @@ use MoonShine\Core\Traits\WithAssets;
 use MoonShine\Core\Traits\WithCore;
 use MoonShine\Core\Traits\WithUriKey;
 use MoonShine\Core\Traits\WithViewRenderer;
+use MoonShine\Support\Concerns\MenuFillerConcern;
 use MoonShine\Support\Enums\Layer;
 use MoonShine\Support\Enums\PageType;
 
@@ -35,6 +36,7 @@ abstract class Page implements PageContract
     use WithUriKey;
     use WithAssets;
     use WithViewRenderer;
+    use MenuFillerConcern;
 
     protected string $title = '';
 

--- a/src/Core/src/Resources/Resource.php
+++ b/src/Core/src/Resources/Resource.php
@@ -13,6 +13,7 @@ use MoonShine\Core\Pages\Pages;
 use MoonShine\Core\Traits\WithAssets;
 use MoonShine\Core\Traits\WithCore;
 use MoonShine\Core\Traits\WithUriKey;
+use MoonShine\Support\Concerns\MenuFillerConcern;
 
 /**
  * @template TPage of PageContract = PageContract
@@ -24,6 +25,7 @@ abstract class Resource implements ResourceContract
     use WithCore;
     use WithUriKey;
     use WithAssets;
+    use MenuFillerConcern;
 
     protected string $title = '';
 

--- a/src/Laravel/src/Exceptions/MoonShineNotFoundException.php
+++ b/src/Laravel/src/Exceptions/MoonShineNotFoundException.php
@@ -11,9 +11,9 @@ use MoonShine\Laravel\Pages\ErrorPage;
 
 final class MoonShineNotFoundException extends MoonShineException
 {
-    public function report(): bool
+    public function report(): void
     {
-        return false;
+        //
     }
 
     public function render(Request $request): Response

--- a/src/Laravel/src/Layouts/AppLayout.php
+++ b/src/Laravel/src/Layouts/AppLayout.php
@@ -29,14 +29,8 @@ class AppLayout extends BaseLayout
     {
         return [
             MenuGroup::make(static fn () => __('moonshine::ui.resource.system'), [
-                MenuItem::make(
-                    static fn () => __('moonshine::ui.resource.admins_title'),
-                    MoonShineUserResource::class
-                ),
-                MenuItem::make(
-                    static fn () => __('moonshine::ui.resource.role_title'),
-                    MoonShineUserRoleResource::class
-                ),
+                MenuItem::make(MoonShineUserResource::class),
+                MenuItem::make(MoonShineUserRoleResource::class),
             ]),
         ];
     }

--- a/src/Laravel/src/Pages/ErrorPage.php
+++ b/src/Laravel/src/Pages/ErrorPage.php
@@ -10,11 +10,11 @@ use MoonShine\Laravel\Layouts\BlankLayout;
 use MoonShine\MenuManager\Attributes\SkipMenu;
 use MoonShine\UI\Components\FlexibleRender;
 
-#[SkipMenu]
-#[Layout(BlankLayout::class)]
 /**
  * @method static static make(int $code, string $message)
  */
+#[SkipMenu]
+#[Layout(BlankLayout::class)]
 class ErrorPage extends Page
 {
     private int $code;

--- a/src/Laravel/src/Resources/MoonShineUserResource.php
+++ b/src/Laravel/src/Resources/MoonShineUserResource.php
@@ -13,12 +13,12 @@ use MoonShine\Support\Attributes\Icon;
 use MoonShine\Support\Enums\Action;
 use MoonShine\Support\ListOf;
 
-#[Icon('users')]
-#[Group('moonshine::ui.resource.system', 'users', translatable: true)]
-#[Order(1)]
 /**
  * @extends ModelResource<MoonshineUser, MoonShineUserIndexPage, MoonShineUserFormPage, null>
  */
+#[Icon('users')]
+#[Group('moonshine::ui.resource.system', 'users', translatable: true)]
+#[Order(0)]
 class MoonShineUserResource extends ModelResource
 {
     protected string $model = MoonshineUser::class;

--- a/src/Laravel/src/Resources/MoonShineUserRoleResource.php
+++ b/src/Laravel/src/Resources/MoonShineUserRoleResource.php
@@ -13,12 +13,12 @@ use MoonShine\Support\Attributes\Icon;
 use MoonShine\Support\Enums\Action;
 use MoonShine\Support\ListOf;
 
-#[Icon('bookmark')]
-#[Group('moonshine::ui.resource.system', 'users', translatable: true)]
-#[Order(1)]
 /**
  * @extends ModelResource<MoonshineUserRole, MoonShineUserRoleIndexPage, MoonShineUserRoleFormPage, null>
  */
+#[Icon('bookmark')]
+#[Group('moonshine::ui.resource.system', 'users', translatable: true)]
+#[Order(0)]
 class MoonShineUserRoleResource extends ModelResource
 {
     protected string $model = MoonshineUserRole::class;

--- a/src/Laravel/src/Traits/WithComponentsPusher.php
+++ b/src/Laravel/src/Traits/WithComponentsPusher.php
@@ -19,6 +19,9 @@ trait WithComponentsPusher
         static::$pushedComponents[] = $component;
     }
 
+    /**
+     * @return list<ComponentContract>
+     */
     protected function getPushedComponents(): array
     {
         return collect(static::$pushedComponents)

--- a/src/MenuManager/src/Attributes/Badge.php
+++ b/src/MenuManager/src/Attributes/Badge.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\MenuManager\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class Badge
+{
+    public function __construct(
+        public string $value,
+    ) {}
+}

--- a/src/Support/src/Concerns/MenuFillerConcern.php
+++ b/src/Support/src/Concerns/MenuFillerConcern.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Support\Concerns;
+
+trait MenuFillerConcern
+{
+    public function getTitle(): string
+    {
+        return '';
+    }
+
+    public function getUrl(): string
+    {
+        return '';
+    }
+
+    public function isActive(): bool
+    {
+        return true;
+    }
+
+    public function skipMenu(): bool
+    {
+        return false;
+    }
+
+    public function getGroup(): ?string
+    {
+        return null;
+    }
+
+    public function getGroupIcon(): ?string
+    {
+        return null;
+    }
+
+    public function getBadge(): ?string
+    {
+        return null;
+    }
+
+    public function canSee(): bool
+    {
+        return true;
+    }
+
+    public function getIcon(): ?string
+    {
+        return null;
+    }
+
+    public function getPosition(): int
+    {
+        return 1;
+    }
+}

--- a/src/UI/src/Traits/ActionButton/WithModal.php
+++ b/src/UI/src/Traits/ActionButton/WithModal.php
@@ -77,7 +77,7 @@ trait WithModal
         Closure|string|null $button = null,
         Closure|array|null $fields = null,
         HttpMethod $method = HttpMethod::POST,
-        /** @var null|Closure(mixed): FormBuilderContract $formBuilder */
+        /** @var null|Closure(FormBuilderContract, mixed): FormBuilderContract $formBuilder */
         ?Closure $formBuilder = null,
         ?Closure $modalBuilder = null,
         Closure|string|null $name = null,

--- a/src/UI/src/Traits/WithLabel.php
+++ b/src/UI/src/Traits/WithLabel.php
@@ -14,6 +14,11 @@ trait WithLabel
 
     protected string $translatableKey = '';
 
+    public function hasLabel(): bool
+    {
+        return $this->label !== '';
+    }
+
     public function getLabel(): string
     {
         $this->label = value($this->label, $this);

--- a/tests/Feature/MenuAutoloaderTest.php
+++ b/tests/Feature/MenuAutoloaderTest.php
@@ -44,24 +44,24 @@ it('to array', function () {
     $autoloader = app(MenuAutoloaderContract::class);
     $items = $autoloader->toArray();
     $snapshot = [
-        'position' => 1,
+        'position' => 0,
         'group' => [
             'class' => 'MoonShine\Laravel\Resources\MoonShineUserRoleResource',
             'label' => 'moonshine::ui.resource.system',
             'icon' => 'users',
-            'canSee' => null,
+            'canSee' => 'canSee',
             'translatable' => true,
         ],
         'items' => [
             0 => [
                 'filler' => 'MoonShine\Laravel\Resources\MoonShineUserResource',
-                'canSee' => null,
-                'position' => 1,
+                'canSee' => 'canSee',
+                'position' => 0,
             ],
             1 => [
                 'filler' => 'MoonShine\Laravel\Resources\MoonShineUserRoleResource',
-                'canSee' => null,
-                'position' => 1,
+                'canSee' => 'canSee',
+                'position' => 0,
             ],
         ],
     ];

--- a/tests/Unit/MenuManagerTest.php
+++ b/tests/Unit/MenuManagerTest.php
@@ -22,7 +22,7 @@ it('empty menu elements', function (): void {
 });
 
 it('add menu elements', function (): void {
-    $this->menuManager->add(MenuItem::make('Item', '/'));
+    $this->menuManager->add(MenuItem::make('/', 'Item'));
 
     expect($this->menuManager->all())
         ->toHaveCount(1)
@@ -37,12 +37,12 @@ it('add menu elements', function (): void {
 
 it('add before menu elements', function (): void {
     $this->menuManager->add([
-        MenuItem::make('Item 1', '/item1'),
-        MenuItem::make('Item 2', '/item2'),
-        MenuItem::make('Item 3', '/item3'),
+        MenuItem::make('/item1', 'Item 1'),
+        MenuItem::make('/item2', 'Item 2'),
+        MenuItem::make('/item3', 'Item 3'),
     ]);
 
-    $item = MenuItem::make('Item 2_0', '/item2_0');
+    $item = MenuItem::make('/item2_0', 'Item 2_0');
 
     $this->menuManager->addBefore(static fn (MenuItem $el) => $el->getUrl() === '/item2', $item);
 
@@ -54,12 +54,12 @@ it('add before menu elements', function (): void {
 
 it('add after menu elements', function (): void {
     $this->menuManager->add([
-        MenuItem::make('Item 1', '/item1'),
-        MenuItem::make('Item 2', '/item2'),
-        MenuItem::make('Item 3', '/item3'),
+        MenuItem::make('/item1', 'Item 1'),
+        MenuItem::make('/item2', 'Item 2'),
+        MenuItem::make('/item3', 'Item 3'),
     ]);
 
-    $item = MenuItem::make('Item 2_0', '/item2_0');
+    $item = MenuItem::make('/item2_0', 'Item 2_0');
 
     $this->menuManager->addAfter(static fn (MenuItem $el) => $el->getUrl() === '/item2', [$item]);
 
@@ -71,9 +71,9 @@ it('add after menu elements', function (): void {
 
 it('remove menu elements', function (): void {
     $this->menuManager->add([
-        MenuItem::make('Item 1', '/item1'),
-        MenuItem::make('Item 2', '/item2'),
-        MenuItem::make('Item 3', '/item3'),
+        MenuItem::make('/item1', 'Item 1'),
+        MenuItem::make('/item2', 'Item 2'),
+        MenuItem::make('/item3', 'Item 3'),
     ]);
 
     $this->menuManager->remove(static fn (MenuItem $el) => $el->getUrl() === '/item2');
@@ -87,22 +87,22 @@ it('remove menu elements', function (): void {
 
 it('replace items', function (): void {
     $this->menuManager->add([
-        MenuItem::make('Item 1', '/item1'),
-        MenuItem::make('Item 2', '/item2'),
-        MenuItem::make('Item 3', '/item3'),
+        MenuItem::make('/item1', 'Item 1'),
+        MenuItem::make('/item2', 'Item 2'),
+        MenuItem::make('/item3', 'Item 3'),
     ]);
 
     expect($this->menuManager->all())
         ->toHaveCount(3)
-        ->and($this->menuManager->all([MenuItem::make('Item 1', '/item1')]))
+        ->and($this->menuManager->all([MenuItem::make('/item1', 'Item 1')]))
         ->toHaveCount(1);
 });
 
 it('only visible items', function (): void {
     $this->menuManager->add([
-        MenuItem::make('Item 1', '/item1'),
-        MenuItem::make('Item 2', '/item2')->canSee(static fn () => false),
-        MenuItem::make('Item 3', '/item3'),
+        MenuItem::make('/item1', 'Item 1'),
+        MenuItem::make('/item2', 'Item 2')->canSee(static fn () => false),
+        MenuItem::make('/item3', 'Item 3'),
     ]);
 
     expect($this->menuManager->all())
@@ -113,9 +113,9 @@ it('only visible items', function (): void {
 it('check active element', function (): void {
     fakeRequest('/item2');
 
-    $item1 = MenuItem::make('Item 1', '/item1');
-    $item2 = MenuItem::make('Item 2', '/item2');
-    $item3 = MenuItem::make('Item 2', '/item2?query=1');
+    $item1 = MenuItem::make('/item1', 'Item 1');
+    $item2 = MenuItem::make('/item2', 'Item 2');
+    $item3 = MenuItem::make('/item2?query=1', 'Item 2');
 
     expect($item1->isActive())
         ->toBeFalse()
@@ -124,9 +124,9 @@ it('check active element', function (): void {
         ->and($item3->isActive())
         ->toBeTrue();
 
-    $item1 = MenuItem::make('Item 1', 'http://localhost/item1');
-    $item2 = MenuItem::make('Item 2', 'http://localhost/item2');
-    $item3 = MenuItem::make('Item 3', 'http://localhost/item2?query=1');
+    $item1 = MenuItem::make('http://localhost/item1', 'Item 1');
+    $item2 = MenuItem::make('http://localhost/item2', 'Item 2');
+    $item3 = MenuItem::make('http://localhost/item2?query=1', 'Item 3');
 
     expect($item1->isActive())
         ->toBeFalse()
@@ -136,9 +136,9 @@ it('check active element', function (): void {
         ->toBeTrue();
 
 
-    $item1 = MenuItem::make('Item 1', 'http://localhost/item1')->whenActive(static fn () => true);
-    $item2 = MenuItem::make('Item 2', 'http://localhost/item2');
-    $item3 = MenuItem::make('Item 3', 'http://localhost/item2?query=1');
+    $item1 = MenuItem::make('http://localhost/item1', 'Item 1')->whenActive(static fn () => true);
+    $item2 = MenuItem::make('http://localhost/item2', 'Item 2');
+    $item3 = MenuItem::make('http://localhost/item2?query=1', 'Item 3');
 
 
     expect($item1->isActive())
@@ -150,8 +150,8 @@ it('check active element', function (): void {
 
     fakeRequest('/admin/test-image-resource/index-page?query=1');
 
-    $item1 = MenuItem::make('Item 1', TestCommentResource::class);
-    $item2 = MenuItem::make('Item 2', TestImageResource::class);
+    $item1 = MenuItem::make(TestCommentResource::class, 'Item 1');
+    $item2 = MenuItem::make(TestImageResource::class, 'Item 2');
 
     expect($item1->isActive())
         ->toBeFalse()
@@ -162,14 +162,14 @@ it('check active element', function (): void {
 it('check active when home', function (): void {
     fakeRequest('/item');
 
-    $item = MenuItem::make('Item 1', fn () => config('app.url'));
+    $item = MenuItem::make(fn () => config('app.url'), 'Item 1');
 
     expect($item->isActive())
         ->toBeFalse();
 
     fakeRequest();
 
-    $item = MenuItem::make('Item 1', fn () => config('app.url'));
+    $item = MenuItem::make(fn () => config('app.url'), 'Item 1');
 
     expect($item->isActive())
         ->toBeTrue();

--- a/tests/Unit/MoonShineTest.php
+++ b/tests/Unit/MoonShineTest.php
@@ -20,7 +20,7 @@ it('find resource by uri key', function (): void {
 
 it('menu', function (): void {
     $this->menuManager->add([
-        MenuItem::make('Resource', $this->resource),
+        MenuItem::make($this->resource, 'Resource'),
     ]);
 
     expect($this->menuManager->all())->toBeCollection()


### PR DESCRIPTION
Now the filler is the first parameter, so if the filler is specified, then the label can be omitted and it will be automatically taken from the filler's getTitle, which is convenient.

```php
MenuItem::make(UserResource::class);
```


Now you can control the menu display via filler methods

```php
interface MenuFillerContract
{
    public function getTitle(): string;

    public function getUrl(): string;

    public function getBadge(): ?string;

    public function getGroup(): ?string;

    public function getGroupIcon(): ?string;

    public function isActive(): bool;

    public function skipMenu(): bool;

    public function canSee(): bool;

    public function getIcon(): ?string;

    public function getPosition(): int;
}
```

Also added attribute to indicate badge

```php
#[\MoonShine\MenuManager\Attributes\Badge('new')]
class CarResource extends ModelResource
```

BREAKING-CHANGE:

MenuItem filler parameter now before label

Before

```php
MenuItem::make(label: 'Label',  filler: '/');
```

After

```php
MenuItem::make(filler: '/',  label: 'Label');
```
