### PR TITLE
fix: Removed scroll up on updateInPopover() method when you click the Edit button

### DIFF
--- a/src/UI/src/Sets/UpdateOnPreviewPopover.php
+++ b/src/UI/src/Sets/UpdateOnPreviewPopover.php
@@ -33,7 +33,7 @@ final readonly class UpdateOnPreviewPopover
         return Popover::make(
             '',
             (string) Link::make(
-                '#',
+                'javascript:void(0);',
                 (string) $this->field->toFormattedValue()
             )->icon('pencil')
         )


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Заменен в ссылке якорь **#** на **javascript:void(0);**

## Why?
При inline редактировании поля, когда кликаешь на иконку Edit, браузер скроллился вверх так как # - это якорь

## Checklist

- Issue #1824
- Tested
    - [ x] Tested manually
    - [ ] Tests added
- [ ] Documentation <!--- Remove if not needed -->
