### PR TITLE
fix: improve modal transition effects

### DIFF
--- a/src/UI/resources/views/shared/img-popup.blade.php
+++ b/src/UI/resources/views/shared/img-popup.blade.php
@@ -1,18 +1,17 @@
 <div x-data="{ open : false, src : '', auto: true, wide: false, styles: ''}">
     <template
         @img-popup.window="open = true; src = $event.detail.src; auto = $event.detail.auto; wide = $event.detail.wide; styles = $event.detail.styles"
-        x-if="open"
         x-teleport="body"
     >
         <div class="modal-template">
             <div
                 x-show="open"
-                x-transition:enter="transition ease-out duration-300"
-                x-transition:enter-start="opacity-0 -translate-y-10"
-                x-transition:enter-end="opacity-100 translate-y-0"
+                x-transition:enter="transition ease-out duration-250"
+                x-transition:enter-start="opacity-0 scale-95"
+                x-transition:enter-end="opacity-100 scale-100"
                 x-transition:leave="transition ease-in duration-150"
-                x-transition:leave-start="opacity-100 translate-y-0"
-                x-transition:leave-end="opacity-0 -translate-y-10"
+                x-transition:leave-start="opacity-100 scale-100"
+                x-transition:leave-end="opacity-0 scale-95"
                 class="modal"
                 aria-modal="true"
                 role="dialog"


### PR DESCRIPTION
# #1947  Исправление анимации popup изображения.

## Что изменено?
1. В файле src/UI/resources/views/shared/img-popup.blade.php убрал  x-if="open" у template. С ним анимация некорректно работала, а так же дублировалось модальное окно в dom и показывалось одновременно. Накладывалось друг на друга. Если точнее то проблема была не из-за анимации а из-за дублирования html контента модального окна
2. Скопирована анимация с модального окна в файле src/UI/resources/views/components/modal.blade.php для однообразия эффектов открытия модального окна

## Зачем?
1. Дергалось модальное окно при открытии
2. Мусор в dom дереве

## Тестирование:
    - [x] Ручное тестирование открытия popup изображение в таблице на индексной странице и в таблице редактирования в модальном окне (Модалка в модалке)

## Что желательно сделать в будущем:
1. Сделать рефактор модального окна img-popup. Сейчас оно вроде как модальное, но не совсем. Потому что используется верстка от модального окна, но не используется компонент Modal.js. По этому не работает кнопка Escape для закрытия image popup
2. Сейчас при открытии модального окна не заблокирована прокрутка страницы. (на body не добавляется стиль overflow: hidden). По этому прокручивается фон страницы. Если размер по "y" модального окна слишком большой, то появляются 2 полосы прокрутки от body и от контейнера модального окна.
3. Добавить e2e тестирование. Сейчас часто один фикс порождает другую проблему.