### PR TITLE
fix: make tab icon inherit active color from parent button

### DIFF
--- a/src/UI/src/Components/Tabs/Tab.php
+++ b/src/UI/src/Components/Tabs/Tab.php
@@ -119,7 +119,7 @@ class Tab extends AbstractWithComponents implements HasLabelContract, HasIconCon
     protected function viewData(): array
     {
         return [
-            'icon' => $this->getIcon(6, Color::SECONDARY),
+            'icon' => $this->getIcon(6),
             'label' => $this->getLabel(),
             'labelAttributes' => $this->labelAttributes,
             'id' => $this->getId(),


### PR DESCRIPTION
- Changed icon color from Color::SECONDARY to empty string
- Icon now uses text-current class and inherits color from .tabs-button._is-active
- Fixes issue where tab icon didn't change color when tab is active