### PR TITLE
feat: Pretty limit

### DIFF
--- a/src/UI/resources/css/components/pretty-limit.css
+++ b/src/UI/resources/css/components/pretty-limit.css
@@ -1,0 +1,255 @@
+/* PrettyLimit basic */
+
+.pretty-limit {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  max-width: var(--pretty-limit-width, 150px);
+  vertical-align: middle;
+}
+
+/* Ghost element to maintain height when inner becomes absolute */
+.pretty-limit::before {
+  content: '\00a0';
+  display: block;
+  padding-block: var(--ms-pretty-limit-padding-y, --spacing(1.5));
+  font-size: var(--ms-pretty-limit-font-size, var(--text-sm));
+  visibility: hidden;
+}
+
+.pretty-limit-inner {
+  position: absolute;
+  inset-inline-start: 0;
+  top: 0;
+  display: inline-flex;
+  align-items: center;
+  max-width: var(--pretty-limit-width, 150px);
+  padding-block: var(--ms-pretty-limit-padding-y, --spacing(1.5));
+  padding-inline: var(--ms-pretty-limit-padding-x, --spacing(3));
+  border-radius: var(--ms-pretty-limit-radius, var(--radius-lg));
+  background-color: var(--ms-pretty-limit-bg-color, var(--color-base-200));
+  color: var(--ms-pretty-limit-color, var(--color-base-text));
+  font-size: var(--ms-pretty-limit-font-size, var(--text-sm));
+  transition-property: box-shadow;
+  transition-duration: var(--default-transition-duration);
+  transition-timing-function: var(--default-transition-timing-function);
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: var(--color-base-700);
+  }
+}
+
+.pretty-limit-label {
+  flex-shrink: 0;
+  padding-inline-end: --spacing(2);
+  margin-inline-end: --spacing(2);
+  border-inline-end: 1px solid var(--ms-pretty-limit-border-color, currentColor);
+  opacity: 0.5;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.pretty-limit-value {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Hover: expand without affecting layout */
+.pretty-limit:hover .pretty-limit-inner {
+  max-width: none;
+  z-index: 10;
+  box-shadow: var(--shadow-lg);
+  background-color: var(--ms-pretty-limit-bg-color-hover, var(--color-base-200));
+  color: var(--ms-pretty-limit-color-hover, var(--ms-pretty-limit-color, var(--color-base-text)));
+
+  @variant dark {
+    background-color: var(--ms-pretty-limit-bg-color-hover, var(--color-base-700));
+  }
+}
+
+.pretty-limit:hover .pretty-limit-value {
+  overflow: visible;
+}
+
+/* Allow overflow in table cells */
+td:has(.pretty-limit:hover),
+th:has(.pretty-limit:hover) {
+  overflow: visible;
+}
+
+/* PrettyLimit themes */
+
+.pretty-limit-primary {
+  --ms-pretty-limit-bg-color: var(--color-primary);
+  --ms-pretty-limit-color: var(--color-primary-text);
+  --ms-pretty-limit-color-hover: var(--color-primary-text);
+  --ms-pretty-limit-bg-color-hover: var(--color-primary);
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: var(--color-primary);
+    --ms-pretty-limit-color: var(--color-primary-text);
+  }
+}
+
+.pretty-limit-secondary {
+  --ms-pretty-limit-bg-color: var(--color-secondary);
+  --ms-pretty-limit-color: var(--color-secondary-text);
+  --ms-pretty-limit-color-hover: var(--color-secondary-text);
+  --ms-pretty-limit-bg-color-hover: var(--color-secondary);
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: var(--color-secondary);
+    --ms-pretty-limit-color: var(--color-secondary-text);
+  }
+}
+
+.pretty-limit-success {
+  --ms-pretty-limit-bg-color: --alpha(var(--color-success) / 0.15);
+  --ms-pretty-limit-bg-color-hover: var(--color-success);
+  --ms-pretty-limit-color: var(--color-success-text);
+  --ms-pretty-limit-color-hover: #fff;
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: --alpha(var(--color-success) / 0.25);
+    --ms-pretty-limit-bg-color-hover: var(--color-success);
+    --ms-pretty-limit-color-hover: #fff;
+  }
+}
+
+.pretty-limit-warning {
+  --ms-pretty-limit-bg-color: --alpha(var(--color-warning) / 0.15);
+  --ms-pretty-limit-bg-color-hover: var(--color-warning);
+  --ms-pretty-limit-color: var(--color-warning-text);
+  --ms-pretty-limit-color-hover: #fff;
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: --alpha(var(--color-warning) / 0.25);
+    --ms-pretty-limit-bg-color-hover: var(--color-warning);
+    --ms-pretty-limit-color-hover: #fff;
+  }
+}
+
+.pretty-limit-error {
+  --ms-pretty-limit-bg-color: --alpha(var(--color-error) / 0.15);
+  --ms-pretty-limit-bg-color-hover: var(--color-error);
+  --ms-pretty-limit-color: var(--color-error-text);
+  --ms-pretty-limit-color-hover: #fff;
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: --alpha(var(--color-error) / 0.25);
+    --ms-pretty-limit-bg-color-hover: var(--color-error);
+    --ms-pretty-limit-color-hover: #fff;
+  }
+}
+
+.pretty-limit-info {
+  --ms-pretty-limit-bg-color: --alpha(var(--color-info) / 0.15);
+  --ms-pretty-limit-bg-color-hover: var(--color-info);
+  --ms-pretty-limit-color: var(--color-info-text);
+  --ms-pretty-limit-color-hover: #fff;
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: --alpha(var(--color-info) / 0.25);
+    --ms-pretty-limit-bg-color-hover: var(--color-info);
+    --ms-pretty-limit-color-hover: #fff;
+  }
+}
+
+.pretty-limit-purple {
+  --ms-pretty-limit-bg-color: --alpha(var(--color-purple-500) / 0.15);
+  --ms-pretty-limit-bg-color-hover: var(--color-purple-500);
+  --ms-pretty-limit-color: var(--color-purple-700);
+  --ms-pretty-limit-color-hover: #fff;
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: --alpha(var(--color-purple-500) / 0.25);
+    --ms-pretty-limit-bg-color-hover: var(--color-purple-600);
+    --ms-pretty-limit-color: var(--color-purple-300);
+    --ms-pretty-limit-color-hover: #fff;
+  }
+}
+
+.pretty-limit-pink {
+  --ms-pretty-limit-bg-color: --alpha(var(--color-pink-500) / 0.15);
+  --ms-pretty-limit-bg-color-hover: var(--color-pink-500);
+  --ms-pretty-limit-color: var(--color-pink-700);
+  --ms-pretty-limit-color-hover: #fff;
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: --alpha(var(--color-pink-500) / 0.25);
+    --ms-pretty-limit-bg-color-hover: var(--color-pink-600);
+    --ms-pretty-limit-color: var(--color-pink-300);
+    --ms-pretty-limit-color-hover: #fff;
+  }
+}
+
+.pretty-limit-blue {
+  --ms-pretty-limit-bg-color: --alpha(var(--color-blue-500) / 0.15);
+  --ms-pretty-limit-bg-color-hover: var(--color-blue-500);
+  --ms-pretty-limit-color: var(--color-blue-700);
+  --ms-pretty-limit-color-hover: #fff;
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: --alpha(var(--color-blue-500) / 0.25);
+    --ms-pretty-limit-bg-color-hover: var(--color-blue-600);
+    --ms-pretty-limit-color: var(--color-blue-300);
+    --ms-pretty-limit-color-hover: #fff;
+  }
+}
+
+.pretty-limit-green {
+  --ms-pretty-limit-bg-color: --alpha(var(--color-green-500) / 0.15);
+  --ms-pretty-limit-bg-color-hover: var(--color-green-500);
+  --ms-pretty-limit-color: var(--color-green-700);
+  --ms-pretty-limit-color-hover: #fff;
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: --alpha(var(--color-green-500) / 0.25);
+    --ms-pretty-limit-bg-color-hover: var(--color-green-600);
+    --ms-pretty-limit-color: var(--color-green-300);
+    --ms-pretty-limit-color-hover: #fff;
+  }
+}
+
+.pretty-limit-yellow {
+  --ms-pretty-limit-bg-color: --alpha(var(--color-yellow-500) / 0.15);
+  --ms-pretty-limit-bg-color-hover: var(--color-yellow-400);
+  --ms-pretty-limit-color: var(--color-yellow-700);
+  --ms-pretty-limit-color-hover: var(--color-yellow-900);
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: --alpha(var(--color-yellow-500) / 0.25);
+    --ms-pretty-limit-bg-color-hover: var(--color-yellow-500);
+    --ms-pretty-limit-color: var(--color-yellow-300);
+    --ms-pretty-limit-color-hover: var(--color-yellow-900);
+  }
+}
+
+.pretty-limit-red {
+  --ms-pretty-limit-bg-color: --alpha(var(--color-red-500) / 0.15);
+  --ms-pretty-limit-bg-color-hover: var(--color-red-500);
+  --ms-pretty-limit-color: var(--color-red-700);
+  --ms-pretty-limit-color-hover: #fff;
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: --alpha(var(--color-red-500) / 0.25);
+    --ms-pretty-limit-bg-color-hover: var(--color-red-600);
+    --ms-pretty-limit-color: var(--color-red-300);
+    --ms-pretty-limit-color-hover: #fff;
+  }
+}
+
+.pretty-limit-gray {
+  --ms-pretty-limit-bg-color: --alpha(var(--color-gray-500) / 0.15);
+  --ms-pretty-limit-bg-color-hover: var(--color-gray-500);
+  --ms-pretty-limit-color: var(--color-gray-700);
+  --ms-pretty-limit-color-hover: #fff;
+
+  @variant dark {
+    --ms-pretty-limit-bg-color: --alpha(var(--color-gray-500) / 0.25);
+    --ms-pretty-limit-bg-color-hover: var(--color-gray-600);
+    --ms-pretty-limit-color: var(--color-gray-300);
+    --ms-pretty-limit-color-hover: #fff;
+  }
+}

--- a/src/UI/resources/css/main.css
+++ b/src/UI/resources/css/main.css
@@ -48,6 +48,7 @@
 @import './components/toasts.css' layer(components);
 @import './components/skeleton.css' layer(components);
 @import './components/snippet.css' layer(components);
+@import './components/pretty-limit.css' layer(components);
 
 /* Pages */
 @import './pages/authentication.css';

--- a/src/UI/resources/views/components/pretty-limit.blade.php
+++ b/src/UI/resources/views/components/pretty-limit.blade.php
@@ -1,0 +1,15 @@
+@props([
+    'color' => 'secondary',
+    'label' => null,
+    'limit' => 150,
+])
+<span {{ $attributes->merge(['class' => 'pretty-limit']) }}
+      @if($limit) style="--pretty-limit-width: {{ $limit }}px" @endif
+>
+    <span class="pretty-limit-inner {{ $color ? 'pretty-limit-'.$color : '' }}">
+        @if($label)
+            <span class="pretty-limit-label">{{ $label }}</span>
+        @endif
+        <span class="pretty-limit-value">{{ $slot }}</span>
+    </span>
+</span>

--- a/src/UI/src/Components/PrettyLimit.php
+++ b/src/UI/src/Components/PrettyLimit.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\UI\Components;
+
+use Illuminate\View\ComponentSlot;
+use InvalidArgumentException;
+use MoonShine\Support\Enums\Color;
+
+/**
+ * @method static static make(string $value = '', string|null|Color $color = Color::SECONDARY, ?string $label = null, ?int $limit = 150)
+ */
+final class PrettyLimit extends MoonShineComponent
+{
+    protected string $view = 'moonshine::components.pretty-limit';
+
+    public function __construct(
+        public string $value = '',
+        public string|null|Color $color = Color::SECONDARY,
+        public ?string $label = null,
+        public ?int $limit = 150,
+    ) {
+        parent::__construct();
+
+        if ($this->color === null) {
+            $this->color = Color::SECONDARY;
+        }
+
+        if ($this->limit !== null && $this->limit < 100) {
+            throw new InvalidArgumentException('Limit should be more than 100');
+        }
+
+        $this->color = $this->color instanceof Color ? $this->color->value : $this->color;
+    }
+
+    public function value(string $value): self
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function color(string|Color $color): self
+    {
+        $this->color = $color instanceof Color ? $color->value : $color;
+
+        return $this;
+    }
+
+    public function label(?string $label): self
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    public function limit(?int $limit): self
+    {
+        if ($this->limit !== null && $this->limit < 100) {
+            throw new InvalidArgumentException('Limit should be more than 100');
+        }
+
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function viewData(): array
+    {
+        return [
+            'slot' => new ComponentSlot($this->value),
+        ];
+    }
+}

--- a/src/UI/src/Fields/Text.php
+++ b/src/UI/src/Fields/Text.php
@@ -16,11 +16,13 @@ use MoonShine\UI\Traits\Fields\WithDefaultValue;
 use MoonShine\UI\Traits\Fields\WithEscapedValue;
 use MoonShine\UI\Traits\Fields\WithInputExtensions;
 use MoonShine\UI\Traits\Fields\WithMask;
+use MoonShine\UI\Traits\Fields\WithPrettyLimit;
 
 class Text extends Field implements HasDefaultValueContract, CanBeString, HasUpdateOnPreviewContract
 {
     use WithInputExtensions;
     use WithMask;
+    use WithPrettyLimit;
     use WithDefaultValue;
     use HasPlaceholder;
     use UpdateOnPreview;

--- a/src/UI/src/Traits/Fields/WithPrettyLimit.php
+++ b/src/UI/src/Traits/Fields/WithPrettyLimit.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\UI\Traits\Fields;
+
+use Closure;
+use MoonShine\Support\Enums\Color;
+use MoonShine\UI\Components\PrettyLimit;
+
+trait WithPrettyLimit
+{
+    /**
+     * @param  string|Color|(Closure(string|int|null $value, static $ctx): null|Color|string)|null  $color = null
+     * @param  string|(Closure(string|int|null $value, static $ctx): null|string)|null  $label = null
+     * @param  int|(Closure(string|int|null $value, static $ctx): null|int)|null  $limit = null
+     *
+     */
+    public function prettyLimit(
+        null|Color|string|Closure $color = null,
+        null|string|Closure $label = null,
+        null|int|Closure $limit = null,
+    ): static {
+        return $this->changePreview(
+            static fn (string|int|null $value, self $ctx): string => $value
+                ? (string) PrettyLimit::make(
+                    value: (string) $value,
+                    color: $color instanceof Closure ? $color($value, $ctx) : $color,
+                    label: $label instanceof Closure ? $label($value, $ctx) : $label,
+                    limit: $limit instanceof Closure ? $limit($value, $ctx) : $limit,
+                )
+                : (string) $value
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Added new `PrettyLimit` component for displaying limited content in Blade templates and fields. Content is constrained by width, truncated with ellipsis, and fully expanded on hover.

## Features

### 🎨 New PrettyLimit Component
- Displays text with width constraint (150px by default)
- Full text shows on cursor hover
- Supports all color schemes (PRIMARY, SECONDARY, SUCCESS, ERROR, WARNING, INFO, PURPLE, PINK, BLUE, GREEN, YELLOW, RED, GRAY)
- Optional label for additional context
- Dark mode support for all colors

### 📝 Field Integration
- Added `WithPrettyLimit` trait for use in fields
- Integrated into `Text` field
- Support for Closure for dynamic color, label, and limit values

### 🎯 Usage Examples

**In components:**
```php
PrettyLimit::make('Sample long content in tariff name', color: Color::PRIMARY, label: '2 weeks')
