### PR TITLE
refactor(4.x): Async search term before request

### DIFF
--- a/src/Laravel/src/Http/Controllers/AsyncSearchController.php
+++ b/src/Laravel/src/Http/Controllers/AsyncSearchController.php
@@ -57,8 +57,8 @@ final class AsyncSearchController extends MoonShineController
             $query = value(
                 $field->getAsyncSearchQuery(),
                 $query,
-                $request,
                 $term,
+                $request,
                 $field
             );
         }

--- a/src/Laravel/src/Traits/Fields/WithAsyncSearch.php
+++ b/src/Laravel/src/Traits/Fields/WithAsyncSearch.php
@@ -161,7 +161,7 @@ trait WithAsyncSearch
 
     /**
      * @param  string|null  $column
-     * @param  ?Closure(Builder $query, RelationModelFieldRequest $request, string $term, FieldContract $field): static  $searchQuery
+     * @param  ?Closure(Builder $query, string $term, RelationModelFieldRequest $request, FieldContract $field): static  $searchQuery
      * @param  ?Closure(mixed $data, FieldContract $field): static  $formatted
      */
     public function asyncSearch(
@@ -199,7 +199,7 @@ trait WithAsyncSearch
     }
 
     /**
-     * @param  ?Closure(Builder $query, RelationModelFieldRequest $request, string $term, FieldContract $field): static  $searchQuery
+     * @param  ?Closure(Builder $query, string $term, RelationModelFieldRequest $request, FieldContract $field): static  $searchQuery
      */
     public function associatedWith(string $column, ?Closure $searchQuery = null): static
     {


### PR DESCRIPTION
## BC

### Before

```php
->asyncSearch(searchQuery: fn(Builder $query, Request $request, string $term, FieldContract $ctx))
```
### After

```php
->asyncSearch(searchQuery: fn(Builder $query, string $term, Request $request, FieldContract $ctx))
```