### PR TITLE
fix: showWhen respects required attribute

### DIFF
--- a/src/UI/resources/js/Support/ShowWhen.js
+++ b/src/UI/resources/js/Support/ShowWhen.js
@@ -163,20 +163,29 @@ function showHideInputElement(isShow, inputElement, showWhenSubmit) {
   }
 
   if (isShow) {
-    fieldContainer.style.removeProperty('display')
+    fieldContainer.classList.remove('hidden')
 
     const nameAttr = inputElement.getAttribute('data-show-when-column')
     if (nameAttr) {
       inputElement.setAttribute('name', nameAttr)
     }
+    const requiredAttr = inputElement.getAttribute('data-required-when-column')
+    if (nameAttr) {
+      inputElement.setAttribute('required', requiredAttr)
+    }
   } else {
-    fieldContainer.style.display = 'none'
+    fieldContainer.classList.add('hidden')
 
     if (!showWhenSubmit) {
       const nameAttr = inputElement.getAttribute('name')
       if (nameAttr) {
         inputElement.setAttribute('data-show-when-column', nameAttr)
         inputElement.removeAttribute('name')
+      }
+      const requiredAttr = inputElement.getAttribute('required')
+      if (requiredAttr) {
+        inputElement.setAttribute('data-required-when-column', requiredAttr)
+        inputElement.removeAttribute('required')
       }
     }
   }
@@ -201,20 +210,29 @@ function showHideTableInputs(isShow, table, fieldName, showWhenSubmit) {
     }
 
     if (isShow) {
-      td.style.removeProperty('display')
+      td.classList.remove('hidden')
 
       const nameAttr = element.getAttribute('data-show-when-column')
       if (nameAttr) {
         element.setAttribute('name', nameAttr)
       }
+      const requiredAttr = element.getAttribute('data-required-when-column')
+      if (requiredAttr) {
+        element.setAttribute('required', requiredAttr)
+      }
     } else {
-      td.style.display = 'none'
+      td.classList.add('hidden')
 
       if (!showWhenSubmit) {
         const nameAttr = element.getAttribute('name')
         if (nameAttr) {
           element.setAttribute('data-show-when-column', nameAttr)
           element.removeAttribute('name')
+        }
+        const requiredAttr = element.getAttribute('required')
+        if (requiredAttr) {
+          element.setAttribute('data-required-when-column', requiredAttr)
+          element.removeAttribute('required')
         }
       }
     }
@@ -229,7 +247,7 @@ function showHideTableInputs(isShow, table, fieldName, showWhenSubmit) {
       if (element.cellIndex !== cellIndexTd) {
         return
       }
-      element.style.display = isShow ? null : 'none'
+      element.classList.toggle('hidden', ! isShow)
     })
   }
 }

--- a/src/UI/resources/js/__tests__/Support/ShowWhen.test.js
+++ b/src/UI/resources/js/__tests__/Support/ShowWhen.test.js
@@ -187,7 +187,7 @@ describe('showWhenVisibilityChange', () => {
       'test-form',
     )
 
-    expect(inputElement.style.display).toBe('none')
+    expect(inputElement.classList.contains('hidden')).toBe(true)
   })
 
   it('should show the field if conditions are met', () => {
@@ -200,7 +200,7 @@ describe('showWhenVisibilityChange', () => {
       'test-form',
     )
 
-    expect(inputElement.style.display).toBe('')
+    expect(inputElement.classList.contains('hidden')).toBe(false)
   })
 
   it('should do nothing if inputElement is null', () => {


### PR DESCRIPTION
## Что изменилось?
Теперь при скрытии поля `showWhen()` не только удаляет атрибут `name`, но и атрибут `required` (сохраняя оба в `data-`атрибутах). При открытии поля атрибут `required` восстанавливается.
Также для скрытия используется не установка стиля `display` в `none`, а добавление класса `hidden`.
 
Тест изменён на проверку наличия класса `hidden` а не значения стиля `display`

## Зачем?
Браузер не разрешал отправить форму, если в ней присутствовали поля с атрибутом `required` но при этом лишённые атрибута `name`. Поле с применённым `showWhen()` и `required()` блокировало отправку формы если становилось скрытым.

## Чеклист
- Тесты
    - [x] Проверено вручную на поле `Text`, зависимого от `Switcher`
    - [x] Тест `ShowWhen` обновлён
