### PR TITLE
fix: Stabs with the tests

### DIFF
--- a/src/Laravel/stubs/pest.stub
+++ b/src/Laravel/stubs/pest.stub
@@ -25,7 +25,7 @@ it('detail page', function (): void {
 
     actingAs($this->user, 'moonshine')
         ->get(
-            $this->resource->getDetailPageUrl($item)
+            $this->resource->getDetailPageUrl($item->getKey())
         )
         ->assertOk();
 });
@@ -43,7 +43,7 @@ it('edit page', function (): void {
 
     actingAs($this->user, 'moonshine')
         ->get(
-            $this->resource->getFormPageUrl($item)
+            $this->resource->getFormPageUrl($item->getKey())
         )
         ->assertOk();
 });

--- a/src/Laravel/stubs/test.stub
+++ b/src/Laravel/stubs/test.stub
@@ -56,7 +56,7 @@ class DummyResourceTest extends TestCase
         $item = {model}::factory()->create();
 
         $response = $this->get(
-            $this->getResource()->getDetailPageUrl($item)
+            $this->getResource()->getDetailPageUrl($item->getKey())
         );
 
         $response->assertSuccessful();
@@ -78,7 +78,7 @@ class DummyResourceTest extends TestCase
         $item = {model}::factory()->create();
 
         $response = $this->get(
-            $this->getResource()->getFormPageUrl($item)
+            $this->getResource()->getFormPageUrl($item->getKey())
         );
 
         $response->assertSuccessful();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed stabs with tests

## Why?
After creating the test with the command
```php artisan moonshine:resource ResourceName --test```
the tests fail with an error on the detail page and on the edit page of the element.

<img width="1788" height="816" alt="image" src="https://github.com/user-attachments/assets/6bca86f1-45ac-49f8-bc7b-a2d90741f026" />

