### PR TITLE
Form Element wrapper attributes new helpers

### DIFF
--- a/src/UI/src/Fields/FormElement.php
+++ b/src/UI/src/Fields/FormElement.php
@@ -528,9 +528,29 @@ abstract class FormElement extends MoonShineComponent implements FormElementCont
         return $this;
     }
 
+    public function removeWrapperAttribute(string $name): static
+    {
+        $this->getWrapperAttributes()->remove($name);
+
+        return $this;
+    }
+
     public function wrapperClass(string|array $classes): static
     {
         $this->wrapperAttributes = $this->wrapperAttributes->class($classes);
+
+        return $this;
+    }
+
+    public function removeWrapperClass(string $pattern): static
+    {
+        $before = $this->wrapperAttributes->get('class', '');
+
+        $this->getWrapperAttributes()->remove('class');
+
+        $this->wrapperAttributes = $this->wrapperAttributes->class(
+            trim((string) preg_replace("/(?<=\s|^)$pattern(?=\s|$)/", '', (string) $before))
+        );
 
         return $this;
     }

--- a/src/UI/src/Fields/FormElement.php
+++ b/src/UI/src/Fields/FormElement.php
@@ -528,6 +528,20 @@ abstract class FormElement extends MoonShineComponent implements FormElementCont
         return $this;
     }
 
+    public function wrapperClass(string|array $classes): static
+    {
+        $this->wrapperAttributes = $this->wrapperAttributes->class($classes);
+
+        return $this;
+    }
+
+    public function wrapperStyle(string|array $styles): static
+    {
+        $this->wrapperAttributes = $this->wrapperAttributes->style($styles);
+
+        return $this;
+    }
+
     public function getWrapperAttributes(): ComponentAttributesBagContract
     {
         return $this->wrapperAttributes;

--- a/src/UI/src/Fields/FormElement.php
+++ b/src/UI/src/Fields/FormElement.php
@@ -535,6 +535,9 @@ abstract class FormElement extends MoonShineComponent implements FormElementCont
         return $this;
     }
 
+    /**
+     * @param  string|array<int|string, bool|string>  $classes
+     */
     public function wrapperClass(string|array $classes): static
     {
         $this->wrapperAttributes = $this->wrapperAttributes->class($classes);
@@ -555,6 +558,9 @@ abstract class FormElement extends MoonShineComponent implements FormElementCont
         return $this;
     }
 
+    /**
+     * @param  string|array<int|string, bool|string>  $styles
+     */
     public function wrapperStyle(string|array $styles): static
     {
         $this->wrapperAttributes = $this->wrapperAttributes->style($styles);


### PR DESCRIPTION
## Что нового?
Класс `FormElement `получил новые методы для взаимодействия с набором атрибутов своей обёртки:
- `wrapperClass()` добавляет класс
- `wrapperStyle()` добавляет стиль
- `removeWrapperClass()` удаляет класс
- `removeWrapperAttribute()` удаляет атрибут

## Зачем?
Теперь гораздо проще добавлять и изменять самые расхожие атрибуты обёртки — класс и стиль.

## Чеклист

- Тесты
    - [x] Потестировано вручную
    - [x] Дополнительных тестов не требуется, т.к. новые методы используют имеющиеся методы класса `ComponentAttributeBag`

- Документация
  - [x] В документацию будет внесён отдельный ПР
