### PR TITLE
feat(4.x): B2m deduplicates mode

### DIFF
--- a/src/Contracts/src/UI/TableBuilderContract.php
+++ b/src/Contracts/src/UI/TableBuilderContract.php
@@ -192,4 +192,6 @@ interface TableBuilderContract extends
     public function pushState(): static;
 
     public function removeAfterClone(): static;
+
+    public function withoutKey(): static;
 }

--- a/src/Laravel/src/Http/Controllers/AsyncSearchController.php
+++ b/src/Laravel/src/Http/Controllers/AsyncSearchController.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use MoonShine\Laravel\Contracts\Fields\HasAsyncSearchContract;
 use MoonShine\Laravel\Contracts\Resource\WithQueryBuilderContract;
+use MoonShine\Laravel\Fields\Relationships\BelongsToMany;
 use MoonShine\Laravel\Fields\Relationships\MorphTo;
 use MoonShine\Laravel\Http\Requests\Relations\RelationModelFieldRequest;
 use MoonShine\Laravel\Support\DBOperators;
@@ -68,6 +69,10 @@ final class AsyncSearchController extends MoonShineController
         $except = \is_array($values)
             ? array_keys($values)
             : array_filter(explode(',', (string) $values));
+
+        if($field instanceof BelongsToMany && !$field->isDeduplicate()) {
+            $except = [];
+        }
 
         $offset = $request->input('offset', 0);
 

--- a/src/UI/resources/js/Components/BelongsToMany.js
+++ b/src/UI/resources/js/Components/BelongsToMany.js
@@ -32,9 +32,14 @@ export default () => ({
 
       const tr = pivot.querySelector('table > tbody > tr:last-child')
       tr.querySelector('.js-pivot-title').innerHTML = item.label
-      tr.dataset.rowKey = item.value
+
+      if(tr.dataset.rowKey) {
+        tr.dataset.rowKey = item.value
+      }
+
       const checker = tr.querySelector('.js-pivot-checker')
       checker.checked = true
+      checker.value = item.value
       checker.dispatchEvent(new Event('change'))
 
       this.$dispatch('table_reindex:' + tableName)

--- a/src/UI/resources/js/Support/Forms.js
+++ b/src/UI/resources/js/Support/Forms.js
@@ -124,10 +124,11 @@ export function crudFormQuery(formElements = null, maxLength = 50) {
       !name.startsWith('hidden_')
     ) {
       const value = inputGetValue(element)
+      const isBoolean = element.getAttribute('type') === 'checkbox' || element.getAttribute('type') === 'radio'
 
-      if (maxLength !== null && typeof value === 'string' && value.length <= maxLength) {
-        values[inputFieldName(name)] = value
-      } else if (maxLength === null) {
+      if(isBoolean && element.checked) {
+        values[inputFieldName(name)] = typeof element.value === 'boolean' ? 1 : element.value
+      } else if (maxLength === false || value.length <= maxLength) {
         values[inputFieldName(name)] = value
       }
     }

--- a/src/UI/src/Components/Table/TableBuilder.php
+++ b/src/UI/src/Components/Table/TableBuilder.php
@@ -89,6 +89,8 @@ final class TableBuilder extends IterableComponent implements
 
     protected ?Closure $topRight = null;
 
+    protected bool $isWithoutKey = false;
+
     public function __construct(
         iterable $fields = [],
         iterable $items = [],
@@ -222,6 +224,13 @@ final class TableBuilder extends IterableComponent implements
         return $this->rows = $this->resolveRows();
     }
 
+    public function withoutKey(): static
+    {
+        $this->isWithoutKey = true;
+
+        return $this;
+    }
+
     /**
      * @throws Throwable
      */
@@ -312,7 +321,7 @@ final class TableBuilder extends IterableComponent implements
                             static fn (TableCellContract $td): TableCellContract => $tdAttributes($td)
                         ),
                     ]),
-                    key: $key,
+                    key: $this->isWithoutKey ? null : $key,
                     builder: $trAttributes
                 );
 
@@ -350,7 +359,7 @@ final class TableBuilder extends IterableComponent implements
 
             $rows->pushRow(
                 $cells,
-                $key,
+                $this->isWithoutKey ? null : $key,
                 builder: $trAttributes,
             );
 


### PR DESCRIPTION
Initially, the idea came from a discussion https://github.com/orgs/moonshine-software/discussions/1677 where it was suggested to create duplicates, the case does exist and by default the field works without duplicates, but the behavior can be disabled

```php
BelongsToMany::make('Categories')->fields([
    Text::make('pivot_field', 'pivot_field'),
])
    ->deduplication(false)
    ->asyncSearch()
```

![Снимок экрана 2025-06-22 в 21 45 33](https://github.com/user-attachments/assets/64cc7266-6b94-430d-9cb3-eb65f4aa0390)
