### PR TITLE
fix: Remove using `array()` method, which only exists in Laravel 12

### DIFF
--- a/src/Laravel/src/Http/Controllers/ReactiveController.php
+++ b/src/Laravel/src/Http/Controllers/ReactiveController.php
@@ -53,7 +53,7 @@ final class ReactiveController extends MoonShineController
             $casted ? new ModelDataWrapper($casted->forceFill($values->except($except)->toArray())) : null,
         );
 
-        $additionally = $request->array('additionally');
+        $additionally = $request->collect('additionally')->all();
 
         foreach ($fields as $field) {
             $fields = $field->formName($form->getName())->getReactiveCallback(


### PR DESCRIPTION
## What was changed
Replaced usage of `\Illuminate\Http\Request::array()` method in `ReactiveController` with a backward-compatible alternative:
```php
$request->collect('additionally')->all()
```

## Why?
The Request::array() method was introduced in Laravel 12.
MoonShine supports Laravel 10 and 11 as well, where this method does not exist and causes a runtime error:
```
Method Illuminate\\Http\\Request::array does not exist.
```

## Checklist

- Tested
    - [x] Tested manually
    - [ ] Tests added
