### PR TITLE
feat: Silent/SilentSelf reactive

### DIFF
--- a/src/Contracts/src/UI/HasReactivityContract.php
+++ b/src/Contracts/src/UI/HasReactivityContract.php
@@ -14,6 +14,16 @@ interface HasReactivityContract
 {
     public function isReactive(): bool;
 
+    /**
+     * @param  array<string, mixed>  $values
+     */
+    public function isSilentReactive(mixed $value, array $values): bool;
+
+    /**
+     * @param  array<string, mixed>  $values
+     */
+    public function isSilentSelfReactive(mixed $value, array $values): bool;
+
     public function isReactivitySupported(): bool;
 
     /**
@@ -26,18 +36,23 @@ interface HasReactivityContract
     /**
      * @param  TFields  $fields
      * @param  array<string, mixed>  $values
+     * @param  array<string, mixed>  $additionally
      *
      * @return TFields
      */
-    public function getReactiveCallback(FieldsContract $fields, mixed $value, array $values): FieldsContract;
+    public function getReactiveCallback(FieldsContract $fields, mixed $value, array $values, array $additionally): FieldsContract;
 
     /**
-     * @param  ?Closure(TFields $fields, mixed $value, static $ctx, array<string, mixed> $values): TFields  $callback
+     * @param  ?Closure(TFields $fields, mixed $value, static $ctx, array<string, mixed> $values, array<string, mixed> $additionally): TFields  $callback
+     * @param  bool|(Closure(mixed $value, array<string, mixed> $values, static $ctx): bool)   $silent
+     * @param  bool|(Closure(mixed $value, array<string, mixed> $values, static $ctx): bool)   $silentSelf
      */
     public function reactive(
         ?Closure $callback = null,
         bool $lazy = false,
         int $debounce = 0,
         int $throttle = 0,
+        bool|Closure $silent = false,
+        bool|Closure $silentSelf = false,
     ): static;
 }

--- a/src/Laravel/src/Http/Controllers/ReactiveController.php
+++ b/src/Laravel/src/Http/Controllers/ReactiveController.php
@@ -21,7 +21,7 @@ final class ReactiveController extends MoonShineController
 
         /** @var ?FormBuilderContract $form */
         $form = $page->getComponents()->findForm(
-            $crudRequest->getComponentName()
+            $crudRequest->getComponentName(),
         );
 
         if (\is_null($form)) {
@@ -36,34 +36,54 @@ final class ReactiveController extends MoonShineController
         $casted = null;
         $except = [];
 
-        $values = $request->collect('values')->map(function (mixed $value, string $column) use ($fields, &$casted, &$except) {
-            $field = $fields->findByColumn($column);
+        $values = $request->collect('values')->map(
+            function (mixed $value, string $column) use ($fields, &$casted, &$except) {
+                $field = $fields->findByColumn($column);
 
-            if (! $field instanceof HasReactivityContract) {
-                return $value;
-            }
+                if (! $field instanceof HasReactivityContract) {
+                    return $value;
+                }
 
-            return $field->prepareReactivityValue($value, $casted, $except);
-        });
+                return $field->prepareReactivityValue($value, $casted, $except);
+            },
+        );
 
         $fields->fill(
             $values->toArray(),
-            $casted ? new ModelDataWrapper($casted->forceFill($values->except($except)->toArray())) : null
+            $casted ? new ModelDataWrapper($casted->forceFill($values->except($except)->toArray())) : null,
         );
+
+        $additionally = $request->array('additionally');
 
         foreach ($fields as $field) {
             $fields = $field->formName($form->getName())->getReactiveCallback(
                 $fields,
                 data_get($values, $field->getColumn()),
                 $values->toArray(),
+                $additionally,
             );
         }
 
         $values = $fields
-            ->mapWithKeys(static fn (FieldContract $field): array => [$field->getColumn() => $field->getReactiveValue()]);
+            ->mapWithKeys(
+                static fn (FieldContract $field): array => [$field->getColumn() => $field->getReactiveValue()],
+            );
+
+        $currentColumn = $request->input('current');
+
+        $skipRender = static fn (FieldContract $field): bool
+            => $field->isSilentReactive(data_get($values, $field->getColumn()), $values->toArray())
+               || ($field->isSilentSelfReactive(
+                   data_get($values, $field->getColumn()),
+                   $values->toArray(),
+               ) && $currentColumn === $field->getColumn());
 
         $fields = $fields->mapWithKeys(
-            static fn (FieldContract $field): array => [$field->getColumn() => (string) FieldsGroup::make([$field])->render()]
+            static fn (FieldContract $field): array => $skipRender($field)
+                ? []
+                : [
+                    $field->getColumn() => (string)FieldsGroup::make([$field])->render(),
+                ],
         );
 
         return $this->json(data: [

--- a/src/UI/resources/js/Components/FormBuilder.js
+++ b/src/UI/resources/js/Components/FormBuilder.js
@@ -31,6 +31,7 @@ export default (name = '', initData = {}, reactive = {}) => ({
 
       if (!t.blockWatch) {
         let focused = document.activeElement
+        let additionally = {}
 
         componentRequestData.withAfterResponse(function (data) {
           for (let [column, html] of Object.entries(data.fields)) {
@@ -75,14 +76,23 @@ export default (name = '', initData = {}, reactive = {}) => ({
           t.$nextTick(() => (t.blockWatch = false))
         })
 
-        const choices = focused.closest('.choices')
-        const select = choices?.querySelector('select')
+        let tsWrapper = focused.closest('.ts-wrapper')
 
-        if (select && select.multiple) {
-          await t.$nextTick(() => {
-            values[select.getAttribute('data-reactive-column')] =
-              select.dataset.choicesValue.split(',')
-          })
+        if(tsWrapper) {
+          let select = tsWrapper.previousElementSibling
+          focused = select.tagName === 'SELECT' ? select : focused
+        }
+
+        for (let column of Object.keys(values)) {
+          const element = t.$root.querySelector(
+            `[data-reactive-column='${column}']`,
+          )
+
+          if(element.tagName === 'SELECT') {
+            additionally[column] = {
+              label: element.selectedOptions[0]?.text
+            }
+          }
         }
 
         request(
@@ -91,7 +101,9 @@ export default (name = '', initData = {}, reactive = {}) => ({
           'post',
           {
             _component_name: t.name,
-            values: values,
+            current: focused?.getAttribute('data-column'),
+            additionally,
+            values,
           },
           {},
           componentRequestData,

--- a/src/UI/src/Traits/Fields/Reactivity.php
+++ b/src/UI/src/Traits/Fields/Reactivity.php
@@ -24,9 +24,37 @@ trait Reactivity
 
     protected bool $isReactive = false;
 
+    /**
+     * @var bool|(Closure(mixed, array<string, mixed>, static): bool)
+     */
+    protected bool|Closure $isSilentReactive = false;
+
+    /**
+     * @var bool|(Closure(mixed, array<string, mixed>, static): bool)
+     */
+    protected bool|Closure $isSilentSelfReactive = false;
+
     public function isReactive(): bool
     {
         return $this->isReactive;
+    }
+
+    public function isSilentReactive(mixed $value, array $values): bool
+    {
+        if (\is_bool($this->isSilentReactive)) {
+            return $this->isSilentReactive;
+        }
+
+        return (bool) \call_user_func($this->isSilentReactive, $value, $values, $this);
+    }
+
+    public function isSilentSelfReactive(mixed $value, array $values): bool
+    {
+        if (\is_bool($this->isSilentSelfReactive)) {
+            return $this->isSilentSelfReactive;
+        }
+
+        return (bool) \call_user_func($this->isSilentSelfReactive, $value, $values, $this);
     }
 
     public function prepareReactivityValue(mixed $value, mixed &$casted, array &$except): mixed
@@ -39,13 +67,13 @@ trait Reactivity
         return true;
     }
 
-    public function getReactiveCallback(FieldsContract $fields, mixed $value, array $values): FieldsContract
+    public function getReactiveCallback(FieldsContract $fields, mixed $value, array $values, array $additionally): FieldsContract
     {
         if (\is_null($this->reactiveCallback) || ! $this->isReactive()) {
             return $fields;
         }
 
-        return \call_user_func($this->reactiveCallback, $fields, $value, $this, $values);
+        return \call_user_func($this->reactiveCallback, $fields, $value, $this, $values, $additionally);
     }
 
     public function reactive(
@@ -53,12 +81,16 @@ trait Reactivity
         bool $lazy = false,
         int $debounce = 0,
         int $throttle = 0,
+        bool|Closure $silent = false,
+        bool|Closure $silentSelf = false,
     ): static {
         if (! $this->isReactivitySupported()) {
             throw FieldException::reactivityNotSupported(static::class);
         }
 
         $this->isReactive = true;
+        $this->isSilentReactive = $silent;
+        $this->isSilentSelfReactive = $silentSelf;
         $this->reactiveCallback = $callback;
 
         $attribute = Str::of('x-model')

--- a/src/UI/vite.config.js
+++ b/src/UI/vite.config.js
@@ -61,9 +61,6 @@ export default defineConfig(({mode}) => {
           },
         },
       },
-    },
-    define: {
-      'process.env.CHOICES_CAN_USE_DOM': true,
-    },
+    }
   }
 })


### PR DESCRIPTION
## Allows you to skip field re-rendering when making changes if the current field is currently being edited
```php
 Select::make('Select 1')->reactive(silentSelf: true),
```

## Allows you to skip field re-rendering when changes are made

```php
 Select::make('Select 2')->reactive(silent: true),
```

### or via callback

```php
 Select::make('Select 1')->reactive(silentSelf: fn(string $value, array $values, Select $ctx): bool => $value === 'Option 2'),
```

```php
 Select::make('Select 2')->reactive(silent: fn(string $value, array $values, Select $ctx): bool => $values['select1'] === 'Option 2'),
```