### PR TITLE
feat: add support for lazy mode in Slug::live()

### DIFF
--- a/src/Laravel/src/Fields/Slug.php
+++ b/src/Laravel/src/Fields/Slug.php
@@ -28,18 +28,32 @@ class Slug extends Text
         return $this;
     }
 
-    public function live(): static
+    public function live(bool $lazy = false): static
     {
         return $this->reactive(function (FieldsContract $fields): FieldsContract {
             $title = $fields->findByColumn($this->getFrom());
 
+            if (is_null($title)) {
+                return $fields;
+            }
+
+            $slugField = $fields->findByColumn($this->getColumn());
+
+            if (
+                $slugField &&
+                $slugField->toValue() &&
+                $slugField->toValue() !== str($title->toValue())->slug($this->getSeparator())->value()
+            ) {
+                return $fields;
+            }
+
             return tap(
                 $fields,
                 fn ($fields): ?FieldContract => $fields
-                ->findByColumn($this->getColumn())
-                ?->setValue(str($title->toValue())->slug($this->getSeparator())->value())
+                    ->findByColumn($this->getColumn())
+                    ?->setValue(str($title->toValue())->slug($this->getSeparator())->value())
             );
-        });
+        }, lazy: $lazy);
     }
 
     public function separator(string $separator): static
@@ -98,7 +112,7 @@ class Slug extends Text
         $i = 1;
 
         while (! $this->checkUnique($item, $slug)) {
-            $slug = $item->{$this->getColumn()} . $this->getSeparator() . $i++;
+            $slug = $item->{$this->getColumn()}.$this->getSeparator().$i++;
         }
 
         return $slug;


### PR DESCRIPTION
## What was changed

Added support for a lazy mode in the Slug::live() method via a lazy parameter.
Now the Slug field can be reactive only after losing focus (blur), which helps avoid unnecessary requests on every keystroke.
Also improved behavior when manually unlocking the Slug field — it no longer immediately locks again or gets overwritten if the value was edited manually.

## Why?

Currently, Slug::make()->live() sends requests on every change to the name field, which makes manual editing of the Slug difficult: the field is instantly overwritten and locked again.
Adding lazy mode support allows the Slug to update only after losing focus, similar to Text::make()->reactive(lazy: true). This provides more flexible behavior and improves the user experience.

## Checklist

- Issue #1604
- Tested
    - [x] Tested manually
    - [ ] Tests added