### PR TITLE
feat(4.x): New update row event approach

### DIFF
--- a/src/Contracts/src/Core/HasListComponentContract.php
+++ b/src/Contracts/src/Core/HasListComponentContract.php
@@ -21,6 +21,4 @@ interface HasListComponentContract
     public function getListEventType(): JsEvent;
 
     public function getListComponentName(): string;
-
-    public function getListComponentNameWithRow(null|int|string $id = null): string;
 }

--- a/src/Crud/src/Concerns/Page/HasListComponent.php
+++ b/src/Crud/src/Concerns/Page/HasListComponent.php
@@ -20,11 +20,6 @@ trait HasListComponent
         return "index-table-{$this->getResource()->getUriKey()}";
     }
 
-    public function getListComponentNameWithRow(null|int|string $id = null): string
-    {
-        return $this->getListComponentName() . ($id ? "-$id" : "-{row-id}");
-    }
-
     public function getListEventType(): JsEvent
     {
         return JsEvent::TABLE_UPDATED;

--- a/src/Crud/src/Concerns/Resource/HasListComponent.php
+++ b/src/Crud/src/Concerns/Resource/HasListComponent.php
@@ -37,17 +37,6 @@ trait HasListComponent
         return $page->getListComponentName();
     }
 
-    public function getListComponentNameWithRow(null|int|string $id = null): string
-    {
-        $page = $this->getIndexPage();
-
-        if (! $page instanceof HasListComponentContract) {
-            return $this->getListComponentName() . ($id ? "-$id" : "-{row-id}");
-        }
-
-        return $page->getListComponentNameWithRow($id);
-    }
-
     public function getListEventType(): JsEvent
     {
         return JsEvent::TABLE_UPDATED;

--- a/src/Support/src/AlpineJs.php
+++ b/src/Support/src/AlpineJs.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use MoonShine\Support\DTOs\AsyncCallback;
 use MoonShine\Support\Enums\HttpMethod;
 use MoonShine\Support\Enums\JsEvent;
+use MoonShine\Support\EventParams\EventParams;
 
 final readonly class AlpineJs
 {
@@ -43,7 +44,7 @@ final readonly class AlpineJs
                 );
         }
 
-        return $event;
+        return str_replace('=', '~', $event);
     }
 
     /**

--- a/src/Support/src/Enums/JsEvent.php
+++ b/src/Support/src/Enums/JsEvent.php
@@ -14,6 +14,10 @@ enum JsEvent: string
 
     case TABLE_ROW_UPDATED = 'table_row_updated';
 
+    case TABLE_ROW_ADDED = 'table_row_added';
+
+    case TABLE_EMPTY_ROW_ADDED = 'table_empty_row_added';
+
     case CARDS_UPDATED = 'cards_updated';
 
     case FORM_RESET = 'form_reset';

--- a/src/Support/src/Enums/ListRowEventType.php
+++ b/src/Support/src/Enums/ListRowEventType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Support\Enums;
+
+enum ListRowEventType: string
+{
+    case APPEND = 'append';
+
+    case PREPEND = 'prepend';
+
+    case REMOVE = 'remove';
+
+    case CHANGE = 'change';
+}

--- a/src/Support/src/EventParams/EventParams.php
+++ b/src/Support/src/EventParams/EventParams.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MoonShine\Support;
+namespace MoonShine\Support\EventParams;
 
 use InvalidArgumentException;
 use MoonShine\Support\Traits\Makeable;

--- a/src/Support/src/EventParams/ListRowEventParams.php
+++ b/src/Support/src/EventParams/ListRowEventParams.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Support\EventParams;
+
+use MoonShine\Support\Enums\ListRowEventType;
+
+/**
+ * @method static static make(int|string|null $key = null, ListRowEventType $type = ListRowEventType::CHANGE)
+ */
+class ListRowEventParams extends EventParams
+{
+    public function __construct(int|string|null $key = null, ListRowEventType $type = ListRowEventType::CHANGE)
+    {
+        parent::__construct([
+            'key' => $key,
+            'type' => $type->value,
+        ]);
+    }
+
+}

--- a/src/Support/src/EventParams/ToastEventParams.php
+++ b/src/Support/src/EventParams/ToastEventParams.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MoonShine\Support;
+namespace MoonShine\Support\EventParams;
 
 use MoonShine\Support\Enums\ToastType;
 

--- a/src/UI/resources/js/Components/BelongsToMany.js
+++ b/src/UI/resources/js/Components/BelongsToMany.js
@@ -28,7 +28,7 @@ export default () => ({
     if (pivot !== null) {
       const tableName = pivot.dataset.tableName.toLowerCase()
 
-      this.$dispatch('table_row_added:' + tableName)
+      this.$dispatch('table_empty_row_added:' + tableName)
 
       const tr = pivot.querySelector('table > tbody > tr:last-child')
       tr.querySelector('.js-pivot-title').innerHTML = item.label

--- a/src/UI/resources/js/Components/FormBuilder.js
+++ b/src/UI/resources/js/Components/FormBuilder.js
@@ -223,7 +223,7 @@ export default (name = '', initData = {}, reactive = {}) => ({
           t.toggleModal()
         }
 
-        if (!('redirect' in data)) {
+      if (typeof data !== 'object' || data === null || !('redirect' in data)) {
           submitState(form, false, false)
         }
 

--- a/src/UI/resources/js/Components/TableBuilder.js
+++ b/src/UI/resources/js/Components/TableBuilder.js
@@ -1,6 +1,6 @@
 import {crudFormQuery} from '../Support/Forms.js'
 import sortableFunction from './Sortable.js'
-import {listComponentRequest} from '../Request/Sets.js'
+import {listComponentRequest, listRowRequest} from '../Request/Sets.js'
 import {urlWithQuery, prepareUrl} from '../Request/Core.js'
 import {dispatchEvents} from '../Support/DispatchEvents.js'
 
@@ -203,21 +203,21 @@ export default (
   asyncRequest() {
     listComponentRequest(this, this.$root?.dataset?.pushState)
   },
-  asyncRowRequest(key, index) {
-    const t = this
-    const tr = this.table.querySelector('[data-row-key="' + key + '"]')
+  asyncRowRequest(key = null, index = null) {
+    let eventData = this.$event.detail
 
-    if (tr === null) {
-      return
+    key = key || eventData.key
+    index = index || key || 0
+
+    if (key === null && this.$el.tagName.toLowerCase() === 'form') {
+      key = new URL(this.$el.action).searchParams.get('resourceItem') ?? index
+    } else if(key === null) {
+      const tr = this.$el.closest('tr')
+
+      key = tr?.dataset?.rowKey ?? index
     }
 
-    axios
-      .get(prepareUrl(t.asyncUrl + `&_key=${key}&_index=${index}`))
-      .then(response => {
-        tr.outerHTML = response.data
-        t.initColumnSelection()
-      })
-      .catch(error => {})
+    listRowRequest(this, key, index, eventData.type)
   },
   actions(type, id) {
     let all = this.$root.querySelector(`.${id}-actions-all-checked`)

--- a/src/UI/resources/js/Request/Sets.js
+++ b/src/UI/resources/js/Request/Sets.js
@@ -1,7 +1,54 @@
 import {dispatchEvents} from '../Support/DispatchEvents.js'
-import request, {urlWithQuery} from './Core.js'
+import request, {prepareUrl, urlWithQuery} from './Core.js'
 import {ComponentRequestData} from '../DTOs/ComponentRequestData.js'
 import {getQueryString} from '../Support/Forms.js'
+
+export function listRowRequest(component, key = null, index = null, type = 'change') {
+  const body = component.table.querySelector('tbody')
+  const isChange = type === 'change'
+  const isRemove = type === 'remove'
+
+  let tr = body.querySelector('[data-row-key="' + key + '"]')
+
+  if ((isChange || isRemove) && tr === null) {
+    return
+  }
+
+  if (isRemove) {
+    tr.remove()
+    component.initColumnSelection()
+
+    return
+  }
+
+  axios
+  .get(prepareUrl(component.asyncUrl + `&_key=${key}&_index=${index}`))
+  .then(response => {
+    const html = response.data.trim()
+
+    if(isChange) {
+      tr.outerHTML = html
+    } else {
+      const template= document.createElement('template')
+      template.innerHTML = html
+
+      tr = template.content.firstElementChild;
+    }
+
+    if (tr === null || tr.tagName !== 'TR') {
+      return
+    }
+
+    if (type === 'prepend') {
+      body.prepend(tr)
+    } else if (type === 'append') {
+      body.appendChild(tr)
+    }
+
+    component.initColumnSelection()
+  })
+  .catch(error => {})
+}
 
 export function listComponentRequest(component, pushState = false) {
   component.$event.preventDefault()

--- a/src/UI/resources/js/Support/DispatchEvents.js
+++ b/src/UI/resources/js/Support/DispatchEvents.js
@@ -9,18 +9,6 @@ export function dispatchEvents(events, type, component, extraProperties = {}) {
     return
   }
 
-  if (events.includes('{row-id}') && component.$el !== undefined) {
-    if (component.$el.tagName.toLowerCase() === 'form') {
-      events = events.replace(
-        /{row-id}/g,
-        new URL(component.$el.action).searchParams.get('resourceItem') ?? 0,
-      )
-    } else {
-      const tr = component.$el.closest('tr')
-      events = events.replace(/{row-id}/g, tr?.dataset?.rowKey ?? 0)
-    }
-  }
-
   if (events !== '' && type !== 'error') {
     const allEvents = events.split(',')
 
@@ -36,7 +24,7 @@ export function dispatchEvents(events, type, component, extraProperties = {}) {
         let params = parts[1].split(';')
 
         for (let param of params) {
-          let pair = param.split('=')
+          let pair = param.split('~')
           attributes[pair[0]] = pair[1].replace(/`/g, '').trim()
         }
       }

--- a/src/UI/resources/js/__tests__/Support/DispatchEvents.test.js
+++ b/src/UI/resources/js/__tests__/Support/DispatchEvents.test.js
@@ -38,16 +38,8 @@ describe('dispatchEvents', () => {
     expect(mockDispatchEvents()).not.toHaveBeenCalled()
   })
 
-  it('should replace {row-id} with rowKey from dataset', () => {
-    dispatchEvents('{row-id}', 'eventType', component)
-
-    jest.runAllTimers()
-
-    expect(mockDispatchEvents()).toHaveBeenCalledWith(expectEvent('123'))
-  })
-
   it('delayed dispatch', () => {
-    dispatchEvents('somevent|_delay=500', 'eventType', component)
+    dispatchEvents('somevent|_delay~500', 'eventType', component)
 
     expect(mockDispatchEvents()).not.toHaveBeenCalled()
 
@@ -57,7 +49,7 @@ describe('dispatchEvents', () => {
   })
 
   it('should dispatch events correctly', () => {
-    const events = 'click|param1=value1;param2=value2,hover|param3=value3'
+    const events = 'click|param1~value1;param2~value2,hover|param3~value3'
     dispatchEvents(events, 'eventType', component, {extraParam: 'extraValue'})
 
     jest.runAllTimers()

--- a/src/UI/resources/views/components/table/builder.blade.php
+++ b/src/UI/resources/views/components/table/builder.blade.php
@@ -34,9 +34,10 @@
     {{ (int) $async }},
     '{{ $asyncUrl }}'
 )"
-        @defineEvent('table_row_added', $name, 'add(true)')
+        @defineEvent('table_empty_row_added', $name, 'add(true)')
         @defineEvent('table_reindex', $name, 'resolveReindex')
         @defineEventWhen($async, 'table_updated', $name, 'asyncRequest')
+        @defineEventWhen($async, 'table_row_added', $name, 'asyncRowRequest()')
         {{ $attributes }}
     >
         <x-moonshine::iterable-wrapper

--- a/src/UI/src/Components/Table/TableBuilder.php
+++ b/src/UI/src/Components/Table/TableBuilder.php
@@ -21,6 +21,7 @@ use MoonShine\Contracts\UI\TableRowContract;
 use MoonShine\Support\AlpineJs;
 use MoonShine\Support\Components\MoonShineComponentAttributeBag;
 use MoonShine\Support\Enums\JsEvent;
+use MoonShine\Support\EventParams\ListRowEventParams;
 use MoonShine\UI\Collections\Fields;
 use MoonShine\UI\Collections\TableCells;
 use MoonShine\UI\Collections\TableRows;
@@ -441,9 +442,10 @@ final class TableBuilder extends IterableComponent implements
             ? []
             : [
                 AlpineJs::eventBlade(
-                    JsEvent::TABLE_ROW_UPDATED,
-                    "{$this->getName()}-{$data->getKey()}",
-                ) => "asyncRowRequest(`{$data->getKey()}`,`$index`)",
+                    event: JsEvent::TABLE_ROW_UPDATED,
+                    name: $this->getName(),
+                    params: ListRowEventParams::make($data->getKey() ?? $index)
+                ) => 'asyncRowRequest()',
             ];
     }
 

--- a/src/UI/src/Sets/UpdateOnPreviewPopover.php
+++ b/src/UI/src/Sets/UpdateOnPreviewPopover.php
@@ -8,6 +8,7 @@ use MoonShine\Contracts\UI\FieldContract;
 use MoonShine\Support\AlpineJs;
 use MoonShine\Support\Enums\FormMethod;
 use MoonShine\Support\Enums\JsEvent;
+use MoonShine\Support\EventParams\ListRowEventParams;
 use MoonShine\UI\Components\FormBuilder;
 use MoonShine\UI\Components\Layout\Flex;
 use MoonShine\UI\Components\Link;
@@ -49,8 +50,9 @@ final readonly class UpdateOnPreviewPopover
                     ->async(events: [
                         AlpineJs::event(JsEvent::POPOVER_TOGGLED, $name),
                         AlpineJs::event(
-                            JsEvent::TABLE_ROW_UPDATED,
-                            $this->component . "-" . $this->field->getData()?->getKey(),
+                            event: JsEvent::TABLE_ROW_UPDATED,
+                            name: $this->component,
+                            params: ListRowEventParams::make($this->field->getData()?->getKey() ?? $this->field->getRowIndex())
                         ),
                     ])
                     ->fields([

--- a/src/UI/src/Traits/Fields/UpdateOnPreview.php
+++ b/src/UI/src/Traits/Fields/UpdateOnPreview.php
@@ -65,7 +65,7 @@ trait UpdateOnPreview
         return $this->setUpdateOnPreviewUrl(
             $this->updateOnPreviewUrl,
             events: [
-                AlpineJs::event(JsEvent::TABLE_ROW_UPDATED, "$component-{row-id}"),
+                AlpineJs::event(JsEvent::TABLE_ROW_UPDATED, $component),
             ]
         );
     }

--- a/tests/Unit/AlpineJsEventTest.php
+++ b/tests/Unit/AlpineJsEventTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Str;
+use MoonShine\Support\AlpineJs;
+use MoonShine\Support\Enums\JsEvent;
+use MoonShine\Support\Enums\ListRowEventType;
+use MoonShine\Support\EventParams\ListRowEventParams;
+
+uses()->group('events');
+
+it('perform eventBlade with params', function () {
+    $key = Str::uuid()->toString();
+    $type = ListRowEventType::CHANGE;
+
+    $event = AlpineJs::eventBlade(
+        event: JsEvent::TABLE_ROW_UPDATED,
+        name: 'my-table',
+        params: ListRowEventParams::make($key, $type)
+    );
+
+    expect($event)
+        ->toBe("@table_row_updated:my-table|key~$key;type~$type->value;_delay~0.window");
+});


### PR DESCRIPTION
### New Events

- JSEvent::TABLE_EMPTY_ROW_ADDED - append new cloned row
- JSEvent::TABLE_ROW_ADDED - append/prepend new row

### New row added event

```php
AlpineJs::event(
    JsEvent::TABLE_ROW_ADDED,
    $this->getListComponentName(),
    ListRowEventParams::make(key: 1, type: ListRowEventType::PREPEND)
)
```

### BC:
- Changed row update event approach

#### Before
```php
AlpineJs::event(
    JsEvent::TABLE_ROW_UPDATED,
    $this->getListComponentName() . '-{row-id}',
)
```
#### After
```php
AlpineJs::event(
    JsEvent::TABLE_ROW_UPDATED,
    $this->getListComponentName(),
)

// OR

AlpineJs::event(
    JsEvent::TABLE_ROW_UPDATED,
    $this->getListComponentName(),
    ListRowEventParams::make(key: 1)
)
```

- The resource and index page method of getListComponentNameWithRow has been removed (unused)