### PR TITLE
fix: improve password handling and disable password field escaping

### DIFF
--- a/src/UI/src/Fields/Password.php
+++ b/src/UI/src/Fields/Password.php
@@ -26,14 +26,21 @@ class Password extends Text
         return '';
     }
 
+    public function isUnescape(): bool
+    {
+        return true;
+    }
+
     protected function resolveOnApply(): ?Closure
     {
         return function ($item) {
-            if ($this->getRequestValue()) {
+            $value = $this->getRequestValue();
+
+            if (\is_string($value) && $value !== '') {
                 data_set(
                     $item,
                     $this->getColumn(),
-                    $this->getCore()->getContainer(Hasher::class)->make($this->getRequestValue())
+                    $this->getCore()->getContainer(Hasher::class)->make($value)
                 );
             }
 

--- a/tests/Unit/Fields/PasswordFieldTest.php
+++ b/tests/Unit/Fields/PasswordFieldTest.php
@@ -38,10 +38,12 @@ it('preview value', function (): void {
         ->toBe('***');
 });
 
-it('apply', function (): void {
-    $data = ['password' => '12345'];
+it('apply', function ($password, $escape, $isEqual): void {
+    $data = ['password' => $password];
 
     fakeRequest(parameters: $data);
+
+    $escape ? $this->field->escape() : $this->field->unescape();
 
     expect(
         $item = $this->field->apply(
@@ -55,6 +57,23 @@ it('apply', function (): void {
     )
         ->toBeInstanceOf(Model::class)
         ->and(Hash::check($data['password'], $item->password))
-        ->toBeTrue()
+        ->toBe($isEqual)
     ;
-});
+})->with([
+    ['3Lt\'`I"ge),B%\d&quot;\t9%\\\'x#B!<>密码\n\0🔑', false, true],
+    ['3Lt\'`I"ge),B%\d&quot;\t9%\\\'x#B!<>密码\n\0🔑', true, true],
+    ["Invalid UTF-8: \xC3\x28", false, true],
+    ["Invalid UTF-8: \xC3\x28", true, true],
+    ['0', false, true],
+    ['0', true, true],
+    [' ', false, true],
+    [' ', true, true],
+    ["\t\r\n", false, true],
+    ["\t\r\n", true, true],
+    ['', false, false],
+    ['', true, false],
+    [[''], false, false],
+    [[''], true, false],
+    [['1234'], false, false],
+    [['1234'], true, false],
+]);


### PR DESCRIPTION
# Исправление обработки поля Password

## Что изменено

### Основные изменения в `Password.php`:

1. Так же как и имеющийся метод заглушка
```php
protected function resolveValue(): string
{
    return '';
}
```

Добавлен метод заглушка
```php
public function isUnescape(): bool
{
      return true;
}
```
который отключает экранирование символов. XSS маловероятна, потому что пароли хранятся в базе данных в виде хеша, не расшифровываются до оригинального значения и к тому же не показываются

2. Улучшена проверка
```php
if (\is_string($value) && $value !== '') {
...
}
```
Которая не мешает сохранить пароль "0". К тому же Hasher по аннотации ожидает на вход метода make строку.

### Тестирование:

Расширены unit-тесты в `PasswordFieldTest.php`:

- ✅ Проверка обработки паролей со специальными символами (кавычки, слеши, HTML-entities)
- ✅ Тестирование многобайтовых символов (китайские иероглифы, эмодзи: 密码🔑)
- ✅ Проверка невалидных UTF-8 последовательностей
- ✅ Обработка граничных случаев: `'0'`, пробелы, `\t\r\n`
- ✅ Корректная обработка пустых строк (не должны хешироваться)
- ✅ Защита от передачи массивов вместо строк
- ✅ Тестирование в режимах `escape()` и `unescape()`

## Проблемы, которые решает

- Предотвращает хеширование невалидных значений (пустые строки, массивы)
- Корректно обрабатывает пароли с любыми специальными символами
- Защита от некорректных типов данных в запросе

## Checklist

- Tested
    - [ x] Tested manually
    - [ x] Tests added
