### PR TITLE
fix(4.x) Pass original item instead of `DataWrapperContract` into apply handlers

### DIFF
--- a/src/Laravel/src/Resources/ModelResource.php
+++ b/src/Laravel/src/Resources/ModelResource.php
@@ -281,9 +281,9 @@ abstract class ModelResource extends CrudResource implements WithQueryBuilderCon
 
         $initial = clone $item;
         $data = Field::silentApply(static function () use ($item, $fields, $resource): array {
-            $fields->each(static fn (FieldContract $field): mixed => $field->beforeApply($item));
-            $fields->each(static fn (FieldContract $field): mixed => $field->apply($resource->fieldApply($field), $item));
-            $fields->each(static fn (FieldContract $field): mixed => $field->afterApply($item));
+            $fields->each(static fn (FieldContract $field): mixed => $field->beforeApply($item->getOriginal()));
+            $fields->each(static fn (FieldContract $field): mixed => $field->apply($resource->fieldApply($field), $item->getOriginal()));
+            $fields->each(static fn (FieldContract $field): mixed => $field->afterApply($item->getOriginal()));
 
             return $item->toArray();
         });


### PR DESCRIPTION
Pass original item instead of `DataWrapperContract` into apply handlers

## What was changed
Fix error for feature in PR https://github.com/moonshine-software/moonshine/pull/1713 by passing original item insted of `DataWrapperContact` into apply methods

## Why?
Without this fix when i add a `SaveHandler` to my resource and save item i have error:
```
"MoonShine\\Laravel\\Fields\\Relationships\\BelongsTo::{closure:MoonShine\\Laravel\\Fields\\Relationships\\BelongsTo::resolveOnApply():100}(): Argument #1 ($item) must be of type Illuminate\\Database\\Eloquent\\Model, MoonShine\\Laravel\\TypeCasts\\ModelDataWrapper given, called in /var/www/app/moonshine/src/UI/src/Traits/Fields/Applies.php on line 154"
```

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Tests added
