### PR TITLE
Fixed modal column selection window does not expand

### DIFF
--- a/src/UI/resources/css/components/dropdowns.css
+++ b/src/UI/resources/css/components/dropdowns.css
@@ -35,6 +35,13 @@
   }
 }
 
+/* Dropdown modifiers */
+
+.dropdown-body--column-selection {
+  --ms-dropdown-content-max-width: none;
+  white-space: nowrap;
+}
+
 /* Dropdown heading */
 
 .dropdown-heading {

--- a/src/UI/src/Components/Table/TableBuilder.php
+++ b/src/UI/src/Components/Table/TableBuilder.php
@@ -691,6 +691,7 @@ final class TableBuilder extends IterableComponent implements
 
             $components[] = Dropdown::make()
                 ->strategy('auto')
+                ->class('dropdown-body--column-selection')
                 ->content(
                     fn (): Div => Div::make($selectionFields)->class('p-2 space-y-2')
                 )


### PR DESCRIPTION
Fixed an issue where column selection with text longer than 7 characters was moved to a new line instead of expanding the block.