### PR TITLE
Fix: No redirect if the Resource is edited in a modal window

### DIFF
--- a/src/Laravel/src/Traits/Resource/ResourceCrudRouter.php
+++ b/src/Laravel/src/Traits/Resource/ResourceCrudRouter.php
@@ -118,12 +118,12 @@ trait ResourceCrudRouter
 
     public function getRedirectAfterSave(): ?string
     {
-        if (\is_null($this->redirectAfterSave) && ! $this->isAsync()) {
-            $this->redirectAfterSave = PageType::FORM;
+        if ($this->isAsync()) {
+            return null;
         }
 
         if (\is_null($this->redirectAfterSave)) {
-            return null;
+            $this->redirectAfterSave = PageType::FORM;
         }
 
         $params = \is_null($this->getItem()) || $this->redirectAfterSave === PageType::INDEX


### PR DESCRIPTION
## What was changed
Убран редирект по заданному $redirectAfterSave, если ресурс редактируется в модальном окне.

## Why?
1. Мне кажется, что смысл использования модального окна как в том, чтобы в итоге остаться на той же странице, откуда вызвано это окно.
2. В случае, если ресурс является дочерним по отношению HasMany и он редактируется со страницы родителя (поле HasMany, форма будет в модальном), то при указанном $redirectAfterSave сначала произойдет асинхронное обновление страницы родителя и сразу же редирект со страницы родителя на указанную в $redirectAfterSave страницу, что выглядит как ошибка.
Особенно странно выглядит такой кейс: у дочернего указываем $redirectAfterSave=PageType::INDEX, редактируем в модальном от родителя - как результат попадаем в список **всех** дочерних ресурсов. При этом в ресурсе дочерней модели редактирование указано без модалки и там редирект на индекс после сохранения является нормальным.

## Checklist

- Issue #<!-- add issue number here -->
- Tested
    - [x] Tested manually
    - [ ] Tests added
- [ ] Documentation <!--- Remove if not needed -->
