### PR TITLE
Fix Unique Validation Rules to Use Model Classes

### DIFF
--- a/src/Laravel/src/Http/Requests/ProfileFormRequest.php
+++ b/src/Laravel/src/Http/Requests/ProfileFormRequest.php
@@ -29,7 +29,7 @@ class ProfileFormRequest extends MoonShineFormRequest
             $username => blank($username) ? null : [
                 'required',
                 Rule::unique(
-                    MoonShineAuth::getModel()->getTable(),
+                    MoonShineAuth::getModel()::class,
                     moonshineConfig()->getUserField('username')
                 )->ignore(MoonShineAuth::getGuard()->id()),
             ],

--- a/src/Laravel/src/Pages/MoonShineUser/MoonShineUserFormPage.php
+++ b/src/Laravel/src/Pages/MoonShineUser/MoonShineUserFormPage.php
@@ -98,7 +98,7 @@ final class MoonShineUserFormPage extends FormPage
                 'bail',
                 'required',
                 'email',
-                Rule::unique('moonshine_users')->ignoreModel($item->getOriginal()),
+                Rule::unique($item->getOriginal()::class)->ignoreModel($item->getOriginal()),
             ],
             'avatar' => ['sometimes', 'nullable', 'image', 'mimes:jpeg,jpg,png,gif'],
             'password' => [


### PR DESCRIPTION
## What was changed
Updated unique validation rules to use model class references instead of table names to ensure proper database connection handling.

## Why?
When using table names ('moonshine_users') directly in validation rules, Laravel's validator could incorrectly determine the database connection, particularly when:

Models use non-default database connections - A model might be configured to use a different connection than the default, but table names don't carry this information

Multi-database/multi-tenant setups

Complex application architectures with multiple DB connections

## Checklist

- Tested
    - [x] Tested manually
