### PR TITLE
fix: remove duplicate query on resource item pages

### DIFF
--- a/src/Laravel/src/Traits/Resource/ResourceModelQuery.php
+++ b/src/Laravel/src/Traits/Resource/ResourceModelQuery.php
@@ -104,9 +104,7 @@ trait ResourceModelQuery
 
         $item = $builder->find($this->getItemID());
 
-        return $item !== null ? $this->getCaster()->cast(
-            $builder->find($this->getItemID())
-        ) : null;
+        return $item !== null ? $this->getCaster()->cast($item) : null;
     }
 
     protected function modifyItemQueryBuilder(Builder $builder): Builder


### PR DESCRIPTION
 Исправление дублирования запросов на страницах просмотра/редактирования элемента:

```sql
select * from `moonshine_users` where `moonshine_users`.`id` = '1' limit 1
select * from `moonshine_users` where `moonshine_users`.`id` = '1' and `moonshine_users`.`id` = '1' limit 1
```
