### PR TITLE
feat: Modal/OffCanvas modifiers + Modal->full()

### DIFF
--- a/src/Contracts/src/Core/CrudResourceWithModalsContract.php
+++ b/src/Contracts/src/Core/CrudResourceWithModalsContract.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MoonShine\Contracts\Core;
 
+use MoonShine\Contracts\UI\ModalContract;
+
 /**
  * @internal
  */
@@ -14,4 +16,14 @@ interface CrudResourceWithModalsContract
     public function isEditInModal(): bool;
 
     public function isDetailInModal(): bool;
+
+    public function resolveCreateModal(ModalContract $modal): ModalContract;
+
+    public function resolveEditModal(ModalContract $modal): ModalContract;
+
+    public function resolveDetailModal(ModalContract $modal): ModalContract;
+
+    public function resolveDeleteModal(ModalContract $modal): ModalContract;
+
+    public function resolveMassDeleteModal(ModalContract $modal): ModalContract;
 }

--- a/src/Contracts/src/UI/ModalContract.php
+++ b/src/Contracts/src/UI/ModalContract.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Contracts\UI;
+
+use Closure;
+
+interface ModalContract
+{
+    public function open(Closure|bool|null $condition = null): self;
+
+    public function closeOutside(Closure|bool|null $condition = null): self;
+
+    public function wide(Closure|bool|null $condition = null): self;
+
+    public function full(Closure|bool|null $condition = null): self;
+
+    public function auto(Closure|bool|null $condition = null): self;
+
+    public function autoClose(Closure|bool|null $condition = null): self;
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     *
+     */
+    public function outerAttributes(array $attributes): self;
+
+    /**
+     * @param string[] $events
+     */
+    public function toggleEvents(array $events, bool $onlyOpening = false, bool $onlyClosing = false): self;
+
+    public function alwaysLoad(): self;
+}

--- a/src/Contracts/src/UI/OffCanvasContract.php
+++ b/src/Contracts/src/UI/OffCanvasContract.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Contracts\UI;
+
+use Closure;
+
+interface OffCanvasContract
+{
+    public function open(Closure|bool|null $condition = null): self;
+
+    public function left(Closure|bool|null $condition = null): self;
+
+    public function wide(Closure|bool|null $condition = null): self;
+
+    public function full(Closure|bool|null $condition = null): self;
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     *
+     */
+    public function togglerAttributes(array $attributes): self;
+
+    /**
+     * @param string[] $events
+     */
+    public function toggleEvents(array $events, bool $onlyOpening = false, bool $onlyClosing = false): self;
+
+    public function alwaysLoad(): self;
+}

--- a/src/Crud/src/Buttons/CreateButton.php
+++ b/src/Crud/src/Buttons/CreateButton.php
@@ -6,6 +6,7 @@ namespace MoonShine\Crud\Buttons;
 
 use MoonShine\Contracts\Core\CrudResourceContract;
 use MoonShine\Contracts\UI\ActionButtonContract;
+use MoonShine\Contracts\UI\ModalContract;
 use MoonShine\Support\Enums\Ability;
 use MoonShine\Support\Enums\Action;
 use MoonShine\UI\Components\ActionButton;
@@ -54,7 +55,7 @@ final class CreateButton
                     static fn (): string => $label,
                     static fn (): string => '',
                     name: $modalName,
-                    builder: static fn (Modal $modal): Modal => $modal->wide(),
+                    builder: static fn (ModalContract $modal): ModalContract => $resource->resolveCreateModal($modal),
                 )
             )
             ->canSee(

--- a/src/Crud/src/Buttons/DeleteButton.php
+++ b/src/Crud/src/Buttons/DeleteButton.php
@@ -8,10 +8,12 @@ use MoonShine\Contracts\Core\CrudResourceContract;
 use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
 use MoonShine\Contracts\UI\ActionButtonContract;
 use MoonShine\Contracts\UI\FormBuilderContract;
+use MoonShine\Contracts\UI\ModalContract;
 use MoonShine\Support\Enums\Ability;
 use MoonShine\Support\Enums\Action;
 use MoonShine\Support\Enums\HttpMethod;
 use MoonShine\UI\Components\ActionButton;
+use MoonShine\UI\Components\Modal;
 
 final class DeleteButton
 {
@@ -49,9 +51,10 @@ final class DeleteButton
                             $componentName ?? $resource->getListComponentName(),
                             params: $query,
                         )
-                    )
+                    ),
                 ),
-                name: static fn (mixed $item, ActionButtonContract $ctx): string => "$modalName-{$ctx->getData()?->getKey()}"
+                modalBuilder: static fn (ModalContract $modal): ModalContract => $resource->resolveDeleteModal($modal),
+                name: static fn (mixed $item, ActionButtonContract $ctx): string => "$modalName-{$ctx->getData()?->getKey()}",
             )
             ->canSee(
                 static fn (mixed $item, ?DataWrapperContract $data): bool => $data?->getKey()

--- a/src/Crud/src/Buttons/DetailButton.php
+++ b/src/Crud/src/Buttons/DetailButton.php
@@ -7,12 +7,12 @@ namespace MoonShine\Crud\Buttons;
 use MoonShine\Contracts\Core\CrudResourceContract;
 use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
 use MoonShine\Contracts\UI\ActionButtonContract;
+use MoonShine\Contracts\UI\ModalContract;
 use MoonShine\Support\AlpineJs;
 use MoonShine\Support\Enums\Ability;
 use MoonShine\Support\Enums\Action;
 use MoonShine\Support\Enums\JsEvent;
 use MoonShine\UI\Components\ActionButton;
-use MoonShine\UI\Components\Modal;
 use MoonShine\UI\Exceptions\ActionButtonException;
 
 final class DetailButton
@@ -57,7 +57,7 @@ final class DetailButton
                     title: static fn (): string => $label,
                     content: static fn (): string => '',
                     name: static fn (mixed $data, ActionButtonContract $ctx): string => "$modalName-{$ctx->getData()?->getKey()}",
-                    builder: static fn (Modal $modal): Modal => $modal->wide()
+                    builder: static fn (ModalContract $modal): ModalContract => $resource->resolveDetailModal($modal)
                 )
             )
             ->canSee(

--- a/src/Crud/src/Buttons/FiltersButton.php
+++ b/src/Crud/src/Buttons/FiltersButton.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use MoonShine\Contracts\Core\CrudResourceContract;
 use MoonShine\Contracts\UI\ActionButtonContract;
 use MoonShine\Contracts\UI\FormBuilderContract;
+use MoonShine\Contracts\UI\OffCanvasContract;
 use MoonShine\Crud\Resources\CrudResource;
 use MoonShine\UI\Components\ActionButton;
 
@@ -33,7 +34,8 @@ final class FiltersButton
                 static fn (): string => $label,
                 static fn (): FormBuilderContract => $form,
                 name: 'filters-off-canvas',
-                components: [$form]
+                builder: fn(OffCanvasContract $offCanvas): OffCanvasContract => $resource->resolveFiltersOffCanvas($offCanvas),
+                components: [$form],
             )
             ->showInLine()
             ->class('js-filter-button')

--- a/src/Crud/src/Buttons/MassDeleteButton.php
+++ b/src/Crud/src/Buttons/MassDeleteButton.php
@@ -7,10 +7,12 @@ namespace MoonShine\Crud\Buttons;
 use MoonShine\Contracts\Core\CrudResourceContract;
 use MoonShine\Contracts\UI\ActionButtonContract;
 use MoonShine\Contracts\UI\FormBuilderContract;
+use MoonShine\Contracts\UI\ModalContract;
 use MoonShine\Support\Enums\Ability;
 use MoonShine\Support\Enums\Action;
 use MoonShine\Support\Enums\HttpMethod;
 use MoonShine\UI\Components\ActionButton;
+use MoonShine\UI\Components\Modal;
 
 final class MassDeleteButton
 {
@@ -48,6 +50,7 @@ final class MassDeleteButton
                         )
                     )
                 ),
+                modalBuilder: static fn (ModalContract $modal): ModalContract => $resource->resolveMassDeleteModal($modal),
                 name: $modalName
             )
             ->canSee(

--- a/src/Crud/src/Pages/CrudPage.php
+++ b/src/Crud/src/Pages/CrudPage.php
@@ -71,25 +71,25 @@ abstract class CrudPage extends Page implements CrudPageContract
         $components = [];
 
         if ($this->getResource()->isEditInModal()) {
-            $components[] = Modal::make(
-                $this->getCore()->getTranslator()->get('moonshine::ui.edit'),
-                components: [
-                    Div::make()->customAttributes(['id' => 'resource-edit-modal']),
-                ],
-            )
-                ->wide()
-                ->name('resource-edit-modal');
+            $components[] = $this->getResource()->resolveEditModal(
+                Modal::make(
+                    $this->getCore()->getTranslator()->get('moonshine::ui.edit'),
+                    components: [
+                        Div::make()->customAttributes(['id' => 'resource-edit-modal']),
+                    ],
+                )->name('resource-edit-modal')
+            );
         }
 
         if ($this->getResource()->isDetailInModal()) {
-            $components[] = Modal::make(
-                $this->getCore()->getTranslator()->get('moonshine::ui.show'),
-                components: [
-                    Div::make()->customAttributes(['id' => 'resource-detail-modal']),
-                ],
-            )
-                ->wide()
-                ->name('resource-detail-modal');
+            $components[] = $this->getResource()->resolveDetailModal(
+                Modal::make(
+                    $this->getCore()->getTranslator()->get('moonshine::ui.show'),
+                    components: [
+                        Div::make()->customAttributes(['id' => 'resource-detail-modal']),
+                    ],
+                )->name('resource-detail-modal')
+            );
         }
 
         return $components;

--- a/src/Crud/src/Resources/CrudResource.php
+++ b/src/Crud/src/Resources/CrudResource.php
@@ -17,6 +17,9 @@ use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
 use MoonShine\Contracts\Core\PageContract;
 use MoonShine\Contracts\Core\TypeCasts\DataCasterContract;
 use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
+use MoonShine\Contracts\UI\ComponentContract;
+use MoonShine\Contracts\UI\ModalContract;
+use MoonShine\Contracts\UI\OffCanvasContract;
 use MoonShine\Contracts\UI\TableBuilderContract;
 use MoonShine\Core\Resources\Resource;
 use MoonShine\Core\TypeCasts\MixedDataCaster;
@@ -40,6 +43,8 @@ use MoonShine\Crud\Traits\Resource\ResourceQuery;
 use MoonShine\Crud\Traits\Resource\ResourceWithAuthorization;
 use MoonShine\Crud\Traits\Resource\ResourceWithButtons;
 use MoonShine\Crud\Traits\Resource\ResourceWithFields;
+use MoonShine\UI\Components\Modal;
+use MoonShine\UI\Components\OffCanvas;
 use Throwable;
 
 /**
@@ -171,14 +176,74 @@ abstract class CrudResource extends Resource implements
         return $this->createInModal;
     }
 
+    public function resolveCreateModal(ModalContract $modal): ModalContract
+    {
+        return $this->modifyCreateModal($modal);
+    }
+
+    protected function modifyCreateModal(ModalContract $modal): ModalContract
+    {
+        return $modal->wide();
+    }
+
     public function isEditInModal(): bool
     {
         return $this->editInModal;
     }
 
+    public function resolveEditModal(ModalContract $modal): ModalContract
+    {
+        return $this->modifyEditModal($modal);
+    }
+
+    protected function modifyEditModal(ModalContract $modal): ModalContract
+    {
+        return $modal->wide();
+    }
+
     public function isDetailInModal(): bool
     {
         return $this->detailInModal;
+    }
+
+    public function resolveDetailModal(ModalContract $modal): ModalContract
+    {
+        return $this->modifyDetailModal($modal);
+    }
+
+    protected function modifyDetailModal(ModalContract $modal): ModalContract
+    {
+        return $modal->wide();
+    }
+
+    public function resolveDeleteModal(ModalContract $modal): ModalContract
+    {
+        return $this->modifyDeleteModal($modal);
+    }
+
+    protected function modifyDeleteModal(ModalContract $modal): ModalContract
+    {
+        return $modal->auto();
+    }
+
+    public function resolveMassDeleteModal(ModalContract $modal): ModalContract
+    {
+        return $this->modifyMassDeleteModal($modal);
+    }
+
+    protected function modifyMassDeleteModal(ModalContract $modal): ModalContract
+    {
+        return $modal->auto();
+    }
+
+    public function resolveFiltersOffCanvas(OffCanvasContract $offCanvas): OffCanvasContract
+    {
+        return $this->modifyFiltersOffCanvas($offCanvas);
+    }
+
+    protected function modifyFiltersOffCanvas(OffCanvasContract $offCanvas): OffCanvasContract
+    {
+        return $offCanvas;
     }
 
     /**
@@ -255,7 +320,7 @@ abstract class CrudResource extends Resource implements
         }
 
         return $this->getCaster()->cast(
-            $this->getItem()
+            $this->getItem(),
         );
     }
 

--- a/src/UI/resources/views/components/modal.blade.php
+++ b/src/UI/resources/views/components/modal.blade.php
@@ -3,6 +3,7 @@
     'async' => false,
     'asyncUrl' => '',
     'wide' => $isWide ?? false,
+    'full' => $isFull ?? false,
     'open' => $isOpen ?? false,
     'auto' => $isAuto ?? false,
     'autoClose' => $isAutoClose ?? false,
@@ -18,7 +19,7 @@
     {{ $attributes }}
 >
     <template x-teleport="body">
-        <div 
+        <div
             class="modal-template"
             @defineEvent('modal_toggled', $name, 'toggleModal')
         >
@@ -35,15 +36,15 @@
                 {{ $attributes->merge(['class' => 'modal']) }}
                 @if($closeOutside) @click.self="toggleModal" @endif
             >
-                <div 
+                <div
                     class="modal-dialog
-                    @if($wide) modal-dialog-xl @elseif($auto) modal-dialog-auto @endif"
+                    @if($wide) modal-dialog-xl @elseif($full) w-full max-w-none @elseif($auto) modal-dialog-auto @endif"
                     x-bind="dismissModal"
                 >
                     <div class="modal-content">
                         <div class="modal-header">
                             <h5 class="modal-title">{{ $title ?? '' }}</h5>
-                            <button 
+                            <button
                                 type="button"
                                 class="modal-close btn-fit"
                                 @click.stop="toggleModal"

--- a/src/UI/src/Components/Modal.php
+++ b/src/UI/src/Components/Modal.php
@@ -9,13 +9,14 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\View\ComponentSlot;
 use MoonShine\Contracts\UI\ActionButtonContract;
 use MoonShine\Contracts\UI\ComponentContract;
+use MoonShine\Contracts\UI\ModalContract;
 use MoonShine\Support\AlpineJs;
 use Throwable;
 
 /**
  * @method static static make(Closure|string $title, Closure|Renderable|string $content = '', Closure|Renderable|ActionButtonContract|string $outer = '', Closure|string|null $asyncUrl = '', iterable $components = [])
  */
-final class Modal extends AbstractWithComponents
+final class Modal extends AbstractWithComponents implements ModalContract
 {
     protected string $view = 'moonshine::components.modal';
 
@@ -24,6 +25,8 @@ final class Modal extends AbstractWithComponents
     protected bool $closeOutside = true;
 
     protected bool $wide = false;
+
+    protected bool $full = false;
 
     protected bool $auto = false;
 
@@ -72,6 +75,13 @@ final class Modal extends AbstractWithComponents
     public function wide(Closure|bool|null $condition = null): self
     {
         $this->wide = \is_null($condition) || value($condition, $this);
+
+        return $this;
+    }
+
+    public function full(Closure|bool|null $condition = null): self
+    {
+        $this->full = \is_null($condition) || value($condition, $this);
 
         return $this;
     }
@@ -147,6 +157,7 @@ final class Modal extends AbstractWithComponents
             'isWide' => $this->wide,
             'isOpen' => $this->open,
             'isAuto' => $this->auto,
+            'isFull' => $this->full,
             'isAutoClose' => $this->autoClose,
             'isCloseOutside' => $this->closeOutside,
             'async' => ! empty($this->asyncUrl),

--- a/src/UI/src/Components/OffCanvas.php
+++ b/src/UI/src/Components/OffCanvas.php
@@ -8,13 +8,14 @@ use Closure;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\View\ComponentSlot;
 use MoonShine\Contracts\UI\ComponentContract;
+use MoonShine\Contracts\UI\OffCanvasContract;
 use MoonShine\Support\AlpineJs;
 use Throwable;
 
 /**
  * @method static static make(Closure|string $title = '', Closure|Renderable|string $content = '', Closure|string $toggler = '', Closure|string|null $asyncUrl = '', iterable $components = [])
  */
-final class OffCanvas extends AbstractWithComponents
+final class OffCanvas extends AbstractWithComponents implements OffCanvasContract
 {
     protected string $view = 'moonshine::components.off-canvas';
 

--- a/src/UI/src/Traits/ActionButton/WithModal.php
+++ b/src/UI/src/Traits/ActionButton/WithModal.php
@@ -9,6 +9,7 @@ use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
 use MoonShine\Contracts\UI\ActionButtonContract;
 use MoonShine\Contracts\UI\ComponentContract;
 use MoonShine\Contracts\UI\FormBuilderContract;
+use MoonShine\Contracts\UI\ModalContract;
 use MoonShine\Support\AlpineJs;
 use MoonShine\Support\Enums\FormMethod;
 use MoonShine\Support\Enums\HttpMethod;
@@ -23,7 +24,7 @@ use MoonShine\UI\Fields\HiddenIds;
 trait WithModal
 {
     /**
-     * @var null|Closure(mixed, DataWrapperContract, static): ComponentContract
+     * @var null|Closure(mixed, DataWrapperContract, static): ModalContract
      */
     protected ?Closure $modal = null;
 
@@ -33,7 +34,7 @@ trait WithModal
     }
 
     /**
-     * @param  ?Closure(Modal $modal, ActionButtonContract $ctx): Modal  $builder
+     * @param  ?Closure(ModalContract $modal, ActionButtonContract $ctx): ModalContract  $builder
      */
     public function inModal(
         Closure|string|null $title = null,
@@ -57,7 +58,7 @@ trait WithModal
             ->name(value($name, $item, $ctx))
             ->when(
                 ! \is_null($builder),
-                static fn (Modal $modal): Modal => $builder($modal, $ctx)
+                static fn (ModalContract $modal): ModalContract => $builder($modal, $ctx)
             );
 
         return $this->onBeforeRender(
@@ -69,7 +70,7 @@ trait WithModal
 
     /**
      * @param  ?Closure(FormBuilderContract $form, mixed $data): FormBuilderContract  $formBuilder
-     * @param  ?Closure(Modal $modal, ActionButtonContract $ctx): Modal  $modalBuilder
+     * @param  ?Closure(ModalContract $modal, ActionButtonContract $ctx): ModalContract  $modalBuilder
      */
     public function withConfirm(
         Closure|string|null $title = null,

--- a/src/UI/src/Traits/ActionButton/WithOffCanvas.php
+++ b/src/UI/src/Traits/ActionButton/WithOffCanvas.php
@@ -8,6 +8,7 @@ use Closure;
 use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
 use MoonShine\Contracts\UI\ActionButtonContract;
 use MoonShine\Contracts\UI\ComponentContract;
+use MoonShine\Contracts\UI\OffCanvasContract;
 use MoonShine\Support\AlpineJs;
 use MoonShine\Support\Enums\JsEvent;
 use MoonShine\UI\Components\OffCanvas;
@@ -15,7 +16,7 @@ use MoonShine\UI\Components\OffCanvas;
 trait WithOffCanvas
 {
     /**
-     * @var null|Closure(mixed, DataWrapperContract, static): ComponentContract
+     * @var null|Closure(mixed, DataWrapperContract, static): OffCanvasContract
      */
     protected ?Closure $offCanvas = null;
 
@@ -25,7 +26,7 @@ trait WithOffCanvas
     }
 
     /**
-     * @param  ?Closure(OffCanvas $offCanvas, ActionButtonContract $ctx): OffCanvas  $builder
+     * @param  ?Closure(OffCanvasContract $offCanvas, ActionButtonContract $ctx): OffCanvasContract  $builder
      */
     public function inOffCanvas(
         Closure|string|null $title = null,
@@ -49,7 +50,7 @@ trait WithOffCanvas
             ->name(value($name, $item, $ctx))
             ->when(
                 ! \is_null($builder),
-                static fn (OffCanvas $offCanvas) => $builder($offCanvas, $ctx)
+                static fn (OffCanvasContract $offCanvas) => $builder($offCanvas, $ctx)
             );
 
         return $this->onBeforeRender(


### PR DESCRIPTION
## Modals modifiers

### CrudResource 

```php
protected function modifyCreateModal(ModalContract $modal): ModalContract
{
    return $modal->full();
}

protected function modifyEditModal(ModalContract $modal): ModalContract
    {
        return $modal-> full();
    }

protected function modifyDetailModal(ModalContract $modal): ModalContract
    {
        return $modal-> full();
    }

protected function modifyDeleteModal(ModalContract $modal): ModalContract
{
    return $modal->auto();
}


protected function modifyMassDeleteModal(ModalContract $modal): ModalContract
{
    return $modal->auto();
}


protected function modifyFiltersOffCanvas(OffCanvasContract $offCanvas): OffCanvasContract
{
    return $offCanvas->full()->autoClose(false);
}
```


## Modal

New full width method

```php
Modal::make()->full()
```