### PR TITLE
[4.x] Forward resource prefix to query tags

### DIFF
--- a/src/Crud/src/Concerns/Page/HasQueryTags.php
+++ b/src/Crud/src/Concerns/Page/HasQueryTags.php
@@ -24,7 +24,7 @@ trait HasQueryTags
             ->when(
                 $queryParamPrefix != '',
                 fn (Collection $queryTags): Collection => $queryTags
-                    ->map(fn (QueryTag $queryTag): QueryTag => $queryTag->setPrefix($queryParamPrefix))
+                    ->map(fn (QueryTag $queryTag): QueryTag => $queryTag->prefix($queryParamPrefix))
             )
             ->toArray();
     }

--- a/src/Crud/src/Concerns/Page/HasQueryTags.php
+++ b/src/Crud/src/Concerns/Page/HasQueryTags.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MoonShine\Crud\Concerns\Page;
 
+use Illuminate\Support\Collection;
 use MoonShine\Crud\Contracts\Page\IndexPageContract;
 use MoonShine\Crud\QueryTags\QueryTag;
 
@@ -17,7 +18,15 @@ trait HasQueryTags
      */
     public function getQueryTags(): array
     {
-        return $this->queryTags();
+        $queryParamPrefix = $this->getResource()?->getQueryParamPrefix() ?? '';
+
+        return Collection::make($this->queryTags())
+            ->when(
+                $queryParamPrefix != '',
+                fn (Collection $queryTags): Collection => $queryTags
+                    ->map(fn (QueryTag $queryTag): QueryTag => $queryTag->setPrefix($queryParamPrefix))
+            )
+            ->toArray();
     }
 
     /**

--- a/src/Crud/src/Concerns/Page/HasQueryTags.php
+++ b/src/Crud/src/Concerns/Page/HasQueryTags.php
@@ -18,14 +18,8 @@ trait HasQueryTags
      */
     public function getQueryTags(): array
     {
-        $queryParamPrefix = $this->getResource()?->getQueryParamPrefix() ?? '';
-
         return Collection::make($this->queryTags())
-            ->when(
-                $queryParamPrefix != '',
-                fn (Collection $queryTags): Collection => $queryTags
-                    ->map(fn (QueryTag $queryTag): QueryTag => $queryTag->prefix($queryParamPrefix))
-            )
+            ->map(fn (QueryTag $queryTag): QueryTag => $queryTag->prefix($this->getResource()?->getQueryParamPrefix() ?? ''))
             ->toArray();
     }
 

--- a/src/Crud/src/Concerns/Resource/HasQueryTags.php
+++ b/src/Crud/src/Concerns/Resource/HasQueryTags.php
@@ -26,14 +26,8 @@ trait HasQueryTags
             return $this->getIndexPage()->getQueryTags();
         }
 
-        $queryParamPrefix = $this->getQueryParamPrefix();
-
         return Collection::make($this->queryTags())
-            ->when(
-                $queryParamPrefix != '',
-                fn (Collection $queryTags): Collection => $queryTags
-                    ->map(fn (QueryTag $queryTag): QueryTag => $queryTag->prefix($queryParamPrefix))
-            )
+            ->map(fn (QueryTag $queryTag): QueryTag => $queryTag->prefix($this->getQueryParamPrefix()))
             ->toArray();
     }
 

--- a/src/Crud/src/Concerns/Resource/HasQueryTags.php
+++ b/src/Crud/src/Concerns/Resource/HasQueryTags.php
@@ -22,10 +22,19 @@ trait HasQueryTags
     public function getQueryTags(): array
     {
         if ($this->getIndexPage() instanceof HasQueryTagsContract && $this->getIndexPage()->hasQueryTags()) {
-            return $this->getIndexPage()->getQueryTags();
+            $queryTags = $this->getIndexPage()->getQueryTags();
+        } else {
+            $queryTags = $this->getQueryTags();
         }
 
-        return $this->queryTags();
+        $queryParamPrefix = $this->getQueryParamPrefix();
+        if ($queryParamPrefix != '') {
+            foreach ($queryTags as $queryTag) {
+                $queryTag->setPrefix($queryParamPrefix);
+            }
+        }
+
+        return $queryTags;
     }
 
     /**

--- a/src/Crud/src/Concerns/Resource/HasQueryTags.php
+++ b/src/Crud/src/Concerns/Resource/HasQueryTags.php
@@ -24,7 +24,7 @@ trait HasQueryTags
         if ($this->getIndexPage() instanceof HasQueryTagsContract && $this->getIndexPage()->hasQueryTags()) {
             $queryTags = $this->getIndexPage()->getQueryTags();
         } else {
-            $queryTags = $this->getQueryTags();
+            $queryTags = $this->queryTags();
         }
 
         $queryParamPrefix = $this->getQueryParamPrefix();

--- a/src/Crud/src/Concerns/Resource/HasQueryTags.php
+++ b/src/Crud/src/Concerns/Resource/HasQueryTags.php
@@ -32,7 +32,7 @@ trait HasQueryTags
             ->when(
                 $queryParamPrefix != '',
                 fn (Collection $queryTags): Collection => $queryTags
-                    ->map(fn (QueryTag $queryTag): QueryTag => $queryTag->setPrefix($queryParamPrefix))
+                    ->map(fn (QueryTag $queryTag): QueryTag => $queryTag->prefix($queryParamPrefix))
             )
             ->toArray();
     }

--- a/src/Crud/src/Concerns/Resource/HasQueryTags.php
+++ b/src/Crud/src/Concerns/Resource/HasQueryTags.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MoonShine\Crud\Concerns\Resource;
 
+use Illuminate\Support\Collection;
 use MoonShine\Contracts\Core\CrudResourceContract;
 use MoonShine\Crud\Contracts\HasQueryTagsContract;
 use MoonShine\Crud\Pages\IndexPage;
@@ -22,19 +23,18 @@ trait HasQueryTags
     public function getQueryTags(): array
     {
         if ($this->getIndexPage() instanceof HasQueryTagsContract && $this->getIndexPage()->hasQueryTags()) {
-            $queryTags = $this->getIndexPage()->getQueryTags();
-        } else {
-            $queryTags = $this->queryTags();
+            return $this->getIndexPage()->getQueryTags();
         }
 
         $queryParamPrefix = $this->getQueryParamPrefix();
-        if ($queryParamPrefix != '') {
-            foreach ($queryTags as $queryTag) {
-                $queryTag->setPrefix($queryParamPrefix);
-            }
-        }
 
-        return $queryTags;
+        return Collection::make($this->queryTags())
+            ->when(
+                $queryParamPrefix != '',
+                fn (Collection $queryTags): Collection => $queryTags
+                    ->map(fn (QueryTag $queryTag): QueryTag => $queryTag->setPrefix($queryParamPrefix))
+            )
+            ->toArray();
     }
 
     /**

--- a/src/Crud/src/QueryTags/QueryTag.php
+++ b/src/Crud/src/QueryTags/QueryTag.php
@@ -52,7 +52,7 @@ class QueryTag implements HasCanSeeContract, HasIconContract, HasLabelContract, 
         $this->setLabel($label);
     }
 
-    public function setPrefix(string $prefix): static
+    public function prefix(string $prefix): static
     {
         $this->prefix = $prefix;
 

--- a/src/Crud/src/QueryTags/QueryTag.php
+++ b/src/Crud/src/QueryTags/QueryTag.php
@@ -52,6 +52,13 @@ class QueryTag implements HasCanSeeContract, HasIconContract, HasLabelContract, 
         $this->setLabel($label);
     }
 
+    public function setPrefix(string $prefix): static
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
     public function alias(string $alias): self
     {
         $this->alias = $alias;

--- a/src/Laravel/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Laravel/src/Traits/Resource/ResourceModelQuery.php
@@ -229,7 +229,7 @@ trait ResourceModelQuery
 
         $tags = array_merge(
             $this->getIndexPage()?->getQueryTags() ?? [],
-            $this->queryTags()
+            $this->getQueryTags()
         );
 
         /** @var ?QueryTag $tag */

--- a/src/Laravel/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Laravel/src/Traits/Resource/ResourceModelQuery.php
@@ -227,13 +227,8 @@ trait ResourceModelQuery
             return $this;
         }
 
-        $tags = array_merge(
-            $this->getIndexPage()?->getQueryTags() ?? [],
-            $this->getQueryTags()
-        );
-
         /** @var ?QueryTag $tag */
-        $tag = Collection::make($tags)
+        $tag = Collection::make($this->getQueryTags())
             ->first(
                 static fn (QueryTag $tag): bool => $tag->isActive(),
             );


### PR DESCRIPTION

## What was changed
Added forwarding resource query params prefix (feature from https://github.com/moonshine-software/moonshine/pull/1835 ) to query tags

## Why?
If we are using query params prefix in resource, we ned additionally set prefix param in each query tag in `queryTags()` method

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Tests added
