### PR TITLE
fix: unescape password field value before saving

### DIFF
--- a/src/UI/src/Fields/Password.php
+++ b/src/UI/src/Fields/Password.php
@@ -29,11 +29,15 @@ class Password extends Text
     protected function resolveOnApply(): ?Closure
     {
         return function ($item) {
-            if ($this->getRequestValue()) {
+            $value = $this->getRequestValue();
+
+            if (\is_string($value) && $value !== '') {
                 data_set(
                     $item,
                     $this->getColumn(),
-                    $this->getCore()->getContainer(Hasher::class)->make($this->getRequestValue())
+                    $this->getCore()->getContainer(Hasher::class)->make(
+                        htmlspecialchars_decode($value, ENT_QUOTES)
+                    )
                 );
             }
 

--- a/tests/Unit/Fields/PasswordFieldTest.php
+++ b/tests/Unit/Fields/PasswordFieldTest.php
@@ -38,8 +38,8 @@ it('preview value', function (): void {
         ->toBe('***');
 });
 
-it('apply', function (): void {
-    $data = ['password' => '12345'];
+it('apply', function ($password, $isEqual): void {
+    $data = ['password' => $password];
 
     fakeRequest(parameters: $data);
 
@@ -55,6 +55,24 @@ it('apply', function (): void {
     )
         ->toBeInstanceOf(Model::class)
         ->and(Hash::check($data['password'], $item->password))
-        ->toBeTrue()
+        ->toBe($isEqual)
     ;
-});
+})->with([
+    ['3Lt\'`I"ge),B%\d&quot;\t9%\\\'x#B!<>', true],
+    ['\';', true],
+    ['***', true],
+    ['0', true],
+    [' ', true],
+    ['密码123', true],
+    ['🔒pa\nss\0word🔑', true],
+    ["\t\r\n", true],
+    ['constructor', true],
+    ['null', true],
+    ['false', true],
+    ['true', true],
+    ['<script>', true],
+    ['http://', true],
+    ['', false],
+    [[''], false],
+    [['1234'], false],
+]);


### PR DESCRIPTION
# 🔒 Fix: Password Field HTML Entities Decoding

## Описание проблемы

При сохранении паролей, содержащих специальные символы (кавычки, апострофы и другие HTML-сущности), они автоматически экранировались. Это приводило к тому, что пароль сохранялся в уже экранированном виде (например, `&quot;` вместо `"`), что делало невозможным последующую аутентификацию с оригинальным паролем.

## Внесенные изменения

### 1. Декодирование HTML-сущностей (`src/UI/src/Fields/Password.php`)
- Добавлена функция `htmlspecialchars_decode($value, ENT_QUOTES)` перед хешированием пароля
- Улучшена проверка значения: теперь проверяется, что значение является строкой и не пустое (`\is_string($value) && $value !== ''`)
- Это гарантирует, что пароль хешируется в том виде, в котором его ввел пользователь

### 2. Расширенное тестирование (`tests/Unit/Fields/PasswordFieldTest.php`)
- Добавлен параметризованный тест с 17 различными тестовыми случаями
- Покрыты edge cases:
  - Специальные символы и HTML-сущности: `'`, `"`, `&quot;`, `<>`, `<script>`
  - Unicode символы: `密码123`, `🔒pa\nss\0word🔑`
  - Управляющие символы: пробелы, табуляция, переводы строк
  - Зарезервированные слова: `constructor`, `null`, `false`, `true`
  - Пустые и невалидные значения: `''`, `['']`, `['1234']`

## Технические детали

**До:**
```php
if ($this->getRequestValue()) {
    data_set($item, $this->getColumn(), 
        $this->getCore()->getContainer(Hasher::class)->make($this->getRequestValue())
    );
}
```
**После:**
```php
$value = $this->getRequestValue();

if (\is_string($value) && $value !== '') {
    data_set($item, $this->getColumn(),
        $this->getCore()->getContainer(Hasher::class)->make(
            htmlspecialchars_decode($value, ENT_QUOTES)
        )
    );
}