### PR TITLE
feat: Crud page default components

### DIFF
--- a/src/Crud/src/Contracts/PageComponents/DefaultDetailComponentContract.php
+++ b/src/Crud/src/Contracts/PageComponents/DefaultDetailComponentContract.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Crud\Contracts\PageComponents;
+
+
+use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
+use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
+use MoonShine\Contracts\UI\ComponentContract;
+use MoonShine\Crud\Contracts\Page\DetailPageContract;
+
+interface DefaultDetailComponentContract
+{
+    public function __invoke(
+        DetailPageContract $page,
+        ?DataWrapperContract $item,
+        FieldsContract $fields,
+    ): ComponentContract;
+}

--- a/src/Crud/src/Contracts/PageComponents/DefaultFormContract.php
+++ b/src/Crud/src/Contracts/PageComponents/DefaultFormContract.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Crud\Contracts\PageComponents;
+
+use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
+use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
+use MoonShine\Contracts\UI\FormBuilderContract;
+use MoonShine\Crud\Contracts\Page\FormPageContract;
+
+interface DefaultFormContract
+{
+    public function __invoke(
+        FormPageContract $page,
+        string $action,
+        ?DataWrapperContract $item,
+        FieldsContract $fields,
+        bool $isAsync = true,
+    ): FormBuilderContract;
+}

--- a/src/Crud/src/Contracts/PageComponents/DefaultListComponentContract.php
+++ b/src/Crud/src/Contracts/PageComponents/DefaultListComponentContract.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Crud\Contracts\PageComponents;
+
+
+use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
+use MoonShine\Contracts\UI\ComponentContract;
+use MoonShine\Crud\Contracts\Page\IndexPageContract;
+
+interface DefaultListComponentContract
+{
+    /**
+     * @param  iterable<array-key, mixed>  $items
+     */
+    public function __invoke(
+        IndexPageContract $page,
+        iterable $items,
+        FieldsContract $fields
+    ): ComponentContract;
+}

--- a/src/Crud/src/Pages/DetailPage.php
+++ b/src/Crud/src/Pages/DetailPage.php
@@ -14,6 +14,8 @@ use MoonShine\Core\Exceptions\ResourceException;
 use MoonShine\Crud\Collections\Fields;
 use MoonShine\Crud\Components\Fragment;
 use MoonShine\Crud\Contracts\Page\DetailPageContract;
+use MoonShine\Crud\Contracts\PageComponents\DefaultDetailComponentContract;
+use MoonShine\Crud\Pages\PageComponents\DefaultDetailComponent;
 use MoonShine\Crud\Resources\CrudResource;
 use MoonShine\Support\Enums\Ability;
 use MoonShine\Support\Enums\Action;
@@ -38,6 +40,11 @@ use Throwable;
 class DetailPage extends CrudPage implements DetailPageContract
 {
     protected ?PageType $pageType = PageType::DETAIL;
+
+    /**
+     * @var class-string<DefaultDetailComponentContract>
+     */
+    protected string $component = DefaultDetailComponent::class;
 
     public function getTitle(): string
     {
@@ -132,20 +139,13 @@ class DetailPage extends CrudPage implements DetailPageContract
     public function getDetailComponent(bool $withoutFragment = false): ComponentContract
     {
         $resource = $this->getResource();
-        $item = $resource->getCastedData();
-        $fields = $this->getResource()->getDetailFields();
+
+        $detailComponent = $this->getCore()->getContainer(
+            $this->component
+        );
 
         $component = $this->modifyDetailComponent(
-            TableBuilder::make($fields)
-                ->cast($this->getResource()->getCaster())
-                ->items([$item])
-                ->vertical(
-                    title: $this->getResource()->isDetailInModal() ? 3 : 2,
-                    value: $this->getResource()->isDetailInModal() ? 9 : 10,
-                )
-                ->simple()
-                ->preview()
-                ->class('table-divider'),
+            $detailComponent($this, $resource->getCastedData(), $resource->getDetailFields())
         );
 
         if ($withoutFragment) {

--- a/src/Crud/src/Pages/FormPage.php
+++ b/src/Crud/src/Pages/FormPage.php
@@ -16,6 +16,8 @@ use MoonShine\Crud\Collections\Fields;
 use MoonShine\Crud\Components\Fragment;
 use MoonShine\Crud\Concerns\Page\HasFormValidation;
 use MoonShine\Crud\Contracts\Page\FormPageContract;
+use MoonShine\Crud\Contracts\PageComponents\DefaultFormContract;
+use MoonShine\Crud\Pages\PageComponents\DefaultForm;
 use MoonShine\Crud\Resources\CrudResource;
 use MoonShine\Support\AlpineJs;
 use MoonShine\Support\Enums\Ability;
@@ -44,6 +46,11 @@ class FormPage extends CrudPage implements FormPageContract
     use HasFormValidation;
 
     protected ?PageType $pageType = PageType::FORM;
+
+    /**
+     * @var class-string<DefaultFormContract>
+     */
+    protected string $form = DefaultForm::class;
 
     public function getTitle(): string
     {
@@ -191,57 +198,16 @@ class FormPage extends CrudPage implements FormPageContract
         FieldsContract $fields,
         bool $isAsync = true,
     ): FormBuilderContract {
-        $resource = $this->getResource();
+        $form = $this->getCore()->getContainer($this->form);
 
         return $this->modifyFormComponent(
-            FormBuilder::make($action)
-                ->cast($this->getResource()->getCaster())
-                ->fill($item)
-                ->fields([
-                    /** @phpstan-ignore argument.templateType */
-                    ...$fields
-                        ->when(
-                            ! \is_null($item),
-                            static fn (Fields $fields): Fields
-                                => $fields->push(
-                                    Hidden::make('_method')->setValue('PUT'),
-                                ),
-                        )
-                        ->toArray(),
-                ])
-                ->when(
-                    ! $this->hasErrorsAbove(),
-                    fn (FormBuilderContract $form): FormBuilderContract => $form->errorsAbove($this->hasErrorsAbove()),
-                )
-                ->when(
-                    $isAsync,
-                    fn (FormBuilderContract $formBuilder): FormBuilderContract
-                        => $formBuilder
-                        ->async(
-                            events: array_filter([
-                                $resource->getListEventName(
-                                    $this->getCore()->getRequest()->getScalar('_component_name', 'default'),
-                                    $isAsync && $resource->isItemExists() ? array_filter([
-                                        'page' => $this->getCore()->getRequest()->getScalar('page'),
-                                        'sort' => $this->getCore()->getRequest()->getScalar('sort'),
-                                    ]) : [],
-                                ),
-                                ! $resource->isItemExists() && $resource->isCreateInModal()
-                                    ? AlpineJs::event(JsEvent::FORM_RESET, $resource->getUriKey())
-                                    : null,
-                            ]),
-                        ),
-                )
-                ->when(
-                    $this->isPrecognitive() || ($this->getCore()->getCrudRequest()->isFragmentLoad('crud-form') && ! $isAsync),
-                    static fn (FormBuilderContract $form): FormBuilderContract => $form->precognitive(),
-                )
-                ->name($resource->getUriKey())
-                ->submit(
-                    $this->getCore()->getTranslator()->get('moonshine::ui.save'),
-                    ['class' => 'btn-primary btn-lg'],
-                )
-                ->buttons($this->getFormButtons()),
+            $form(
+                $this,
+                $action,
+                $item,
+                $fields,
+                $isAsync
+            )
         );
     }
 

--- a/src/Crud/src/Pages/IndexPage.php
+++ b/src/Crud/src/Pages/IndexPage.php
@@ -19,6 +19,8 @@ use MoonShine\Crud\Concerns\Page\HasListComponent;
 use MoonShine\Crud\Concerns\Page\HasMetrics;
 use MoonShine\Crud\Concerns\Page\HasQueryTags;
 use MoonShine\Crud\Contracts\Page\IndexPageContract;
+use MoonShine\Crud\Contracts\PageComponents\DefaultListComponentContract;
+use MoonShine\Crud\Pages\PageComponents\DefaultListComponent;
 use MoonShine\Crud\Resources\CrudResource;
 use MoonShine\Support\Enums\Ability;
 use MoonShine\Support\Enums\PageType;
@@ -50,6 +52,11 @@ class IndexPage extends CrudPage implements IndexPageContract
     use HasMetrics;
 
     protected ?PageType $pageType = PageType::INDEX;
+
+    /**
+     * @var class-string<DefaultListComponentContract>
+     */
+    protected string $component = DefaultListComponent::class;
 
     protected bool $isLazy = false;
 
@@ -169,38 +176,10 @@ class IndexPage extends CrudPage implements IndexPageContract
      */
     protected function getItemsComponent(iterable $items, FieldsContract $fields): ComponentContract
     {
+        $component = $this->getCore()->getContainer($this->component);
+
         return $this->modifyListComponent(
-            TableBuilder::make(items: $items)
-                ->name($this->getListComponentName())
-                ->fields($fields)
-                ->cast($this->getResource()->getCaster())
-                ->withNotFound()
-                ->buttons($this->getButtons())
-                ->when($this->isAsync(), function (TableBuilderContract $table): void {
-                    $table->async(
-                        url: fn (): string
-                            => $this->getRouter()->getEndpoints()->component(
-                                name: $table->getName(),
-                                additionally: $this->getCore()->getRequest()->getRequest()->getQueryParams(),
-                            ),
-                    )->pushState();
-                })
-                ->when($this->isLazy(), function (TableBuilderContract $table): void {
-                    $table->lazy()->whenAsync(
-                        fn (TableBuilderContract $t): TableBuilderContract
-                            => $t->items(
-                                $this->getResource()->getItems(),
-                            ),
-                    );
-                })
-                ->when(
-                    ! \is_null($this->getResource()->getItemsResolver()),
-                    function (TableBuilderContract $table): void {
-                        $table->itemsResolver(
-                            $this->getResource()->getItemsResolver(),
-                        );
-                    },
-                ),
+            $component($this, $items, $fields)
         );
     }
 

--- a/src/Crud/src/Pages/PageComponents/DefaultDetailComponent.php
+++ b/src/Crud/src/Pages/PageComponents/DefaultDetailComponent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Crud\Pages\PageComponents;
+
+use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
+use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
+use MoonShine\Contracts\UI\ComponentContract;
+use MoonShine\Crud\Contracts\Page\DetailPageContract;
+use MoonShine\UI\Components\Table\TableBuilder;
+
+final class DefaultDetailComponent
+{
+    public function __invoke(
+        DetailPageContract $page,
+        ?DataWrapperContract $item,
+        FieldsContract $fields,
+    ): ComponentContract {
+        $resource = $page->getResource();
+
+        return TableBuilder::make($fields)
+            ->cast($resource->getCaster())
+            ->items([$item])
+            ->vertical(
+                title: $resource->isDetailInModal() ? 3 : 2,
+                value: $resource->isDetailInModal() ? 9 : 10,
+            )
+            ->simple()
+            ->preview()
+            ->class('table-divider');
+    }
+}

--- a/src/Crud/src/Pages/PageComponents/DefaultDetailComponent.php
+++ b/src/Crud/src/Pages/PageComponents/DefaultDetailComponent.php
@@ -8,9 +8,10 @@ use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
 use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
 use MoonShine\Contracts\UI\ComponentContract;
 use MoonShine\Crud\Contracts\Page\DetailPageContract;
+use MoonShine\Crud\Contracts\PageComponents\DefaultDetailComponentContract;
 use MoonShine\UI\Components\Table\TableBuilder;
 
-final class DefaultDetailComponent
+final class DefaultDetailComponent implements DefaultDetailComponentContract
 {
     public function __invoke(
         DetailPageContract $page,

--- a/src/Crud/src/Pages/PageComponents/DefaultForm.php
+++ b/src/Crud/src/Pages/PageComponents/DefaultForm.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Crud\Pages\PageComponents;
+
+use MoonShine\Contracts\Core\DependencyInjection\CoreContract;
+use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
+use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
+use MoonShine\Contracts\UI\FormBuilderContract;
+use MoonShine\Core\Traits\WithCore;
+use MoonShine\Crud\Collections\Fields;
+use MoonShine\Crud\Contracts\Page\FormPageContract;
+use MoonShine\Crud\Contracts\PageComponents\DefaultFormContract;
+use MoonShine\Support\AlpineJs;
+use MoonShine\Support\Enums\JsEvent;
+use MoonShine\UI\Components\FormBuilder;
+use MoonShine\UI\Fields\Hidden;
+
+final class DefaultForm implements DefaultFormContract
+{
+    use WithCore;
+
+    public function __construct(CoreContract $core) {
+        $this->setCore($core);
+    }
+
+    public function __invoke(
+        FormPageContract $page,
+        string $action,
+        ?DataWrapperContract $item,
+        FieldsContract $fields,
+        bool $isAsync = true,
+    ): FormBuilderContract
+    {
+        $resource = $page->getResource();
+
+        return FormBuilder::make($action)
+            ->cast($resource->getCaster())
+            ->fill($item)
+            ->fields([
+                /** @phpstan-ignore argument.templateType */
+                ...$fields
+                    ->when(
+                        ! \is_null($item),
+                        static fn (Fields $fields): Fields
+                            => $fields->push(
+                            Hidden::make('_method')->setValue('PUT'),
+                        ),
+                    )
+                    ->toArray(),
+            ])
+            ->when(
+                ! $page->hasErrorsAbove(),
+                fn (FormBuilderContract $form): FormBuilderContract => $form->errorsAbove($page->hasErrorsAbove()),
+            )
+            ->when(
+                $isAsync,
+                fn (FormBuilderContract $formBuilder): FormBuilderContract
+                    => $formBuilder
+                    ->async(
+                        events: array_filter([
+                            $resource->getListEventName(
+                                $this->getCore()->getRequest()->getScalar('_component_name', 'default'),
+                                $isAsync && $resource->isItemExists() ? array_filter([
+                                    'page' => $this->getCore()->getRequest()->getScalar('page'),
+                                    'sort' => $this->getCore()->getRequest()->getScalar('sort'),
+                                ]) : [],
+                            ),
+                            ! $resource->isItemExists() && $resource->isCreateInModal()
+                                ? AlpineJs::event(JsEvent::FORM_RESET, $resource->getUriKey())
+                                : null,
+                        ]),
+                    ),
+            )
+            ->when(
+                $page->isPrecognitive() || ($this->getCore()->getCrudRequest()->isFragmentLoad('crud-form') && ! $isAsync),
+                static fn (FormBuilderContract $form): FormBuilderContract => $form->precognitive(),
+            )
+            ->name($resource->getUriKey())
+            ->submit(
+                $this->getCore()->getTranslator()->get('moonshine::ui.save'),
+                ['class' => 'btn-primary btn-lg'],
+            )
+            ->buttons($page->getFormButtons());
+    }
+}

--- a/src/Crud/src/Pages/PageComponents/DefaultListComponent.php
+++ b/src/Crud/src/Pages/PageComponents/DefaultListComponent.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Crud\Pages\PageComponents;
+
+use MoonShine\Contracts\Core\DependencyInjection\CoreContract;
+use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
+use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
+use MoonShine\Contracts\UI\ComponentContract;
+use MoonShine\Contracts\UI\FormBuilderContract;
+use MoonShine\Contracts\UI\TableBuilderContract;
+use MoonShine\Core\Traits\WithCore;
+use MoonShine\Crud\Collections\Fields;
+use MoonShine\Crud\Contracts\Page\FormPageContract;
+use MoonShine\Crud\Contracts\Page\IndexPageContract;
+use MoonShine\Crud\Contracts\PageComponents\DefaultFormContract;
+use MoonShine\Crud\Contracts\PageComponents\DefaultListComponentContract;
+use MoonShine\Support\AlpineJs;
+use MoonShine\Support\Enums\JsEvent;
+use MoonShine\UI\Components\FormBuilder;
+use MoonShine\UI\Components\Table\TableBuilder;
+use MoonShine\UI\Fields\Hidden;
+
+final class DefaultListComponent implements DefaultListComponentContract
+{
+    use WithCore;
+
+    public function __construct(CoreContract $core) {
+        $this->setCore($core);
+    }
+
+    /**
+     * @param  iterable<array-key, mixed>  $items
+     */
+    public function __invoke(
+        IndexPageContract $page,
+        iterable $items,
+        FieldsContract $fields
+    ): ComponentContract
+    {
+        $resource = $page->getResource();
+
+        return TableBuilder::make(items: $items)
+            ->name($page->getListComponentName())
+            ->fields($fields)
+            ->cast($resource->getCaster())
+            ->withNotFound()
+            ->buttons($page->getButtons())
+            ->when($page->isAsync(), function (TableBuilderContract $table) use($page): void {
+                $table->async(
+                    url: fn (): string
+                        => $page->getRouter()->getEndpoints()->component(
+                        name: $table->getName(),
+                        additionally: $this->getCore()->getRequest()->getRequest()->getQueryParams(),
+                    ),
+                )->pushState();
+            })
+            ->when($page->isLazy(), function (TableBuilderContract $table) use($resource): void {
+                $table->lazy()->whenAsync(
+                    fn (TableBuilderContract $t): TableBuilderContract
+                        => $t->items(
+                        $resource->getItems(),
+                    ),
+                );
+            })
+            ->when(
+                ! \is_null($resource->getItemsResolver()),
+                function (TableBuilderContract $table) use($resource): void {
+                    $table->itemsResolver(
+                        $resource->getItemsResolver(),
+                    );
+                },
+            );
+    }
+}


### PR DESCRIPTION
## What changed
 
This PR refactors the CRUD page architecture by extracting component creation logic into separate reusable classes. This improves extensibility and allows easy customization of components at the page level.

  **Key changes:**
  - Introduced contracts for default page components (`DefaultDetailComponentContract`, `DefaultFormContract`,
  `DefaultListComponentContract`)
  - Created default implementations: `DefaultDetailComponent`, `DefaultForm`, `DefaultListComponent`
  - Refactored `IndexPage`, `FormPage`, and `DetailPage` to use the new component system via DI container
  - Reduced code duplication by centralizing component creation logic

  ## Why

  - **Inversion of Control**: Pages now depend on contracts rather than concrete implementations
  - **Reusability**: Component logic can be easily reused across different contexts
  - **Extensibility**: Components can be easily replaced by overriding the `$component` or `$form` property
  - **Maintainability**: Cleaner page classes with separated concerns
  - **Testability**: Components can be tested independently

  ## Usage Example

  Developers can now easily customize page components:

  ```php
  class MyIndexPage extends IndexPage
  {
      /** @var class-string<DefaultListComponentContract> $component **/
      protected string $component = MyCustomListComponent::class;
  }

  class MyDetailPage extends DetailPage
  {
      /** @var class-string<DefaultDetailComponentContract> $component **/
      protected string $component = MyCustomDetailComponent::class;
  }

  class MyFormPage extends FormPage
  {
      /** @var class-string<DefaultFormComponentContract> $form **/
      protected string $form = MyCustomFormBuilder::class;
  }
```