### PR TITLE
ShowWhen 3.0

### DIFF
--- a/src/Contracts/src/UI/HasShowWhenContract.php
+++ b/src/Contracts/src/UI/HasShowWhenContract.php
@@ -13,10 +13,6 @@ interface HasShowWhenContract
      */
     public function getShowWhenCondition(): array;
 
-    public function modifyShowFieldName(string $name): static;
-
-    public function modifyShowFieldRangeName(): static;
-
     public function showWhen(
         string $column,
         mixed $operator = null,

--- a/src/Contracts/src/UI/HasShowWhenContract.php
+++ b/src/Contracts/src/UI/HasShowWhenContract.php
@@ -9,7 +9,7 @@ interface HasShowWhenContract
     public function hasShowWhen(): bool;
 
     /**
-     * @return array<string, string>
+     * @return array<array-key, mixed>
      */
     public function getShowWhenCondition(): array;
 
@@ -23,5 +23,11 @@ interface HasShowWhenContract
         string $column,
         mixed $operator = null,
         mixed $value = null
+    ): static;
+
+    public function showWhenRow(
+        string $column,
+        mixed $operator = null,
+        mixed $value = null,
     ): static;
 }

--- a/src/Support/src/DTOs/ShowWhenCondition.php
+++ b/src/Support/src/DTOs/ShowWhenCondition.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Support\DTOs;
+
+
+final class ShowWhenCondition
+{
+    /**
+     * @var string[]
+     */
+    protected array $operators = [
+        '=',
+        '<',
+        '>',
+        '<=',
+        '>=',
+        '!=',
+        'in',
+        'not in',
+    ];
+
+    /**
+     * @var string[]
+     */
+    protected array $arrayOperators = [
+        'in',
+        'not in',
+    ];
+
+    public function __construct(
+        public string $column,
+        public mixed $operator,
+        public mixed $value,
+        public bool $isRowMode = false,
+    ) {
+        if ($this->isInvalidValueForOperator($operator, $value)) {
+            throw new \InvalidArgumentException(
+                'Illegal operator and value combination.'
+            );
+        }
+
+        if ($this->isInvalidOperator($operator)) {
+            $value = $operator;
+            $operator = '=';
+        }
+
+        if (! \is_array($value) && \in_array($operator, $this->arrayOperators)) {
+            throw new \InvalidArgumentException(
+                'Illegal operator and value combination. Value must be array type'
+            );
+        }
+    }
+
+    protected function isInvalidValueForOperator(mixed $operator, mixed $value): bool
+    {
+        return \is_null($value) && \in_array($operator, $this->operators) &&
+               ! \in_array($operator, ['=', '!=']);
+    }
+
+    protected function isInvalidOperator(mixed $operator): bool
+    {
+        return ! \is_string($operator) || (! \in_array(
+                strtolower($operator),
+                $this->operators,
+                true
+            ));
+    }
+}

--- a/src/Support/src/DTOs/ShowWhenCondition.php
+++ b/src/Support/src/DTOs/ShowWhenCondition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MoonShine\Support\DTOs;
 
+use InvalidArgumentException;
 
 final class ShowWhenCondition
 {
@@ -35,36 +36,36 @@ final class ShowWhenCondition
         public mixed $value,
         public bool $isRowMode = false,
     ) {
-        if ($this->isInvalidValueForOperator($operator, $value)) {
-            throw new \InvalidArgumentException(
+        if ($this->isInvalidValueForOperator()) {
+            throw new InvalidArgumentException(
                 'Illegal operator and value combination.'
             );
         }
 
-        if ($this->isInvalidOperator($operator)) {
-            $value = $operator;
-            $operator = '=';
+        if ($this->isInvalidOperator()) {
+            $this->value = $this->operator;
+            $this->operator = '=';
         }
 
         if (! \is_array($value) && \in_array($operator, $this->arrayOperators)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Illegal operator and value combination. Value must be array type'
             );
         }
     }
 
-    protected function isInvalidValueForOperator(mixed $operator, mixed $value): bool
+    protected function isInvalidValueForOperator(): bool
     {
-        return \is_null($value) && \in_array($operator, $this->operators) &&
-               ! \in_array($operator, ['=', '!=']);
+        return \is_null($this->value) && \in_array($this->operator, $this->operators) &&
+               ! \in_array($this->operator, ['=', '!=']);
     }
 
-    protected function isInvalidOperator(mixed $operator): bool
+    protected function isInvalidOperator(): bool
     {
-        return ! \is_string($operator) || (! \in_array(
-                strtolower($operator),
-                $this->operators,
-                true
-            ));
+        return ! \is_string($this->operator) || (! \in_array(
+            strtolower($this->operator),
+            $this->operators,
+            true
+        ));
     }
 }

--- a/src/UI/resources/js/Components/FormBuilder.js
+++ b/src/UI/resources/js/Components/FormBuilder.js
@@ -8,7 +8,7 @@ import {
 } from '../Support/Forms.js'
 import request, {initCallback, prepareUrl} from '../Request/Core.js'
 import {dispatchEvents as de} from '../Support/DispatchEvents.js'
-import {getInputs, showWhenChange, showWhenVisibilityChange} from '../Support/ShowWhen.js'
+import {getShowWhenInputs, showWhenChange, showWhenUpdateVisibility} from '../Support/ShowWhen.js'
 import {formToJSON} from 'axios'
 
 export default (name = '', initData = {}, reactive = {}) => ({
@@ -126,7 +126,7 @@ export default (name = '', initData = {}, reactive = {}) => ({
 
       await t.$nextTick()
 
-      const inputs = t.getInputs(formId)
+      const inputs = t.getShowWhenInputs(formId)
 
       const showWhenFields = {}
 
@@ -145,7 +145,7 @@ export default (name = '', initData = {}, reactive = {}) => ({
       })
 
       for (let key in showWhenFields) {
-        t.showWhenVisibilityChange(showWhenFields[key], key, inputs, formId)
+        t.showWhenUpdateVisibility(showWhenFields[key], key, inputs, formId)
       }
     })
   },
@@ -347,9 +347,9 @@ export default (name = '', initData = {}, reactive = {}) => ({
 
   showWhenChange,
 
-  showWhenVisibilityChange,
+  showWhenUpdateVisibility,
 
-  getInputs,
+  getShowWhenInputs,
 })
 
 function submitState(form, loading = true, reset = false) {

--- a/src/UI/resources/js/Components/FormBuilder.js
+++ b/src/UI/resources/js/Components/FormBuilder.js
@@ -131,15 +131,16 @@ export default (name = '', initData = {}, reactive = {}) => ({
       const showWhenFields = {}
 
       t.whenFields.forEach(field => {
-        if (
-          field.is_row_mode === false &&
-          (inputs[field.changeField] === undefined || inputs[field.changeField].value === undefined)
-        ) {
+        const inputUndefined = inputs[field.changeField]?.value === undefined
+
+        if (!field.is_row_mode && inputUndefined) {
           return
         }
+
         if (showWhenFields[field.showField] === undefined) {
           showWhenFields[field.showField] = []
         }
+
         showWhenFields[field.showField].push(field)
       })
 

--- a/src/UI/resources/js/Support/Forms.js
+++ b/src/UI/resources/js/Support/Forms.js
@@ -1,5 +1,38 @@
-import {inputFieldName, inputGetValue} from './ShowWhen.js'
 import {excludeFromParams, prepareQueryParams} from './URLs.js'
+
+export function inputGetValue(element) {
+  let value
+
+  const type = element.getAttribute('type')
+
+  if (element.hasAttribute('multiple') && element.options !== undefined) {
+    value = []
+    for (let option of element.options) {
+      if (option.selected) {
+        value.push(option.value)
+      }
+    }
+  } else if (type === 'checkbox') {
+    value = element.checked
+  } else if (type === 'radio') {
+    value = element.value
+  } else {
+    value = element.value ?? null
+  }
+
+  return value
+}
+
+export function inputFieldName(inputName) {
+  if (inputName === null) {
+    return ''
+  }
+  inputName = inputName.replace('[]', '')
+  if (inputName.indexOf('slide[') !== -1) {
+    inputName = inputName.replace('slide[', '').replace(']', '')
+  }
+  return inputName
+}
 
 export function filterAttributeStartsWith(data, startsWith) {
   const filtered = {}

--- a/src/UI/resources/js/Support/ShowWhen.js
+++ b/src/UI/resources/js/Support/ShowWhen.js
@@ -119,8 +119,8 @@ export function showWhenUpdateVisibility(relatedFields, fieldName, inputs, formI
   })
 
   /**
-   * If showWhenRow, we don't calculate cell hiding and don't call the element's hiding function again.
-   * todo We'll implement cell hiding in the future.
+   * In row mode, visibility is handled per-row in shouldShowField,
+   * including th hiding when all cells are hidden
    */
   if(fieldElement.dataset.isRowMode) {
     return
@@ -304,6 +304,10 @@ function toggleTableCell(isShow, element, keepName) {
  */
 function shouldShowField(fieldName, inputs, field, formId, keepName) {
   if (field.is_row_mode) {
+    let visibleCellsCount = 0
+    let columnIndex = null
+    let table = null
+
     document
       .querySelectorAll('#' + formId + ' [data-show-when-field="' + fieldName + '"]')
       .forEach(function (element) {
@@ -320,7 +324,29 @@ function shouldShowField(fieldName, inputs, field, formId, keepName) {
         element.setAttribute('data-is-row-mode', 'true')
 
         toggleTableCell(isVisible, element, keepName)
+
+        if (isVisible) {
+          visibleCellsCount++
+        }
+
+        // Remember columnIndex and table for hiding th
+        if (columnIndex === null) {
+          const cell = element.closest('td')
+          if (cell) {
+            columnIndex = cell.cellIndex
+            table = element.closest('table[data-inside=field]')
+          }
+        }
       })
+
+    // Hide th if all cells in the column are hidden
+    if (table !== null && columnIndex !== null) {
+      table.querySelectorAll('th').forEach(header => {
+        if (header.cellIndex === columnIndex) {
+          header.classList.toggle('hidden', visibleCellsCount === 0)
+        }
+      })
+    }
 
     return true
   }

--- a/src/UI/resources/js/Support/ShowWhen.js
+++ b/src/UI/resources/js/Support/ShowWhen.js
@@ -3,7 +3,7 @@ import {inputFieldName, inputGetValue} from './Forms.js'
 /**
  * We collect all the fields that participate in ShowWhen
  */
-export function getInputs(formId) {
+export function getShowWhenInputs(formId) {
   const inputs = {}
 
   const form = document.getElementById(formId)
@@ -19,7 +19,6 @@ export function getInputs(formId) {
 
     inputs[column] = {
       value: inputGetValue(element),
-      name: name,
       type: type,
     }
   })
@@ -29,8 +28,7 @@ export function getInputs(formId) {
     const column = inputFieldName(name)
 
     inputs[column] = {
-      name,
-      value: inputGetValue(element),
+      value: name,
       type: element.getAttribute('type'),
     }
   })
@@ -41,7 +39,6 @@ export function getInputs(formId) {
 
     inputs[column] = {
       value: inputGetValue(element),
-      name,
       type: element.getAttribute('type'),
     }
   })
@@ -52,17 +49,17 @@ export function getInputs(formId) {
 /**
  * Triggered when a field changes on the onChangeField event
  *
- * Find related fields and trigger showWhenVisibilityChange for each
+ * Find related fields and trigger showWhenUpdateVisibility for each
  */
 export function showWhenChange(fieldName, formId) {
   let fieldColumn = inputFieldName(fieldName)
 
-  const showWhenFields = []
+  const relatedFields = []
 
   this.whenFields.forEach(field => {
-    let inputElement = showWhenSelector(fieldName, formId)
+    let fieldElement = findFieldElement(fieldName, formId)
 
-    if (inputElement === null || inputElement === undefined) {
+    if (fieldElement === null || fieldElement === undefined) {
       return
     }
 
@@ -70,7 +67,7 @@ export function showWhenChange(fieldName, formId) {
      * Paired fields (range, date range, etc.) use data-sync-with attribute
      * to reference their sibling field for synchronized show/hide behavior
      */
-    let syncWith = inputElement.dataset.syncWith
+    let syncWith = fieldElement.dataset.syncWith
 
     const isTargetField = fieldColumn === field.changeField || syncWith === field.changeField
 
@@ -80,18 +77,18 @@ export function showWhenChange(fieldName, formId) {
 
     let showField = field.showField
 
-    if (!showWhenFields[showField]) {
-      showWhenFields[showField] = []
+    if (!relatedFields[showField]) {
+      relatedFields[showField] = []
     }
 
-    showWhenFields[showField].push(field)
+    relatedFields[showField].push(field)
   })
 
-  for (let showField in showWhenFields) {
-    this.showWhenVisibilityChange(
-      showWhenFields[showField],
+  for (let showField in relatedFields) {
+    this.showWhenUpdateVisibility(
+      relatedFields[showField],
       showField,
-      this.getInputs(formId),
+      this.getShowWhenInputs(formId),
       formId,
     )
   }
@@ -100,221 +97,235 @@ export function showWhenChange(fieldName, formId) {
 /**
  * Main function
  */
-export function showWhenVisibilityChange(showWhenFields, fieldName, inputs, formId) {
-  if (showWhenFields.length === 0) {
+export function showWhenUpdateVisibility(relatedFields, fieldName, inputs, formId) {
+  if (relatedFields.length === 0) {
     return
   }
 
-  let inputElement = showWhenSelector(fieldName, formId)
+  let fieldElement = findFieldElement(fieldName, formId)
 
-  if (inputElement === null || inputElement === undefined) {
+  if (fieldElement === null || fieldElement === undefined) {
     return
   }
 
-  let visibleFieldsCount = 0
+  let matchedConditions = 0
 
-  showWhenFields.forEach(field => {
-    if (isShowField(fieldName, inputs, field, formId)) {
-      visibleFieldsCount++
+  const keepName = document.querySelector(`#${formId}`).getAttribute('data-submit-show-when')
+
+  relatedFields.forEach(field => {
+    if (shouldShowField(fieldName, inputs, field, formId, keepName)) {
+      matchedConditions++
     }
   })
 
-  const showWhenSubmit = document.querySelector(`#${formId}`).getAttribute('data-submit-show-when')
+  /**
+   * If showWhenRow, we don't calculate cell hiding and don't call the element's hiding function again.
+   * todo We'll implement cell hiding in the future.
+   */
+  if(fieldElement.dataset.isRowMode) {
+    return
+  }
 
   // If input is in a table, then find all tables with this input
-  if (inputElement.closest('table[data-inside=field]')) {
-    const tablesWithInput = []
+  if (fieldElement.closest('table[data-inside=field]')) {
+    const relatedTables = []
 
     // Only data-show-when-field is used in tables, see in UI/Collections/Fields.php(prepareReindex)
     document
       .querySelectorAll('#' + formId + ' [data-show-when-field="' + fieldName + '"]')
       .forEach(function (element) {
-        let inputTable = element.closest('table[data-inside=field]') // Get parent table for data-show-field
-        if (tablesWithInput.indexOf(inputTable) === -1) {
-          tablesWithInput.push(inputTable)
+        let parentTable = element.closest('table[data-inside=field]') // Get parent table for data-show-field
+        if (relatedTables.indexOf(parentTable) === -1) {
+          relatedTables.push(parentTable)
         }
       })
 
     // Tables hide the entire column
-    tablesWithInput.forEach(table => {
-      showHideTableInputs(
-        showWhenFields.length === visibleFieldsCount,
+    relatedTables.forEach(table => {
+      toggleTableColumn(
+        relatedFields.length === matchedConditions,
         table,
         fieldName,
-        showWhenSubmit,
+        keepName,
       )
     })
 
     return
   }
 
-  showHideField(showWhenFields.length === visibleFieldsCount, inputElement, showWhenSubmit)
+  toggleField(relatedFields.length === matchedConditions, fieldElement, keepName)
 }
 
-function showWhenSelector(name, formId) {
-  let inputElement = document.querySelector('#' + formId + ' [name="' + name + '"]')
+function findFieldElement(name, formId) {
+  let element = document.querySelector('#' + formId + ' [name="' + name + '"]')
 
-  if (inputElement === null) {
-    inputElement = document.querySelector(
+  if (element === null) {
+    element = document.querySelector(
       '#' + formId + ' [data-show-when-field="' + name + '"]',
     )
   }
 
-  if (inputElement === null) {
-    inputElement = document.querySelector(
+  if (element === null) {
+    element = document.querySelector(
       '#' + formId + ' [data-show-when-column="' + name + '"]',
     )
   }
 
-  return inputElement
+  return element
 }
 
-function showHideField(isShow, inputElementField, showWhenSubmit) {
-  showHideInputElement(isShow, inputElementField, showWhenSubmit)
+function toggleField(isShow, fieldElement, keepName) {
+  toggleInputElement(isShow, fieldElement, keepName)
 
   // If inside the field there are entry fields with the name attribute
-  let inputs = inputElementField.querySelectorAll('[name]')
+  let inputs = fieldElement.querySelectorAll('[name]')
   if (inputs.length === 0) {
     // If the fields were hidden, then their attribute name is data-show-when-column
-    inputs = inputElementField.querySelectorAll('[data-show-when-column]')
+    inputs = fieldElement.querySelectorAll('[data-show-when-column]')
   }
   for (let i = 0; i < inputs.length; i++) {
-    showHideInputElement(isShow, inputs[i], showWhenSubmit)
+    toggleInputElement(isShow, inputs[i], keepName)
   }
 }
 
-function showHideInputElement(isShow, inputElement, showWhenSubmit) {
-  let fieldContainer = inputElement.closest('.moonshine-field')
+function toggleInputElement(isShow, element, keepName) {
+  let container = element.closest('.moonshine-field')
+  let siblingElements = []
 
-  if (fieldContainer === null) {
-    fieldContainer = inputElement.closest('.form-group')
+  if (container === null) {
+    container = element.closest('.form-group')
   }
 
-  if (fieldContainer === null) {
-    fieldContainer = inputElement.closest('td')
+  if (container === null) {
+    container = element
+    /** tom-select without container problem */
+    const nextElement = container.nextElementSibling
+    if (nextElement?.classList.contains('ts-wrapper')) {
+      siblingElements.push(nextElement)
+    }
   }
 
+  applyVisibility(isShow, container, element, keepName, siblingElements)
+}
+
+function applyVisibility(isShow, container, element, keepName, siblingElements = []) {
   if (isShow) {
-    fieldContainer.classList.remove('hidden')
+    container.classList.remove('hidden')
+    siblingElements.forEach(el => el.classList.remove('hidden'))
 
-    const nameAttr = inputElement.getAttribute('data-show-when-column')
+    const nameAttr = element.getAttribute('data-show-when-column')
 
     if (nameAttr) {
-      inputElement.setAttribute('name', nameAttr)
+      element.setAttribute('name', nameAttr)
     }
 
-    const requiredAttr = inputElement.getAttribute('data-required-when-column')
+    const requiredAttr = element.getAttribute('data-required-when-column')
 
-    if (nameAttr) {
-      inputElement.setAttribute('required', requiredAttr)
+    if (requiredAttr) {
+      element.setAttribute('required', requiredAttr)
     }
   } else {
-    fieldContainer.classList.add('hidden')
+    container.classList.add('hidden')
+    siblingElements.forEach(el => el.classList.add('hidden'))
 
-    if (!showWhenSubmit) {
-      const nameAttr = inputElement.getAttribute('name')
+    if (!keepName) {
+      const nameAttr = element.getAttribute('name')
 
       if (nameAttr) {
-        inputElement.setAttribute('data-show-when-column', nameAttr)
-        inputElement.removeAttribute('name')
+        element.setAttribute('data-show-when-column', nameAttr)
+        element.removeAttribute('name')
       }
 
-      const requiredAttr = inputElement.getAttribute('required')
+      const requiredAttr = element.getAttribute('required')
 
       if (requiredAttr) {
-        inputElement.setAttribute('data-required-when-column', requiredAttr)
-        inputElement.removeAttribute('required')
+        element.setAttribute('data-required-when-column', requiredAttr)
+        element.removeAttribute('required')
       }
     }
   }
 }
 
-function showHideTableInputs(isShow, table, fieldName, showWhenSubmit) {
-  let cellIndexTd = null
+function toggleTableColumn(isShow, table, fieldName, keepName) {
+  let columnIndex = null
 
   table.querySelectorAll('[data-show-when-field="' + fieldName + '"]').forEach(element => {
-    if (element.dataset.objectMode) {
-      showHideField(isShow, element)
+    const cell = toggleTableCell(isShow, element, keepName)
 
+    if(cell === null) {
       return
     }
 
-    const td = element.closest('td')
-
-    if (td.dataset.objectMode) {
-      showHideField(isShow, element)
-
-      return
-    }
-
-    if (isShow) {
-      td.classList.remove('hidden')
-
-      const nameAttr = element.getAttribute('data-show-when-column')
-      if (nameAttr) {
-        element.setAttribute('name', nameAttr)
-      }
-      const requiredAttr = element.getAttribute('data-required-when-column')
-      if (requiredAttr) {
-        element.setAttribute('required', requiredAttr)
-      }
-    } else {
-      td.classList.add('hidden')
-
-      if (!showWhenSubmit) {
-        const nameAttr = element.getAttribute('name')
-        if (nameAttr) {
-          element.setAttribute('data-show-when-column', nameAttr)
-          element.removeAttribute('name')
-        }
-        const requiredAttr = element.getAttribute('required')
-        if (requiredAttr) {
-          element.setAttribute('data-required-when-column', requiredAttr)
-          element.removeAttribute('required')
-        }
-      }
-    }
-
-    if (cellIndexTd === null) {
-      cellIndexTd = td.cellIndex
+    if (columnIndex === null) {
+      columnIndex = cell.cellIndex
     }
   })
 
-  if (cellIndexTd !== null) {
-    table.querySelectorAll('th').forEach(element => {
-      if (element.cellIndex !== cellIndexTd) {
+  if (columnIndex !== null) {
+    table.querySelectorAll('th').forEach(header => {
+      if (header.cellIndex !== columnIndex) {
         return
       }
-      element.classList.toggle('hidden', !isShow)
+      header.classList.toggle('hidden', !isShow)
     })
   }
 }
 
-function isShowField(fieldName, inputs, field, formId) {
-  if (field.is_row_mode) {
-    const showWhenSubmit = document.querySelector(`#${formId}`).getAttribute('data-submit-show-when')
+function toggleTableCell(isShow, element, keepName) {
+  if (element.dataset.objectMode) {
+    toggleField(isShow, element)
 
+    return null
+  }
+
+  const cell = element.closest('td')
+
+  if (cell.dataset.objectMode) {
+    toggleField(isShow, element)
+
+    return null
+  }
+
+  let siblingElements = []
+
+  /** tom-select without container problem */
+  const nextElement = element.nextElementSibling
+  if (nextElement?.classList.contains('ts-wrapper')) {
+    siblingElements.push(nextElement)
+  }
+
+  applyVisibility(isShow, cell, element, keepName, siblingElements)
+
+  return cell
+}
+
+/**
+ * Check if field should be visible based on conditions
+ */
+function shouldShowField(fieldName, inputs, field, formId, keepName) {
+  if (field.is_row_mode) {
     document
       .querySelectorAll('#' + formId + ' [data-show-when-field="' + fieldName + '"]')
       .forEach(function (element) {
         let row = element.closest('tr')
         let target = row.querySelector('[data-column="' + field.changeField + '"]')
 
-        let isShow = isShowFieldCondition(
+        let isVisible = evaluateCondition(
           target.type,
           field.operator,
           field.value,
           inputGetValue(target)
         )
 
+        element.setAttribute('data-is-row-mode', 'true')
 
-        showHideField(isShow, element, showWhenSubmit)
+        toggleTableCell(isVisible, element, keepName)
       })
 
     return true
   }
 
-  return isShowFieldCondition(
+  return evaluateCondition(
     inputs[field.changeField].type,
     field.operator,
     inputs[field.changeField].value,
@@ -322,73 +333,77 @@ function isShowField(fieldName, inputs, field, formId) {
   )
 }
 
-function isShowFieldCondition(inputType, operator, valueInput, valueField) {
-  let isShowField = false
+function evaluateCondition(inputType, operator, inputValue, conditionValue) {
+  let result = false
 
   if (inputType === 'number') {
-    valueInput = parseFloat(valueInput)
-    valueField = parseFloat(valueField)
+    inputValue = parseFloat(inputValue)
+    conditionValue = parseFloat(conditionValue)
   } else if (inputType === 'date' || inputType === 'datetime-local') {
     if (inputType === 'date') {
-      valueInput = valueInput + ' 00:00:00'
+      inputValue = inputValue + ' 00:00:00'
     }
-    valueInput = new Date(valueInput).getTime()
+    inputValue = new Date(inputValue).getTime()
 
-    if (!Array.isArray(valueField)) {
-      valueField = new Date(valueField).getTime()
+    if (!Array.isArray(conditionValue)) {
+      conditionValue = new Date(conditionValue).getTime()
     }
   }
 
+  /**
+   * Using loose equality (==) intentionally to compare values of different types
+   * e.g., string "1" should match number 1 from form inputs
+   */
   switch (operator) {
     case '=':
-      isShowField = valueInput == valueField
+      result = inputValue == conditionValue
       break
     case '!=':
-      isShowField = valueInput != valueField
+      result = inputValue != conditionValue
       break
     case '>':
-      isShowField = valueInput > valueField
+      result = inputValue > conditionValue
       break
     case '<':
-      isShowField = valueInput < valueField
+      result = inputValue < conditionValue
       break
     case '>=':
-      isShowField = valueInput >= valueField
+      result = inputValue >= conditionValue
       break
     case '<=':
-      isShowField = valueInput <= valueField
+      result = inputValue <= conditionValue
       break
     case 'in':
-      if (Array.isArray(valueInput) && Array.isArray(valueField)) {
-        for (let i = 0; i < valueField.length; i++) {
-          if (valueInput.some(v => v == valueField[i])) {
-            isShowField = true
+      if (Array.isArray(inputValue) && Array.isArray(conditionValue)) {
+        for (let i = 0; i < conditionValue.length; i++) {
+          if (inputValue.some(v => v == conditionValue[i])) {
+            result = true
             break
           }
         }
       } else {
-        isShowField =  Array.isArray(valueField)
-          ? valueField.some(v => v == valueInput)
-          : valueField.includes(valueInput);
+        result = Array.isArray(conditionValue)
+          ? conditionValue.some(v => v == inputValue)
+          : conditionValue.includes(inputValue);
       }
       break
     case 'not in':
-      if (Array.isArray(valueInput) && Array.isArray(valueField)) {
+      if (Array.isArray(inputValue) && Array.isArray(conditionValue)) {
         let includes = false
-        for (let i = 0; i < valueField.length; i++) {
-          if (valueInput.some(v => v == valueField[i])) {
+        for (let i = 0; i < conditionValue.length; i++) {
+          if (inputValue.some(v => v == conditionValue[i])) {
             includes = true
             break
           }
         }
-        isShowField = !includes
+        result = !includes
       } else {
-        isShowField = Array.isArray(valueField)
-          ? !valueField.some(v => v == valueInput)
-          : !valueField.includes(valueInput);
+        result = Array.isArray(conditionValue)
+          ? !conditionValue.some(v => v == inputValue)
+          : !conditionValue.includes(inputValue);
       }
       break
   }
 
-  return isShowField
+  return result
 }

--- a/src/UI/resources/js/Support/ShowWhen.js
+++ b/src/UI/resources/js/Support/ShowWhen.js
@@ -1,38 +1,47 @@
+import {inputFieldName, inputGetValue} from './Forms.js'
+
+/**
+ * We collect all the fields that participate in ShowWhen
+ */
 export function getInputs(formId) {
   const inputs = {}
 
   const form = document.getElementById(formId)
 
   form.querySelectorAll('[name]').forEach(element => {
-    const value = element.getAttribute('name')
-    const fieldName = inputFieldName(value)
+    const name = element.getAttribute('name')
+    const column = inputFieldName(name)
     const type = element.getAttribute('type')
 
     if (type === 'radio' && !element.checked) {
       return
     }
 
-    inputs[fieldName] = {
+    inputs[column] = {
       value: inputGetValue(element),
+      name: name,
       type: type,
     }
   })
 
   form.querySelectorAll('[data-show-when-field]').forEach(element => {
-    const value = element.getAttribute('data-show-when-field')
-    const fieldName = inputFieldName(value)
+    const name = element.getAttribute('data-show-when-field')
+    const column = inputFieldName(name)
 
-    inputs[fieldName] = {
-      value,
-      type: 'text',
+    inputs[column] = {
+      name,
+      value: inputGetValue(element),
+      type: element.getAttribute('type'),
     }
   })
 
   form.querySelectorAll('[data-show-when-column]').forEach(element => {
-    const fieldName = element.getAttribute('data-show-when-column')
+    const name = element.getAttribute('data-show-when-column')
+    const column = inputFieldName(name)
 
-    inputs[fieldName] = {
+    inputs[column] = {
       value: inputGetValue(element),
+      name,
       type: element.getAttribute('type'),
     }
   })
@@ -40,25 +49,32 @@ export function getInputs(formId) {
   return inputs
 }
 
+/**
+ * Triggered when a field changes on the onChangeField event
+ *
+ * Find related fields and trigger showWhenVisibilityChange for each
+ */
 export function showWhenChange(fieldName, formId) {
-  fieldName = inputFieldName(fieldName)
+  let fieldColumn = inputFieldName(fieldName)
 
   const showWhenFields = []
 
   this.whenFields.forEach(field => {
-    let inputElement = document.querySelector('#' + formId + ' [name="' + fieldName + '"]')
+    let inputElement = showWhenSelector(fieldName, formId)
 
     if (inputElement === null || inputElement === undefined) {
       return
     }
 
+    /**
+     * Paired fields (range, date range, etc.) use data-sync-with attribute
+     * to reference their sibling field for synchronized show/hide behavior
+     */
     let syncWith = inputElement.dataset.syncWith
 
-    if (
-      field.is_row_mode === false &&
-      fieldName !== field.changeField &&
-      syncWith !== field.changeField
-    ) {
+    const isTargetField = fieldColumn === field.changeField || syncWith === field.changeField
+
+    if (!field.is_row_mode && !isTargetField) {
       return
     }
 
@@ -81,26 +97,17 @@ export function showWhenChange(fieldName, formId) {
   }
 }
 
+/**
+ * Main function
+ */
 export function showWhenVisibilityChange(showWhenFields, fieldName, inputs, formId) {
   if (showWhenFields.length === 0) {
     return
   }
 
-  let inputElement = document.querySelector('#' + formId + ' [name="' + fieldName + '"]')
+  let inputElement = showWhenSelector(fieldName, formId)
 
-  if (inputElement === null) {
-    inputElement = document.querySelector(
-      '#' + formId + ' [data-show-when-field="' + fieldName + '"]',
-    )
-  }
-
-  if (inputElement === null) {
-    inputElement = document.querySelector(
-      '#' + formId + ' [data-show-when-column="' + fieldName + '"]',
-    )
-  }
-
-  if (inputElement === null) {
+  if (inputElement === null || inputElement === undefined) {
     return
   }
 
@@ -114,8 +121,8 @@ export function showWhenVisibilityChange(showWhenFields, fieldName, inputs, form
 
   const showWhenSubmit = document.querySelector(`#${formId}`).getAttribute('data-submit-show-when')
 
+  // If input is in a table, then find all tables with this input
   if (inputElement.closest('table[data-inside=field]')) {
-    // If input is in a table, then find all tables with this input
     const tablesWithInput = []
 
     // Only data-show-when-field is used in tables, see in UI/Collections/Fields.php(prepareReindex)
@@ -144,6 +151,24 @@ export function showWhenVisibilityChange(showWhenFields, fieldName, inputs, form
   showHideField(showWhenFields.length === visibleFieldsCount, inputElement, showWhenSubmit)
 }
 
+function showWhenSelector(name, formId) {
+  let inputElement = document.querySelector('#' + formId + ' [name="' + name + '"]')
+
+  if (inputElement === null) {
+    inputElement = document.querySelector(
+      '#' + formId + ' [data-show-when-field="' + name + '"]',
+    )
+  }
+
+  if (inputElement === null) {
+    inputElement = document.querySelector(
+      '#' + formId + ' [data-show-when-column="' + name + '"]',
+    )
+  }
+
+  return inputElement
+}
+
 function showHideField(isShow, inputElementField, showWhenSubmit) {
   showHideInputElement(isShow, inputElementField, showWhenSubmit)
 
@@ -160,21 +185,26 @@ function showHideField(isShow, inputElementField, showWhenSubmit) {
 
 function showHideInputElement(isShow, inputElement, showWhenSubmit) {
   let fieldContainer = inputElement.closest('.moonshine-field')
+
   if (fieldContainer === null) {
     fieldContainer = inputElement.closest('.form-group')
   }
+
   if (fieldContainer === null) {
-    fieldContainer = inputElement
+    fieldContainer = inputElement.closest('td')
   }
 
   if (isShow) {
     fieldContainer.classList.remove('hidden')
 
     const nameAttr = inputElement.getAttribute('data-show-when-column')
+
     if (nameAttr) {
       inputElement.setAttribute('name', nameAttr)
     }
+
     const requiredAttr = inputElement.getAttribute('data-required-when-column')
+
     if (nameAttr) {
       inputElement.setAttribute('required', requiredAttr)
     }
@@ -183,11 +213,14 @@ function showHideInputElement(isShow, inputElement, showWhenSubmit) {
 
     if (!showWhenSubmit) {
       const nameAttr = inputElement.getAttribute('name')
+
       if (nameAttr) {
         inputElement.setAttribute('data-show-when-column', nameAttr)
         inputElement.removeAttribute('name')
       }
+
       const requiredAttr = inputElement.getAttribute('required')
+
       if (requiredAttr) {
         inputElement.setAttribute('data-required-when-column', requiredAttr)
         inputElement.removeAttribute('required')
@@ -257,51 +290,25 @@ function showHideTableInputs(isShow, table, fieldName, showWhenSubmit) {
   }
 }
 
-export function inputFieldName(inputName) {
-  if (inputName === null) {
-    return ''
-  }
-  inputName = inputName.replace('[]', '')
-  if (inputName.indexOf('slide[') !== -1) {
-    inputName = inputName.replace('slide[', '').replace(']', '')
-  }
-  return inputName
-}
-
-export function inputGetValue(element) {
-  let value
-
-  const type = element.getAttribute('type')
-
-  if (element.hasAttribute('multiple') && element.options !== undefined) {
-    value = []
-    for (let option of element.options) {
-      if (option.selected) {
-        value.push(option.value)
-      }
-    }
-  } else if (type === 'checkbox') {
-    value = element.checked
-  } else if (type === 'radio') {
-    value = element.value
-  } else {
-    value = element.value
-  }
-
-  return value
-}
-
 function isShowField(fieldName, inputs, field, formId) {
   if (field.is_row_mode) {
+    const showWhenSubmit = document.querySelector(`#${formId}`).getAttribute('data-submit-show-when')
+
     document
       .querySelectorAll('#' + formId + ' [data-show-when-field="' + fieldName + '"]')
       .forEach(function (element) {
         let row = element.closest('tr')
         let target = row.querySelector('[data-column="' + field.changeField + '"]')
 
-        let isShow = isShowFieldCondition(target.type, field.operator, field.value, target.value)
+        let isShow = isShowFieldCondition(
+          target.type,
+          field.operator,
+          field.value,
+          inputGetValue(target)
+        )
 
-        element.classList.toggle('hidden', !isShow)
+
+        showHideField(isShow, element, showWhenSubmit)
       })
 
     return true
@@ -354,27 +361,31 @@ function isShowFieldCondition(inputType, operator, valueInput, valueField) {
     case 'in':
       if (Array.isArray(valueInput) && Array.isArray(valueField)) {
         for (let i = 0; i < valueField.length; i++) {
-          if (valueInput.includes(valueField[i])) {
+          if (valueInput.some(v => v == valueField[i])) {
             isShowField = true
             break
           }
         }
       } else {
-        isShowField = valueField.includes(valueInput)
+        isShowField =  Array.isArray(valueField)
+          ? valueField.some(v => v == valueInput)
+          : valueField.includes(valueInput);
       }
       break
     case 'not in':
       if (Array.isArray(valueInput) && Array.isArray(valueField)) {
         let includes = false
         for (let i = 0; i < valueField.length; i++) {
-          if (valueInput.includes(valueField[i])) {
+          if (valueInput.some(v => v == valueField[i])) {
             includes = true
             break
           }
         }
         isShowField = !includes
       } else {
-        isShowField = !valueField.includes(valueInput)
+        isShowField = Array.isArray(valueField)
+          ? !valueField.some(v => v == valueInput)
+          : !valueField.includes(valueInput);
       }
       break
   }

--- a/src/UI/resources/js/__tests__/Support/ShowWhen.test.js
+++ b/src/UI/resources/js/__tests__/Support/ShowWhen.test.js
@@ -1,14 +1,13 @@
 import {afterEach, beforeEach, describe, expect, it, jest} from '@jest/globals'
 
 import {
-  getInputs,
-  inputFieldName,
-  inputGetValue,
+  getShowWhenInputs,
   showWhenChange,
-  showWhenVisibilityChange,
+  showWhenUpdateVisibility,
 } from '../../Support/ShowWhen.js'
+import {inputFieldName, inputGetValue} from '../../Support/Forms.js'
 
-describe('getInputs', () => {
+describe('getShowWhenInputs', () => {
   let form
 
   beforeEach(() => {
@@ -36,7 +35,7 @@ describe('getInputs', () => {
   })
 
   it('should extract input values correctly', () => {
-    const inputs = getInputs('test-form')
+    const inputs = getShowWhenInputs('test-form')
 
     expect(inputs).toEqual({
       username: {value: 'john_doe', type: 'text'},
@@ -52,17 +51,17 @@ describe('getInputs', () => {
 
   it('should handle empty form gracefully', () => {
     document.body.innerHTML = `<form id="empty-form"></form>`
-    const inputs = getInputs('empty-form')
+    const inputs = getShowWhenInputs('empty-form')
     expect(inputs).toEqual({})
   })
 
   it('should extract values from data-show-when-field attributes', () => {
-    const inputs = getInputs('test-form')
+    const inputs = getShowWhenInputs('test-form')
     expect(inputs.dynamicField).toEqual({value: 'dynamicField', type: 'text'})
   })
 
   it('should extract values from data-show-when-column attributes', () => {
-    const inputs = getInputs('test-form')
+    const inputs = getShowWhenInputs('test-form')
     expect(inputs.columnField).toEqual({value: 'columnValue', type: 'text'})
   })
 })
@@ -130,32 +129,32 @@ describe('showWhenChange', () => {
       whenFields: [
         {changeField: 'field1', showField: 'field2', value: 'test-value', operator: '='},
       ],
-      showWhenVisibilityChange: jest.fn(),
-      getInputs: jest.fn().mockReturnValue({
+      showWhenUpdateVisibility: jest.fn(),
+      getShowWhenInputs: jest.fn().mockReturnValue({
         field1: {value: 'test-value', type: 'text'},
         field2: {value: '', type: 'text'},
       }),
     }
   })
 
-  it('should call showWhenVisibilityChange with correct parameters', () => {
+  it('should call showWhenUpdateVisibility with correct parameters', () => {
     showWhenChange.call(mockContext, 'field1', 'test-form')
 
-    expect(mockContext.showWhenVisibilityChange).toHaveBeenCalledWith(
+    expect(mockContext.showWhenUpdateVisibility).toHaveBeenCalledWith(
       [mockContext.whenFields[0]],
       'field2',
-      mockContext.getInputs('test-form'),
+      mockContext.getShowWhenInputs('test-form'),
       'test-form',
     )
   })
 
   it('should do nothing if the changed field is not in whenFields', () => {
     showWhenChange.call(mockContext, 'nonExistentField', 'test-form')
-    expect(mockContext.showWhenVisibilityChange).not.toHaveBeenCalled()
+    expect(mockContext.showWhenUpdateVisibility).not.toHaveBeenCalled()
   })
 })
 
-describe('showWhenVisibilityChange', () => {
+describe('showWhenUpdateVisibility', () => {
   let form, inputElement, mockContext
 
   beforeEach(() => {
@@ -170,7 +169,7 @@ describe('showWhenVisibilityChange', () => {
     inputElement = form.querySelector('[data-show-when-field="field2"]')
 
     mockContext = {
-      getInputs: jest.fn().mockReturnValue({
+      getShowWhenInputs: jest.fn().mockReturnValue({
         field1: {value: 'test-value', type: 'text'},
         field2: {value: '', type: 'text'},
       }),
@@ -180,10 +179,10 @@ describe('showWhenVisibilityChange', () => {
   it('should hide the field if conditions are not met', () => {
     const mockShowWhenFields = [{changeField: 'field1', value: 'wrong-value', operator: '='}]
 
-    showWhenVisibilityChange(
+    showWhenUpdateVisibility(
       mockShowWhenFields,
       'field2',
-      mockContext.getInputs('test-form'),
+      mockContext.getShowWhenInputs('test-form'),
       'test-form',
     )
 
@@ -193,10 +192,10 @@ describe('showWhenVisibilityChange', () => {
   it('should show the field if conditions are met', () => {
     const mockShowWhenFields = [{changeField: 'field1', value: 'test-value', operator: '='}]
 
-    showWhenVisibilityChange(
+    showWhenUpdateVisibility(
       mockShowWhenFields,
       'field2',
-      mockContext.getInputs('test-form'),
+      mockContext.getShowWhenInputs('test-form'),
       'test-form',
     )
 
@@ -206,7 +205,7 @@ describe('showWhenVisibilityChange', () => {
   it('should do nothing if inputElement is null', () => {
     document.body.innerHTML = `<form id="test-form"></form>` // Без полей
     expect(() => {
-      showWhenVisibilityChange([], 'field2', mockContext.getInputs('test-form'), 'test-form')
+      showWhenUpdateVisibility([], 'field2', mockContext.getShowWhenInputs('test-form'), 'test-form')
     }).not.toThrow()
   })
 })

--- a/src/UI/src/Collections/Fields.php
+++ b/src/UI/src/Collections/Fields.php
@@ -306,10 +306,9 @@ class Fields extends BaseCollection implements FieldsContract
                 ->replace('_', '.')
                 ->value();
 
-            return $field->modifyShowFieldName($showWhenName)
-                ->customAttributes([
-                    'data-show-when-field' => $showWhenName,
-                ]);
+            return $field->customAttributes([
+                'data-show-when-field' => $showWhenName,
+            ]);
         });
     }
 

--- a/src/UI/src/Components/FormBuilder.php
+++ b/src/UI/src/Components/FormBuilder.php
@@ -460,9 +460,9 @@ final class FormBuilder extends MoonShineComponent implements
      */
     protected function showWhenFields(FieldsContract $fields, array &$data): void
     {
-        foreach ($fields->whenFieldsConditions() as $whenConditions) {
-            foreach ($whenConditions as $value) {
-                $data[] = $value;
+        foreach ($fields->whenFieldsConditions() as $conditions) {
+            foreach ($conditions as $condition) {
+                $data[] = $condition;
             }
         }
 

--- a/src/UI/src/Fields/Field.php
+++ b/src/UI/src/Fields/Field.php
@@ -6,6 +6,7 @@ namespace MoonShine\UI\Fields;
 
 use Closure;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use MoonShine\Contracts\Core\PageContract;
 use MoonShine\Contracts\Core\ResourceContract;
@@ -17,6 +18,7 @@ use MoonShine\Support\Enums\HttpMethod;
 use MoonShine\Support\Enums\TextWrap;
 use MoonShine\UI\Components\Badge;
 use MoonShine\UI\Components\Link;
+use MoonShine\UI\Contracts\RangeFieldContract;
 use MoonShine\UI\Traits\Fields\Reactivity;
 use MoonShine\UI\Traits\Fields\WithBadge;
 use MoonShine\UI\Traits\Fields\WithHint;

--- a/src/UI/src/Fields/Field.php
+++ b/src/UI/src/Fields/Field.php
@@ -6,7 +6,6 @@ namespace MoonShine\UI\Fields;
 
 use Closure;
 use Illuminate\Contracts\Support\Renderable;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use MoonShine\Contracts\Core\PageContract;
 use MoonShine\Contracts\Core\ResourceContract;
@@ -18,7 +17,6 @@ use MoonShine\Support\Enums\HttpMethod;
 use MoonShine\Support\Enums\TextWrap;
 use MoonShine\UI\Components\Badge;
 use MoonShine\UI\Components\Link;
-use MoonShine\UI\Contracts\RangeFieldContract;
 use MoonShine\UI\Traits\Fields\Reactivity;
 use MoonShine\UI\Traits\Fields\WithBadge;
 use MoonShine\UI\Traits\Fields\WithHint;

--- a/src/UI/src/Fields/FormElement.php
+++ b/src/UI/src/Fields/FormElement.php
@@ -187,12 +187,6 @@ abstract class FormElement extends MoonShineComponent implements FormElementCont
 
     public function setColumn(string $column): static
     {
-        if ($this->showWhenState) {
-            foreach (array_keys($this->showWhenCondition) as $key) {
-                $this->showWhenCondition[$key]['showField'] = $column;
-            }
-        }
-
         $this->column = $column;
 
         return $this;

--- a/src/UI/src/Traits/Fields/RangeTrait.php
+++ b/src/UI/src/Traits/Fields/RangeTrait.php
@@ -99,8 +99,6 @@ trait RangeTrait
         $this->fromField = $fromField;
         $this->toField = $toField;
 
-        $this->modifyShowFieldRangeName();
-
         return $this;
     }
 

--- a/src/UI/src/Traits/Fields/ShowWhen.php
+++ b/src/UI/src/Traits/Fields/ShowWhen.php
@@ -4,44 +4,17 @@ declare(strict_types=1);
 
 namespace MoonShine\UI\Traits\Fields;
 
-use InvalidArgumentException;
+use MoonShine\Support\DTOs\ShowWhenCondition;
 use MoonShine\UI\Contracts\RangeFieldContract;
 
 trait ShowWhen
 {
-    /**
-     * @var string[]
-     */
-    public array $operators = [
-        '=',
-        '<',
-        '>',
-        '<=',
-        '>=',
-        '!=',
-        'in',
-        'not in',
-    ];
-
-    /**
-     * @var string[]
-     */
-    public array $arrayOperators = [
-        'in',
-        'not in',
-    ];
-
     public bool $showWhenState = false;
 
     /**
-     * @var array<array-key, mixed>
+     * @var array<array-key, ShowWhenCondition>
      */
     protected array $showWhenCondition = [];
-
-    /**
-     * @var array<array-key, mixed>
-     */
-    protected array $showWhenData = [];
 
     public function hasShowWhen(): bool
     {
@@ -49,65 +22,35 @@ trait ShowWhen
     }
 
     /**
-     * @return array<string, string>
+     * @return array<array-key, mixed>
      */
     public function getShowWhenCondition(): array
     {
-        return $this->showWhenCondition;
-    }
+        $data = [];
 
-    /*
-     * The "name" attribute in some fields may be changed after "showWhenCondition" is initialized,
-     * then we have to change showField value
-     */
-    public function modifyShowFieldName(string $name): static
-    {
-        $this->showWhenCondition = array_map(static function (array $item) use ($name): array {
-            $item['showField'] = $name;
-
-            return $item;
-        }, $this->showWhenCondition);
-
-        return $this;
-    }
-
-    public function modifyShowFieldRangeName(): static
-    {
-        if (! $this instanceof RangeFieldContract) {
-            return $this;
+        foreach ($this->showWhenCondition as $condition) {
+            if ($this instanceof RangeFieldContract) {
+                $data[] = $this->showWhenConditionToArray($condition, $this->getFromField(), 'from');
+                $data[] = $this->showWhenConditionToArray($condition, $this->getToField(), 'to');
+            } else {
+                $data[] = $this->showWhenConditionToArray($condition);
+            }
         }
 
-        $this->showWhenCondition = array_map(function (array $item): array {
-            $item['showField'] = $item['range_type'] === 'from'
-                ? $this->getNameAttribute($this->getFromField())
-                : $this->getNameAttribute($this->getToField());
-
-            return $item;
-        }, $this->showWhenCondition);
-
-        return $this;
+        return $data;
     }
 
     public function showWhen(
         string $column,
         mixed $operator = null,
-        mixed $value = null
+        mixed $value = null,
     ): static {
-        if ($this instanceof RangeFieldContract) {
-            $this->showWhenRange($column, $operator, $value);
-
-            return $this;
-        }
-
-        $this->showWhenData = $this->makeCondition(...\func_get_args());
-        [$column, $value, $operator] = $this->showWhenData;
         $this->showWhenState = true;
-
-        $this->showWhenCondition[] = $this->showWhenCondition(
-            $column,
-            $operator,
-            $value,
+        $condition = $this->makeCondition(
+            ...\func_get_args(),
         );
+
+        $this->showWhenCondition[] = $condition;
 
         return $this;
     }
@@ -115,49 +58,25 @@ trait ShowWhen
     public function showWhenRow(
         string $column,
         mixed $operator = null,
-        mixed $value = null
+        mixed $value = null,
     ): static {
-        $this->showWhenData = $this->makeCondition(...\func_get_args());
-        [$column, $value, $operator] = $this->showWhenData;
         $this->showWhenState = true;
 
-        $this->showWhenCondition[] = $this->showWhenCondition(
-            $column,
-            $operator,
-            $value,
-            isRowMode: true
+        $condition = $this->makeCondition(
+            ...\func_get_args(),
         );
 
-        return $this;
-    }
+        $condition->isRowMode = true;
 
-    /**
-     * @param array<array-key, mixed> $additionally
-     * @return array<array-key, mixed>
-     */
-    protected function showWhenCondition(
-        string $column,
-        mixed $operator = null,
-        mixed $value = null,
-        bool $isRowMode = false,
-        ?string $nameIndex = null,
-        array $additionally = []
-    ): array {
-        return [
-            'object_id' => (string) spl_object_id($this),
-            'showField' => $this->getNameAttribute($nameIndex),
-            'changeField' => $this->getDotNestedToName($column),
-            'operator' => $operator,
-            'value' => $value,
-            'is_row_mode' => $isRowMode,
-            ...$additionally,
-        ];
+        $this->showWhenCondition[] = $condition;
+
+        return $this;
     }
 
     public function showWhenDate(
         string $column,
         mixed $operator = null,
-        mixed $value = null
+        mixed $value = null,
     ): static {
         if (\func_num_args() === 2) {
             $value = $operator;
@@ -165,7 +84,7 @@ trait ShowWhen
 
         if (\is_array($value)) {
             foreach ($value as $key => $item) {
-                // Casting to Date type for javascript
+                // Casting to Date type for JavaScript
                 $value[$key] = strtotime((string) $item) * 1000;
             }
         } else {
@@ -179,100 +98,41 @@ trait ShowWhen
         return $this->showWhen($column, $operator, $value);
     }
 
-    protected function showWhenRange(
-        string $column,
-        mixed $operator = null,
-        mixed $value = null
-    ): static {
-        if (! $this instanceof RangeFieldContract) {
-            return $this;
+    /**
+     * @return array<string, mixed>
+     */
+    protected function showWhenConditionToArray(
+        ShowWhenCondition $condition,
+        ?string $nameIndex = null,
+        ?string $rangeType = null,
+    ): array {
+        $data = [
+            'object_id' => (string) spl_object_id($this),
+            'showField' => $this->getAttribute('data-show-when-field') ?? $this->getNameAttribute($nameIndex),
+            'changeField' => $this->getDotNestedToName($condition->column),
+            'operator' => $condition->operator,
+            'value' => $condition->value,
+            'is_row_mode' => $condition->isRowMode,
+        ];
+
+        if ($rangeType) {
+            $data['range_type'] = $rangeType;
         }
 
-        $this->showWhenData = $this->makeCondition(...\func_get_args());
-        [$column, $value, $operator] = $this->showWhenData;
-        $this->showWhenState = true;
-
-        $showWhenCondition = $this->showWhenCondition(
-            $column,
-            $operator,
-            $value,
-            nameIndex: $this->getFromField(),
-            additionally: [
-                'range_type' => 'from',
-            ]
-        );
-
-        $this->showWhenCondition[] = $showWhenCondition;
-
-        $showWhenCondition['showField'] = $this->getNameAttribute($this->getToField());
-        $showWhenCondition['range_type'] = 'to';
-        $this->showWhenCondition[] = $showWhenCondition;
-
-        return $this;
+        return $data;
     }
 
-    /**
-     * @return array<array-key, mixed>
-     */
     protected function makeCondition(
         string $column,
         mixed $operator = null,
-        mixed $value = null
-    ): array {
-        return [
+        mixed $value = null,
+        bool $isRowMode = false,
+    ): ShowWhenCondition {
+        return new ShowWhenCondition(
             $column,
-            ...$this->prepareValueAndOperator(
-                $value,
-                $operator,
-                \func_num_args() === 2
-            ),
-        ];
-    }
-
-    /**
-     * @return array<array-key, mixed>
-     */
-    protected function prepareValueAndOperator(
-        mixed $value,
-        mixed $operator = null,
-        bool $useDefault = false
-    ): array {
-        if ($useDefault) {
-            return [$operator, '='];
-        }
-
-        if ($this->isInvalidOperatorAndValue($operator, $value)) {
-            throw new InvalidArgumentException(
-                'Illegal operator and value combination.'
-            );
-        }
-
-        if ($this->isInvalidOperator($operator)) {
-            $value = $operator;
-            $operator = '=';
-        }
-
-        if (! \is_array($value) && \in_array($operator, $this->arrayOperators)) {
-            throw new InvalidArgumentException(
-                'Illegal operator and value combination. Value must be array type'
-            );
-        }
-
-        return [$value, $operator];
-    }
-
-    protected function isInvalidOperatorAndValue(mixed $operator, mixed $value): bool
-    {
-        return \is_null($value) && \in_array($operator, $this->operators) &&
-            ! \in_array($operator, ['=', '!=']);
-    }
-
-    protected function isInvalidOperator(mixed $operator): bool
-    {
-        return ! \is_string($operator) || (! \in_array(
-            strtolower($operator),
-            $this->operators,
-            true
-        ));
+            \func_num_args() === 2 ? '=' : $operator,
+            \func_num_args() === 2 ? $operator : $value,
+            isRowMode: $isRowMode,
+        );
     }
 }

--- a/src/UI/src/Traits/Fields/ShowWhen.php
+++ b/src/UI/src/Traits/Fields/ShowWhen.php
@@ -5,43 +5,17 @@ declare(strict_types=1);
 namespace MoonShine\UI\Traits\Fields;
 
 use InvalidArgumentException;
+use MoonShine\Support\DTOs\ShowWhenCondition;
 use MoonShine\UI\Contracts\RangeFieldContract;
 
 trait ShowWhen
 {
-    /**
-     * @var string[]
-     */
-    public array $operators = [
-        '=',
-        '<',
-        '>',
-        '<=',
-        '>=',
-        '!=',
-        'in',
-        'not in',
-    ];
-
-    /**
-     * @var string[]
-     */
-    public array $arrayOperators = [
-        'in',
-        'not in',
-    ];
-
     public bool $showWhenState = false;
 
     /**
-     * @var array<array-key, mixed>
+     * @var array<array-key, ShowWhenCondition>
      */
     protected array $showWhenCondition = [];
-
-    /**
-     * @var array<array-key, mixed>
-     */
-    protected array $showWhenData = [];
 
     public function hasShowWhen(): bool
     {
@@ -49,65 +23,35 @@ trait ShowWhen
     }
 
     /**
-     * @return array<string, string>
+     * @return array<array-key, ShowWhenCondition>
      */
     public function getShowWhenCondition(): array
     {
-        return $this->showWhenCondition;
-    }
+        $data = [];
 
-    /*
-     * The "name" attribute in some fields may be changed after "showWhenCondition" is initialized,
-     * then we have to change showField value
-     */
-    public function modifyShowFieldName(string $name): static
-    {
-        $this->showWhenCondition = array_map(static function (array $item) use ($name): array {
-            $item['showField'] = $name;
-
-            return $item;
-        }, $this->showWhenCondition);
-
-        return $this;
-    }
-
-    public function modifyShowFieldRangeName(): static
-    {
-        if (! $this instanceof RangeFieldContract) {
-            return $this;
+        foreach ($this->showWhenCondition as $condition) {
+            if($this instanceof RangeFieldContract) {
+                $data[] = $this->showWhenConditionToArray($condition, $this->getFromField(), 'from');
+                $data[] = $this->showWhenConditionToArray($condition, $this->getToField(), 'to');
+            } else {
+                $data[] = $this->showWhenConditionToArray($condition);
+            }
         }
 
-        $this->showWhenCondition = array_map(function (array $item): array {
-            $item['showField'] = $item['range_type'] === 'from'
-                ? $this->getNameAttribute($this->getFromField())
-                : $this->getNameAttribute($this->getToField());
-
-            return $item;
-        }, $this->showWhenCondition);
-
-        return $this;
+        return $data;
     }
 
     public function showWhen(
         string $column,
         mixed $operator = null,
-        mixed $value = null
+        mixed $value = null,
     ): static {
-        if ($this instanceof RangeFieldContract) {
-            $this->showWhenRange($column, $operator, $value);
-
-            return $this;
-        }
-
-        $this->showWhenData = $this->makeCondition(...\func_get_args());
-        [$column, $value, $operator] = $this->showWhenData;
         $this->showWhenState = true;
-
-        $this->showWhenCondition[] = $this->showWhenCondition(
-            $column,
-            $operator,
-            $value,
+        $condition = $this->makeCondition(
+            ...\func_get_args(),
         );
+
+        $this->showWhenCondition[] = $condition;
 
         return $this;
     }
@@ -115,50 +59,25 @@ trait ShowWhen
     public function showWhenRow(
         string $column,
         mixed $operator = null,
-        mixed $value = null
+        mixed $value = null,
     ): static {
-        $this->showWhenData = $this->makeCondition(...\func_get_args());
-        [$column, $value, $operator] = $this->showWhenData;
         $this->showWhenState = true;
 
-        $this->showWhenCondition[] = $this->showWhenCondition(
-            $column,
-            $operator,
-            $value,
-            isRowMode: true
+        $condition = $this->makeCondition(
+            ...\func_get_args(),
         );
 
-        return $this;
-    }
+        $condition->isRowMode = true;
 
-    /**
-     * @param array<array-key, mixed> $additionally
-     * @return array<array-key, mixed>
-     */
-    protected function showWhenCondition(
-        string $column,
-        mixed $operator = null,
-        mixed $value = null,
-        bool $isRowMode = false,
-        ?string $nameIndex = null,
-        array $additionally = []
-    ): array
-    {
-        return [
-            'object_id' => (string) spl_object_id($this),
-            'showField' => $this->getNameAttribute($nameIndex),
-            'changeField' => $this->getDotNestedToName($column),
-            'operator' => $operator,
-            'value' => $value,
-            'is_row_mode' => $isRowMode,
-            ...$additionally
-        ];
+        $this->showWhenCondition[] = $condition;
+
+        return $this;
     }
 
     public function showWhenDate(
         string $column,
         mixed $operator = null,
-        mixed $value = null
+        mixed $value = null,
     ): static {
         if (\func_num_args() === 2) {
             $value = $operator;
@@ -166,7 +85,7 @@ trait ShowWhen
 
         if (\is_array($value)) {
             foreach ($value as $key => $item) {
-                // Casting to Date type for javascript
+                // Casting to Date type for JavaScript
                 $value[$key] = strtotime((string) $item) * 1000;
             }
         } else {
@@ -180,100 +99,39 @@ trait ShowWhen
         return $this->showWhen($column, $operator, $value);
     }
 
-    protected function showWhenRange(
-        string $column,
-        mixed $operator = null,
-        mixed $value = null
-    ): static {
-        if (! $this instanceof RangeFieldContract) {
-            return $this;
+    protected function showWhenConditionToArray(
+        ShowWhenCondition $condition,
+        ?string $nameIndex = null,
+        ?string $rangeType = null,
+    ): array
+    {
+        $data = [
+            'object_id' => (string) spl_object_id($this),
+            'showField' => $this->getNameAttribute($nameIndex),
+            'changeField' => $this->getDotNestedToName($condition->column),
+            'operator' => $condition->operator,
+            'value' => $condition->value,
+            'is_row_mode' => $condition->isRowMode,
+        ];
+
+        if($rangeType) {
+            $data['range_type'] = $rangeType;
         }
 
-        $this->showWhenData = $this->makeCondition(...\func_get_args());
-        [$column, $value, $operator] = $this->showWhenData;
-        $this->showWhenState = true;
-
-        $showWhenCondition = $this->showWhenCondition(
-            $column,
-            $operator,
-            $value,
-            nameIndex: $this->getFromField(),
-            additionally: [
-                'range_type' => 'from',
-            ]
-        );
-
-        $this->showWhenCondition[] = $showWhenCondition;
-
-        $showWhenCondition['showField'] = $this->getNameAttribute($this->getToField());
-        $showWhenCondition['range_type'] = 'to';
-        $this->showWhenCondition[] = $showWhenCondition;
-
-        return $this;
+        return $data;
     }
 
-    /**
-     * @return array<array-key, mixed>
-     */
     protected function makeCondition(
         string $column,
         mixed $operator = null,
-        mixed $value = null
-    ): array {
-        return [
+        mixed $value = null,
+        bool $isRowMode = false,
+    ): ShowWhenCondition {
+        return new ShowWhenCondition(
             $column,
-            ...$this->prepareValueAndOperator(
-                $value,
-                $operator,
-                \func_num_args() === 2
-            ),
-        ];
-    }
-
-    /**
-     * @return array<array-key, mixed>
-     */
-    protected function prepareValueAndOperator(
-        mixed $value,
-        mixed $operator = null,
-        bool $useDefault = false
-    ): array {
-        if ($useDefault) {
-            return [$operator, '='];
-        }
-
-        if ($this->isInvalidOperatorAndValue($operator, $value)) {
-            throw new InvalidArgumentException(
-                'Illegal operator and value combination.'
-            );
-        }
-
-        if ($this->isInvalidOperator($operator)) {
-            $value = $operator;
-            $operator = '=';
-        }
-
-        if (! \is_array($value) && \in_array($operator, $this->arrayOperators)) {
-            throw new InvalidArgumentException(
-                'Illegal operator and value combination. Value must be array type'
-            );
-        }
-
-        return [$value, $operator];
-    }
-
-    protected function isInvalidOperatorAndValue(mixed $operator, mixed $value): bool
-    {
-        return \is_null($value) && \in_array($operator, $this->operators) &&
-            ! \in_array($operator, ['=', '!=']);
-    }
-
-    protected function isInvalidOperator(mixed $operator): bool
-    {
-        return ! \is_string($operator) || (! \in_array(
-            strtolower($operator),
-            $this->operators,
-            true
-        ));
+            func_num_args() === 2 ? '=' : $operator,
+            func_num_args() === 2 ? $operator : $value,
+            isRowMode: $isRowMode,
+        );
     }
 }

--- a/src/UI/src/Traits/Fields/ShowWhen.php
+++ b/src/UI/src/Traits/Fields/ShowWhen.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MoonShine\UI\Traits\Fields;
 
-use InvalidArgumentException;
 use MoonShine\Support\DTOs\ShowWhenCondition;
 use MoonShine\UI\Contracts\RangeFieldContract;
 
@@ -107,7 +106,7 @@ trait ShowWhen
     {
         $data = [
             'object_id' => (string) spl_object_id($this),
-            'showField' => $this->getNameAttribute($nameIndex),
+            'showField' => $this->getAttribute('data-show-when-field') ?? $this->getNameAttribute($nameIndex),
             'changeField' => $this->getDotNestedToName($condition->column),
             'operator' => $condition->operator,
             'value' => $condition->value,

--- a/src/UI/src/Traits/Fields/WithQuickFormElementAttributes.php
+++ b/src/UI/src/Traits/Fields/WithQuickFormElementAttributes.php
@@ -36,17 +36,6 @@ trait WithQuickFormElementAttributes
     {
         $this->wrapName = $wrapName;
 
-        // because showWhen can be declared after
-        if ($this->showWhenState) {
-            [$column, $value, $operator] = $this->showWhenData;
-
-            $this->showWhenCondition = (new Collection($this->showWhenCondition))
-                ->reject(fn (array $data, int|string $index): bool => $data['object_id'] === spl_object_id($this))
-                ->toArray();
-
-            return $this->showWhen($column, $value, $operator);
-        }
-
         return $this;
     }
 

--- a/tests/Unit/Fields/ShowWhenTraitTest.php
+++ b/tests/Unit/Fields/ShowWhenTraitTest.php
@@ -21,6 +21,11 @@ beforeEach(function (): void {
             return 'field1';
         }
 
+        public function getAttribute(string $key, mixed $default = null): mixed
+        {
+            return null;
+        }
+
         protected function getDotNestedToName(string $value): string
         {
             return $value;
@@ -32,6 +37,7 @@ it('default operator', function (): void {
     $this->showWhenTest->showWhen('field2', 1);
 
     $condition = $this->showWhenTest->getShowWhenCondition()[0];
+
     expect($condition['showField'])->toBe('field1')
         ->and($condition['changeField'])->toBe('field2')
         ->and($condition['operator'])->toBe('=')
@@ -65,6 +71,7 @@ it('error operator', function (): void {
     $this->showWhenTest->showWhen('field2', '%', 1);
 
     $condition = $this->showWhenTest->getShowWhenCondition()[0];
+
     expect($condition['showField'])->toBe('field1')
         ->and($condition['changeField'])->toBe('field2')
         ->and($condition['operator'])->toBe('=')


### PR DESCRIPTION
## Summary

  Fixes #1921 - resolves the issue where `showWhen()` conditional visibility was not working correctly when combined with `multiple()`
   on Select fields.

  ## Changes

  ### Backend
  and type checking for array-based operators
  - Added `showWhenRow()` method to `HasShowWhenContract` interface for row-mode conditional visibility
  - Refactored `ShowWhen` trait to use the new DTO structure
  - Updated `Fields` collection, `FormBuilder`, and `FormElement` to integrate with the new condition validation system

  ### Frontend
  - Renamed `getInputs()` → `getShowWhenInputs()` for clarity
  - Renamed `showWhenVisibilityChange()` → `showWhenUpdateVisibility()` for better semantics
  - Extracted `inputGetValue()` and `inputFieldName()` helpers into `Forms.js` module
  - Refactored `ShowWhen.js` to align with new API contract

  ### Tests
  - Updated `ShowWhenTraitTest.php` with validation and operator handling tests
  - Updated `ShowWhen.test.js` to reflect new function names
