### PR TITLE
[4.x] refactor!: Layout bars refactoring

### DIFF
--- a/src/ColorManager/src/ColorManager.php
+++ b/src/ColorManager/src/ColorManager.php
@@ -90,7 +90,7 @@ final class ColorManager implements ColorManagerContract
         $value = $data[$name];
         $value = \is_null($shade)
             ? $value
-            : $value[$shade];
+            : (\is_array($value) ? $value[$shade] : $value);
 
         $hexValue = \is_array($value) ? $value['DEFAULT'] : $value;
 

--- a/src/Laravel/src/Layouts/AppLayout.php
+++ b/src/Laravel/src/Layouts/AppLayout.php
@@ -10,13 +10,22 @@ use MoonShine\Laravel\Resources\MoonShineUserResource;
 use MoonShine\Laravel\Resources\MoonShineUserRoleResource;
 use MoonShine\MenuManager\MenuGroup;
 use MoonShine\MenuManager\MenuItem;
-use MoonShine\UI\Components\{Layout\Body,
+use MoonShine\UI\Components\{
+    When,
+    Layout\Body,
     Layout\Content,
     Layout\Div,
     Layout\Flash,
     Layout\Html,
     Layout\Layout,
-    Layout\Wrapper};
+    Layout\Wrapper,
+    Layout\MobileBar,
+    Layout\Burger,
+    Layout\ThemeSwitcher,
+    Layout\Menu,
+};
+use MoonShine\Laravel\Components\Layout\Profile;
+use MoonShine\Crud\Components\Layout\Notifications;
 
 class AppLayout extends BaseLayout
 {

--- a/src/Laravel/src/Layouts/AppLayout.php
+++ b/src/Laravel/src/Layouts/AppLayout.php
@@ -11,7 +11,6 @@ use MoonShine\Laravel\Resources\MoonShineUserRoleResource;
 use MoonShine\MenuManager\MenuGroup;
 use MoonShine\MenuManager\MenuItem;
 use MoonShine\UI\Components\{
-    When,
     Layout\Body,
     Layout\Content,
     Layout\Div,
@@ -19,13 +18,7 @@ use MoonShine\UI\Components\{
     Layout\Html,
     Layout\Layout,
     Layout\Wrapper,
-    Layout\MobileBar,
-    Layout\Burger,
-    Layout\ThemeSwitcher,
-    Layout\Menu,
 };
-use MoonShine\Laravel\Components\Layout\Profile;
-use MoonShine\Crud\Components\Layout\Notifications;
 
 class AppLayout extends BaseLayout
 {

--- a/src/Laravel/src/Layouts/BaseLayout.php
+++ b/src/Laravel/src/Layouts/BaseLayout.php
@@ -121,7 +121,7 @@ abstract class BaseLayout extends AbstractLayout
                     ...$this->sidebarTopSlot(),
                 ])->class('menu-actions'),
                 Div::make([
-                    Burger::make(),
+                    Burger::make()->toggleMethod('toggleSidebarMenu'),
                 ])->class('menu-burger'),
             ])->class('menu-header')->name('sidebar-top'),
 
@@ -169,11 +169,9 @@ abstract class BaseLayout extends AbstractLayout
                     static fn (): array => [ThemeSwitcher::make()]
                 ),
                 Div::make([
-                    Burger::make(),
+                    Burger::make()->toggleMethod('toggleTopbarMenu'),
                 ])->class('menu-burger'),
             ])->class('menu-actions')->name('topbar-actions'),
-        ])->customAttributes([
-            ':class' => "asideMenuOpen && '_is-opened'",
         ]);
     }
 

--- a/src/UI/resources/css/components/menu.css
+++ b/src/UI/resources/css/components/menu.css
@@ -92,7 +92,7 @@
 }
 
 .menu-logo {
-  flex: 1;
+  flex-shrink: 1;
 
   .logo {
     width: auto;

--- a/src/UI/resources/css/components/menu.css
+++ b/src/UI/resources/css/components/menu.css
@@ -44,23 +44,39 @@
 }
 
 .menu--horizontal {
-  flex: 1;
-  overflow-x: auto;
+  @variant max-lg {
+    overflow-y: auto;
+    flex-direction: column;
+    padding: var(--ms-layout-wrapper-spacing);
 
-  .menu-list {
-    flex-direction: row;
+    .menu-list {
+      flex-direction: column;
+    }
 
-    > .menu-divider {
-      align-self: center;
-      margin-inline: var(--ms-menu-horizontal-divider-space-x, --spacing(1));
+    .menu-divider {
+      margin-block: var(--ms-menu-divider-space-y, --spacing(1));
+    }
+  }
 
-      &::after {
-        width: var(--ms-menu-horizontal-divider-width, 1px);
-        height: var(--ms-menu-horizontal-divider-height, --spacing(4));
-      }
+  @variant lg {
+    flex: 1;
+    overflow-x: auto;
 
-      span {
-        display: none;
+    .menu-list {
+      flex-direction: row;
+
+      > .menu-divider {
+        align-self: center;
+        margin-inline: var(--ms-menu-horizontal-divider-space-x, --spacing(1));
+
+        &::after {
+          width: var(--ms-menu-horizontal-divider-width, 1px);
+          height: var(--ms-menu-horizontal-divider-height, --spacing(4));
+        }
+
+        span {
+          display: none;
+        }
       }
     }
   }

--- a/src/UI/resources/css/layouts/basic.css
+++ b/src/UI/resources/css/layouts/basic.css
@@ -16,16 +16,16 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
-  row-gap: var(--ms-layout-wrapper-gap-y, var(--ms-layout-wrapper-spacing));
-  column-gap: var(--ms-layout-wrapper-gap-x, var(--ms-layout-wrapper-spacing));
   padding: var(--ms-layout-wrapper-spacing);
 
-  @variant max-sm {
+  @variant max-lg {
     padding: 0;
   }
 
   @variant lg {
     flex-direction: row;
+    row-gap: var(--ms-layout-wrapper-gap-y, var(--ms-layout-wrapper-spacing));
+    column-gap: var(--ms-layout-wrapper-gap-x, var(--ms-layout-wrapper-spacing));
   }
 }
 
@@ -57,7 +57,9 @@
   border-color: var(--ms-layout-page-border-color, var(--color-base-stroke));
   background-color: var(--ms-layout-page-bg-color, var(--color-base));
 
-  @variant max-sm {
+  @variant max-lg {
+    padding-block: calc(var(--ms-layout-page-padding-y, --spacing(4)) * 0.75);
+    padding-inline: calc(var(--ms-layout-page-padding-x, --spacing(4)) * 0.75);
     border-radius: 0;
     border: none;
   }

--- a/src/UI/resources/css/layouts/layout-menu-horizontal.css
+++ b/src/UI/resources/css/layouts/layout-menu-horizontal.css
@@ -1,3 +1,9 @@
+@theme {
+  --ms-layout-menu-horizontal-height: --spacing(12);
+}
+
+/* Layout Horizontal */
+
 .layout-menu-horizontal {
   --_menu-safezone-scroll-height: --spacing(75);
 
@@ -5,42 +11,70 @@
   align-items: center;
   column-gap: var(--ms-layout-menu-horizontal-gap-x, --spacing(3));
   width: 100%;
-  padding-block: calc(var(--ms-layout-wrapper-spacing) * 0.5);
-  padding-inline: var(--ms-layout-wrapper-spacing);
+  height: var(--ms-layout-menu-horizontal-height);
+  padding-inline: calc(var(--ms-layout-page-padding-x, --spacing(4)) * 0.75);
+  background-color: var(--ms-layout-menu-horizontal-bg-color, var(--color-body));
 
   @variant lg {
     padding-inline: calc(var(--ms-layout-wrapper-spacing) * 0.5);
   }
 
-  // Compensate height of vertical layout menu
-  & + .layout-menu {
+  @variant max-lg {
+    position: sticky;
+    top: 0;
+    z-index: var(--z-aside);
+    border-bottom: 1px solid var(--color-base-stroke);
+    box-shadow: 0 1px --spacing(4) 0 --alpha(var(--color-base-text) / 0.05);
+
+    &._is-opened {
+      .menu {
+        pointer-events: auto;
+        opacity: 1;
+        visibility: visible;
+        transform: translateY(0);
+      }
+    }
   }
 
   .menu {
     @apply scrollbar-hidden;
 
-    margin-bottom: calc(var(--_menu-safezone-scroll-height) * -1);
-    padding-bottom: var(--_menu-safezone-scroll-height);
-
     @variant max-lg {
-      display: none;
+      pointer-events: none;
+      position: fixed;
+      left: 0;
+      top: var(--ms-layout-menu-horizontal-height);
+      bottom: 0;
+      width: 100%;
+      background-color: var(--ms-layout-body-bg-color, var(--color-body));
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(--spacing(-2));
+      transition-property: opacity, visibility, transform;
+      transition-duration: 250ms;
+      transition-timing-function: var(--default-transition-timing-function);
     }
 
-    .menu-list {
-      > .menu-divider {
-        --ms-menu-divider-min-width: 1px;
+    @variant lg {
+      margin-bottom: calc(var(--_menu-safezone-scroll-height) * -1);
+      padding-bottom: var(--_menu-safezone-scroll-height);
+
+      .menu-list {
+        > .menu-divider {
+          --ms-menu-divider-min-width: 1px;
+        }
       }
-    }
-
-    .menu-submenu {
-      overflow-y: auto;
-      position: absolute;
-      top: 100%;
-      z-index: var(--z-dropdown);
-      max-height: calc(var(--_menu-safezone-scroll-height) - --spacing(5));
 
       .menu-submenu {
-        position: static;
+        overflow-y: auto;
+        position: absolute;
+        top: 100%;
+        z-index: var(--z-dropdown);
+        max-height: calc(var(--_menu-safezone-scroll-height) - --spacing(5));
+
+        .menu-submenu {
+          position: static;
+        }
       }
     }
   }

--- a/src/UI/resources/css/layouts/layout-menu-mobile.css
+++ b/src/UI/resources/css/layouts/layout-menu-mobile.css
@@ -1,0 +1,13 @@
+/* Layout Mobile */
+
+.layout-menu-mobile {
+  @variant max-lg {
+    & ~ .layout-menu-horizontal {
+      display: none;
+    }
+  }
+
+  @variant lg {
+    display: none;
+  }
+}

--- a/src/UI/resources/css/layouts/layout-menu.css
+++ b/src/UI/resources/css/layouts/layout-menu.css
@@ -9,8 +9,7 @@
   flex-shrink: 0;
   row-gap: var(--ms-layout-menu-gap-y, --spacing(3));
   width: min(var(--ms-layout-vertical-menu-width, 264px), 100%);
-  padding-block: var(--ms-layout-wrapper-spacing);
-  padding-inline: var(--ms-layout-wrapper-spacing);
+  padding: var(--ms-layout-wrapper-spacing);
 
   &:hover {
     .layout-collapse {

--- a/src/UI/resources/css/main.css
+++ b/src/UI/resources/css/main.css
@@ -12,6 +12,7 @@
 @import './layouts/basic.css';
 @import './layouts/layout-menu.css';
 @import './layouts/layout-menu-horizontal.css';
+@import './layouts/layout-menu-mobile.css';
 
 /* Tailwind Components */
 @import './components/accordions.css' layer(components);

--- a/src/UI/resources/js/Components/NavTooltip.js
+++ b/src/UI/resources/js/Components/NavTooltip.js
@@ -2,7 +2,6 @@ import tippy from 'tippy.js'
 
 export default () => ({
   tooltipInstance: null,
-  horizontalMenuEl: document.querySelector('.layout-menu-horizontal'),
 
   init() {
     this.tooltipInstance = tippy(this.$el, {

--- a/src/UI/resources/js/app.js
+++ b/src/UI/resources/js/app.js
@@ -76,6 +76,31 @@ document.addEventListener('alpine:init', () => {
       this.on = !this.on
     },
   })
+
+  /* Navigation menues */
+  Alpine.store('menu', {
+    sidebarMenuOpen: false,
+    topbarMenuOpen: false,
+    mobilebarMenuOpen: false,
+    menuOverlayShown: false,
+
+    toggleOverlay() {
+      this.menuOverlayShown = !this.menuOverlayShown
+    },
+
+    toggleSidebarMenu() {
+      this.sidebarMenuOpen = !this.sidebarMenuOpen
+      this.toggleOverlay()
+    },
+
+    toggleTopbarMenu() {
+      this.topbarMenuOpen = !this.topbarMenuOpen
+    },
+
+    toggleMobilebarMenu() {
+      this.mobilebarMenuOpen = !this.mobilebarMenuOpen
+    },
+  })
 })
 
 if (window.Livewire === undefined) {

--- a/src/UI/resources/views/components/layout/body.blade.php
+++ b/src/UI/resources/views/components/layout/body.blade.php
@@ -3,7 +3,7 @@
 ])
 <body {{ $attributes->merge(['class' => 'antialiased']) }}
     x-cloak
-    x-data="{ minimizedMenu: $persist(false).as('minimizedMenu'), asideMenuOpen: false }"
+    x-data="{ minimizedMenu: $persist(false).as('minimizedMenu') }"
 >
     <x-moonshine::components
         :components="$components"

--- a/src/UI/resources/views/components/layout/burger.blade.php
+++ b/src/UI/resources/views/components/layout/burger.blade.php
@@ -1,14 +1,25 @@
-<button 
-    type="button" 
+@props(['toggleMethod' => 'toggleSidebarMenu'])
+
+@php
+    $menuStateMap = [
+        'toggleSidebarMenu' => 'sidebarMenuOpen',
+        'toggleTopbarMenu' => 'topbarMenuOpen',
+        'toggleMobilebarMenu' => 'mobilebarMenuOpen',
+    ];
+    $menuState = $menuStateMap[$toggleMethod] ?? 'sidebarMenuOpen';
+@endphp
+
+<button
+    type="button"
     {{ $attributes->merge([
         'class'          => 'btn-burger btn-fit',
-        '@click.prevent' => 'asideMenuOpen = ! asideMenuOpen',
-    ]) }} 
+        '@click.prevent' => '$store.menu.' . $toggleMethod . '()',
+    ]) }}
 >
-    <svg x-show="!asideMenuOpen" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+    <svg x-show="!$store.menu.{{ $menuState }}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
     </svg>
-    <svg x-cloak x-show="asideMenuOpen" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+    <svg x-cloak x-show="$store.menu.{{ $menuState }}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
     </svg>
 </button>

--- a/src/UI/resources/views/components/layout/mobile-bar.blade.php
+++ b/src/UI/resources/views/components/layout/mobile-bar.blade.php
@@ -1,12 +1,14 @@
 @props([
     'components' => [],
 ])
-<aside {{ $attributes->merge(['class' => 'layout-menu-mobile']) }}
-       :class="minimizedMenu && '_is-minimized'"
+<!-- Mobile bar -->
+<div {{ $attributes->merge(['class' => 'layout-menu-mobile layout-menu-horizontal']) }}
+    :class="$store.menu.mobilebarMenuOpen && '_is-opened'"
 >
     <x-moonshine::components
         :components="$components"
     />
 
     {{ $slot ?? '' }}
-</aside>
+</div>
+<!-- END: Mobile bar -->

--- a/src/UI/resources/views/components/layout/sidebar.blade.php
+++ b/src/UI/resources/views/components/layout/sidebar.blade.php
@@ -4,8 +4,9 @@
     'collapseAttributes',
     'translates' => [],
 ])
+<!-- Sidebar -->
 <aside {{ $attributes->merge(['class' => 'layout-menu']) }}
-       :class="{ '_is-minimized': minimizedMenu, '_is-opened': asideMenuOpen }"
+       :class="{ '_is-minimized': minimizedMenu, '_is-opened': $store.menu.sidebarMenuOpen }"
 >
     <x-moonshine::components
         :components="$components"
@@ -34,3 +35,4 @@
 
     {{ $slot ?? '' }}
 </aside>
+<!-- END: Sidebar -->

--- a/src/UI/resources/views/components/layout/top-bar.blade.php
+++ b/src/UI/resources/views/components/layout/top-bar.blade.php
@@ -1,12 +1,14 @@
 @props([
     'components' => [],
 ])
-<!-- Menu horizontal -->
-<div {{ $attributes->merge(['class' => 'layout-menu-horizontal']) }}>
+<!-- Top bar -->
+<div {{ $attributes->merge(['class' => 'layout-menu-horizontal']) }}
+    :class="$store.menu.topbarMenuOpen && '_is-opened'"
+>
     <x-moonshine::components
         :components="$components"
     />
 
     {{ $slot ?? '' }}
 </div>
-<!-- END: Menu horizontal -->
+<!-- END: Top bar -->

--- a/src/UI/resources/views/components/layout/wrapper.blade.php
+++ b/src/UI/resources/views/components/layout/wrapper.blade.php
@@ -13,9 +13,9 @@
     <div
         class="layout-overlay"
         x-cloak
-        x-show="asideMenuOpen"
-        x-on:click="asideMenuOpen = false"
-        x-transition.opacity=""
+        x-show="$store.menu.sidebarMenuOpen"
+        x-on:click="$store.menu.toggleSidebarMenu()"
+        x-transition.opacity
     >
     </div>
 </div>

--- a/src/UI/src/Components/Layout/Burger.php
+++ b/src/UI/src/Components/Layout/Burger.php
@@ -9,4 +9,13 @@ use MoonShine\UI\Components\MoonShineComponent;
 final class Burger extends MoonShineComponent
 {
     protected string $view = 'moonshine::components.layout.burger';
+
+    public string $toggleMethod = 'toggleSidebarMenu';
+
+    public function toggleMethod(string $method): static
+    {
+        $this->toggleMethod = $method;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
# Refactor: Sidebar, Topbar & Mobilebar layouts

## 📋 Overview

Refactored the menu system to use Alpine.js store for centralized state management of three menu types: Sidebar, Topbar, and Mobilebar. This change eliminates scattered state variables and provides a unified API for menu controls.

---

## 🔧 Backend Changes

### BaseLayout.php
**Sidebar improvements:**
- Burger component now explicitly calls `toggleSidebarMenu` method
- Ensures proper sidebar state management

**TopBar improvements:**
- Burger component configured to toggle topbar menu
- Removed deprecated Alpine.js binding that used local component state
- Now uses centralized store state

### Burger.php Component
- Added public property `toggleMethod` with default value of `toggleSidebarMenu`
- Implemented fluent method `toggleMethod()` to configure which menu the burger controls
- Enables same component to control different menus based on context

---

## ⚙️ Frontend JavaScript Changes

### Alpine.js Menu Store
**New centralized store with four state properties:**
- `sidebarMenuOpen` - Controls vertical sidebar visibility
- `topbarMenuOpen` - Controls horizontal top menu visibility
- `mobilebarMenuOpen` - Controls mobile-specific menu visibility
- `menuOverlayShown` - Controls backdrop overlay display

**Four toggle methods:**
- `toggleSidebarMenu()` - Opens/closes sidebar and shows/hides overlay
- `toggleTopbarMenu()` - Opens/closes topbar menu
- `toggleMobilebarMenu()` - Opens/closes mobile menu
- `toggleOverlay()` - Shows/hides backdrop overlay independently

---

## 🖼️ Template Changes

### Burger Button Template
**Dynamic method binding:**
- Accepts `toggleMethod` prop to determine which store method to call
- Maps toggle methods to corresponding state properties
- Hamburger icon visibility tied to correct menu state
- Close icon (X) appears when corresponding menu is open
- Fully reactive to store changes

### Body Template
- Removed local `asideMenuOpen` state variable
- Simplified Alpine.js data to only include `minimizedMenu` state
- Delegated menu state management to store

### Sidebar Template
- Replaced local `asideMenuOpen` binding with store reference
- Added HTML comments for better code navigation
- Maintains minimized state behavior

### TopBar Template
- Added reactive class binding for open state
- Updated comments from generic "Menu horizontal" to specific "Top bar"
- Now properly shows/hides based on store state

### MobileBar Template
- Changed semantic element from `aside` to `div`
- Added horizontal layout class for consistent styling
- Removed minimized menu logic (not applicable for mobile)
- Added reactive open state binding
- Improved HTML comments for clarity

### Wrapper Template
- Overlay now watches sidebar state from store
- Click handler calls store method instead of setting local variable
- Proper Alpine.js transition directive syntax

---

**New files:**
- Created `layout-menu-mobile.css` for Mobile bar menu styles

---

## 🔄 Breaking Changes

**Removed global state:**
- `asideMenuOpen` variable no longer exists
- All references must be updated to use store

**Template bindings:**
- Direct Alpine.js bindings to `asideMenuOpen` will break
- Must be replaced with `$store.menu.sidebarMenuOpen`

**Click handlers:**
- Toggle expressions like `asideMenuOpen = !asideMenuOpen` are deprecated
- Must be replaced with `$store.menu.toggleSidebarMenu()` calls

**Mobile bar component:**
```
use MoonShine\UI\Components\Layout\MobileBar;

MobileBar::make([
    Fragment::make([
        $this->getLogoComponent()->minimized(),
    ])->class('menu-logo'),

    Fragment::make([
        Menu::make()->top(),
    ])->class('menu menu--horizontal'),

    Fragment::make([
        When::make(
            fn (): bool => $this->isProfileEnabled(),
            fn (): array
                => [
                $this->getProfileComponent(),
            ],
        ),
        Div::make()->class('menu-divider menu-divider--vertical'),
        When::make(
            fn (): bool => $this->hasThemes() && ! $this->isAlwaysDark(),
            static fn (): array => [ThemeSwitcher::make()]
        ),
        Div::make([
            Burger::make()->toggleMethod('toggleMobilebarMenu'),
        ])->class('menu-burger'),
    ])->class('menu-actions'),
]),
```

---

## 📝 Migration Guide

**For custom layouts:**

Replace local menu state variable with store reference in Alpine.js bindings

**For toggle handlers:**

Replace direct state mutations with store method calls

**For burger components:**

Add explicit toggle method configuration for clarity

**For custom menu implementations:**

Integrate with centralized store instead of managing local state