### PR TITLE
feat: opt-in HTML escaping for security (v4.x compatible)

### DIFF
--- a/src/Crud/src/Components/Paginator.php
+++ b/src/Crud/src/Components/Paginator.php
@@ -42,6 +42,8 @@ final class Paginator extends MoonShineComponent
      */
     protected function viewData(): array
     {
+        $escapeUi = (bool) $this->getCore()->getConfig()->get('html_escaping.ui_elements', false);
+
         /**
          * @var (PaginatorContract<array-key, mixed>|CursorPaginator<array-key, mixed>)&Arrayable<array-key, mixed> $data
          */
@@ -49,16 +51,24 @@ final class Paginator extends MoonShineComponent
 
         $pageName = method_exists($data, 'getPageName') ? $data->getPageName() : 'page';
 
+        /**
+         * @var (PaginatorContract<array-key, mixed>|CursorPaginator<array-key, mixed>)&Arrayable<array-key, mixed> $appended
+         */
+        $appended = $data->appends(
+            $this->getCore()->getRequest()->getExcept($pageName)
+        );
+
         $paginator = (new PaginatorCaster(
-            $data->appends(
-                $this->getCore()->getRequest()->getExcept($pageName)
-            )->toArray(),
+            $appended->toArray(),
             $data->items()
         ))->cast();
 
         /**
          * @var array<string, mixed>
          */
-        return $paginator->toArray();
+        return [
+            ...$paginator->toArray(),
+            'escapeUi' => $escapeUi,
+        ];
     }
 }

--- a/src/Laravel/config/moonshine.php
+++ b/src/Laravel/config/moonshine.php
@@ -66,6 +66,14 @@ return [
     'disk_options' => [],
     'cache' => 'file',
 
+    // Opt-in HTML escaping (v4 compatibility defaults)
+    'html_escaping' => [
+        'hints' => false,
+        'labels' => false,
+        'card_values' => false,
+        'ui_elements' => false,
+    ],
+
     // Authentication and profile
     'auth' => [
         'enabled' => true,

--- a/src/MenuManager/src/MenuElement.php
+++ b/src/MenuManager/src/MenuElement.php
@@ -75,10 +75,14 @@ abstract class MenuElement implements MenuElementContract, HasViewRendererContra
      */
     protected function systemViewData(): array
     {
+        $escapeUi = (bool) $this->getCore()->getConfig()->get('html_escaping.ui_elements', false);
+
         return [
             'type' => class_basename($this),
             'attributes' => $this->getAttributes(),
             'label' => $this->getLabel(),
+            'labelRaw' => $this->isLabelRaw(),
+            'escapeUi' => $escapeUi,
             'previewLabel' => Str::of($this->getLabel())->limit(3),
             'icon' => $this->getIcon(),
             'isActive' => $this->isActive(),

--- a/src/MenuManager/src/MenuItem.php
+++ b/src/MenuManager/src/MenuItem.php
@@ -256,6 +256,8 @@ class MenuItem extends MenuElement implements WithBadgeContract
             ->customView('moonshine::components.menu.item-link', [
                 'url' => $this->getUrl(),
                 'label' => $this->getLabel(),
+                'labelRaw' => $this->isLabelRaw(),
+                'escapeUi' => (bool) $this->getCore()->getConfig()->get('html_escaping.ui_elements', false),
                 'onlyIcon' => $this->isOnlyIcon(),
                 'icon' => $this->getIcon(),
                 'top' => $this->isTopMode(),

--- a/src/UI/resources/views/components/action-button.blade.php
+++ b/src/UI/resources/views/components/action-button.blade.php
@@ -7,6 +7,8 @@
     'component' => null,
     'badge' => false,
     'raw' => false,
+    'labelRaw' => false,
+    'escapeUi' => false,
 ])
 @if($attributes->has('type'))
     <x-moonshine::form.button
@@ -17,7 +19,11 @@
 
         <x-slot:icon>{!! $icon !!}</x-slot:icon>
 
-        {!! $label !!}
+        @if(! $escapeUi || $labelRaw)
+            {!! $label !!}
+        @else
+            {{ $label }}
+        @endif
 
         @if($badge !== false)
             <x-moonshine::badge color="">{{ $badge }}</x-moonshine::badge>
@@ -34,7 +40,11 @@
 
         <x-slot:icon>{!! $icon !!}</x-slot:icon>
 
-        {!! $label !!}
+        @if(! $escapeUi || $labelRaw)
+            {!! $label !!}
+        @else
+            {{ $label }}
+        @endif
     </x-moonshine::link-button>
 @endif
 

--- a/src/UI/resources/views/components/badge.blade.php
+++ b/src/UI/resources/views/components/badge.blade.php
@@ -1,5 +1,15 @@
 @props([
     'color' => null,
     'icon' => null,
+    'valueRaw' => false,
+    'escapeUi' => false,
 ])
-<span {{ $attributes->merge(['class' => 'badge'.($color ? ' badge-'.$color : '')])->class(['inline-flex items-center gap-1 max-w-full' => $icon?->isNotEmpty()]) }}>{{ $icon ?? '' }}{{ $slot }}</span>
+<span {{ $attributes->merge(['class' => 'badge'.($color ? ' badge-'.$color : '')])->class(['inline-flex items-center gap-1 max-w-full' => $icon?->isNotEmpty()]) }}>
+    {{ $icon ?? '' }}
+
+    @if(! $escapeUi || $valueRaw)
+        {!! $slot !!}
+    @else
+        {!! e((string) $slot) !!}
+    @endif
+</span>

--- a/src/UI/resources/views/components/card.blade.php
+++ b/src/UI/resources/views/components/card.blade.php
@@ -5,6 +5,8 @@
     'thumbnail' => '',
     'overlay' => false,
     'values' => [],
+    'valuesRaw' => false,
+    'escapeValues' => false,
     'header' => null,
     'actions' => null,
 ])
@@ -53,7 +55,13 @@
                 @foreach($values as $label => $value)
                     <tr>
                         <th width="40%">{{ $label }}:</th>
-                        <td width="60%">{!! $value !!}</td>
+                        <td width="60%">
+                            @if(! $escapeValues || $valuesRaw)
+                                {!! $value !!}
+                            @else
+                                {{ $value }}
+                            @endif
+                        </td>
                     </tr>
                 @endforeach
             </tbody>

--- a/src/UI/resources/views/components/dropdown.blade.php
+++ b/src/UI/resources/views/components/dropdown.blade.php
@@ -7,6 +7,10 @@
     'searchPlaceholder' => '',
     'footer' => null,
     'strategy' => 'fixed',
+    'escapeUi' => false,
+    'titleRaw' => false,
+    'itemsRaw' => false,
+    'footerRaw' => false,
 ])
 <div x-data="dropdown"
      @click.outside="closeDropdown"
@@ -21,7 +25,13 @@
 
     <div {{ $attributes->merge(['class' => 'dropdown-body']) }}>
         @if($title ?? false)
-            <div class="dropdown-heading">{{ $title }}</div>
+            <div class="dropdown-heading">
+                @if(! $escapeUi || $titleRaw)
+                    {!! $title !!}
+                @else
+                    {{ $title }}
+                @endif
+            </div>
         @endif
 
         <div class="dropdown-content">
@@ -44,7 +54,11 @@
                             class="dropdown-menu-item"
                             @if($searchable) x-ref="dropdown_{{$key}}" @endif
                         >
-                            {!! $item !!}
+                            @if(! $escapeUi || $itemsRaw)
+                                {!! $item !!}
+                            @else
+                                {{ $item }}
+                            @endif
                         </li>
                     @endforeach
                 </ul>
@@ -53,7 +67,11 @@
 
         @if($footer ?? false)
             <div class="dropdown-footer">
-                {{ $footer ?? '' }}
+                @if(! $escapeUi || $footerRaw)
+                    {!! $footer ?? '' !!}
+                @else
+                    {!! e((string) ($footer ?? '')) !!}
+                @endif
             </div>
         @endif
     </div>

--- a/src/UI/resources/views/components/form/fieldset.blade.php
+++ b/src/UI/resources/views/components/form/fieldset.blade.php
@@ -1,8 +1,16 @@
 @props([
     'label' => '',
+    'labelRaw' => false,
+    'escapeLabel' => false,
 ])
 <fieldset {{ $attributes }}>
-    <legend>{!! $label !!}</legend>
+    <legend>
+        @if(! $escapeLabel || $labelRaw)
+            {!! $label !!}
+        @else
+            {{ $label }}
+        @endif
+    </legend>
 
     {{ $slot }}
 </fieldset>

--- a/src/UI/resources/views/components/form/hint.blade.php
+++ b/src/UI/resources/views/components/form/hint.blade.php
@@ -1,1 +1,11 @@
-<div {{ $attributes->class(['form-hint']) }}>{!! $slot ?? '' !!}</div>
+@props([
+    'escape' => false,
+    'raw' => false,
+])
+<div {{ $attributes->class(['form-hint']) }}>
+    @if(! $escape || $raw)
+        {!! $slot ?? '' !!}
+    @else
+        {{ $slot ?? '' }}
+    @endif
+</div>

--- a/src/UI/resources/views/components/form/wrapper.blade.php
+++ b/src/UI/resources/views/components/form/wrapper.blade.php
@@ -1,5 +1,7 @@
 @props([
     'label' => '',
+    'labelRaw' => false,
+    'escapeLabel' => false,
     'formName' => '',
     'fieldErrors' => [],
     'beforeLabel' => false,
@@ -20,7 +22,11 @@
             ::for="$id('field-{{ $formName }}')"
         >
             {{ $beforeLabel && $insideLabel ? $slot : '' }}
-            {!! $label !!}
+            @if(! $escapeLabel || $labelRaw)
+                {!! $label !!}
+            @else
+                {{ $label }}
+            @endif
             {{ !$beforeLabel && $insideLabel ? $slot : '' }}
         </x-moonshine::form.label>
     @endif

--- a/src/UI/resources/views/components/menu/divider.blade.php
+++ b/src/UI/resources/views/components/menu/divider.blade.php
@@ -1,6 +1,16 @@
 @props([
     'label',
+    'labelRaw' => false,
+    'escapeUi' => false,
 ])
 <li {{ $attributes->class('menu-divider') }}>
-    {!! $label? "<span>$label</span>" : '' !!}
+    @if($label)
+        <span>
+            @if(! $escapeUi || $labelRaw)
+                {!! $label !!}
+            @else
+                {{ $label }}
+            @endif
+        </span>
+    @endif
 </li>

--- a/src/UI/resources/views/components/menu/group.blade.php
+++ b/src/UI/resources/views/components/menu/group.blade.php
@@ -1,5 +1,7 @@
 @props([
     'label' => '',
+    'labelRaw' => false,
+    'escapeUi' => false,
     'previewLabel' => '',
     'icon' => '',
     'onlyIcon' => false,
@@ -39,7 +41,13 @@
             </div>
         @endif
 
-        <span class="menu-text @if($onlyIcon) menu-only-icon @endif">{{ $label }}</span>
+        <span class="menu-text @if($onlyIcon) menu-only-icon @endif">
+            @if(! $escapeUi || $labelRaw)
+                {!! $label !!}
+            @else
+                {{ $label }}
+            @endif
+        </span>
         <span class="menu-arrow">
             <x-moonshine::icon
                 icon="chevron-down"

--- a/src/UI/resources/views/components/menu/item-link.blade.php
+++ b/src/UI/resources/views/components/menu/item-link.blade.php
@@ -1,5 +1,7 @@
 @props([
     'label' => '',
+    'labelRaw' => false,
+    'escapeUi' => false,
     'previewLabel' => '',
     'url' => 'javascript:void(0);',
     'icon' => '',
@@ -27,7 +29,13 @@
         </div>
     @endif
 
-    <span class="menu-text @if($onlyIcon) menu-only-icon @endif">{{ $label }}</span>
+    <span class="menu-text @if($onlyIcon) menu-only-icon @endif">
+        @if(! $escapeUi || $labelRaw)
+            {!! $label !!}
+        @else
+            {{ $label }}
+        @endif
+    </span>
 
     @if($badge !== false)
         <span class="menu-badge">{{ $badge }}</span>

--- a/src/UI/resources/views/components/metrics/value.blade.php
+++ b/src/UI/resources/views/components/metrics/value.blade.php
@@ -1,9 +1,12 @@
 @props([
     'title' => '',
+    'titleRaw' => false,
+    'escapeUi' => false,
     'icon' => '',
     'progress' => false,
     'value' => 0,
     'simpleValue' => '',
+    'simpleValueRaw' => false,
 ])
 <div {{ $attributes->merge(['class' => 'report-card']) }}>
     @if($icon)
@@ -23,7 +26,19 @@
     @endif
 
     <div class="report-card-body">
-        <div class="report-card-value">{!! $simpleValue !== '' ? $simpleValue : $value !!}</div>
-        <h5 class="report-card-title">{!! $title !!}</h5>
+        <div class="report-card-value">
+            @if(! $escapeUi || $simpleValueRaw)
+                {!! $simpleValue !== '' ? $simpleValue : $value !!}
+            @else
+                {{ $simpleValue !== '' ? $simpleValue : $value }}
+            @endif
+        </div>
+        <h5 class="report-card-title">
+            @if(! $escapeUi || $titleRaw)
+                {!! $title !!}
+            @else
+                {{ $title }}
+            @endif
+        </h5>
     </div>
 </div>

--- a/src/UI/resources/views/components/metrics/wrapped/value.blade.php
+++ b/src/UI/resources/views/components/metrics/wrapped/value.blade.php
@@ -1,11 +1,14 @@
 @props([
     'label' => '',
+    'labelRaw' => false,
+    'escapeUi' => false,
     'icon' => '',
     'columnSpanValue' => 12,
     'adaptiveColumnSpanValue' => 12,
     'isProgress' => false,
     'valueResult' => 0,
     'simpleValue' => 0,
+    'simpleValueRaw' => false,
 ])
 <x-moonshine::layout.column
     :colSpan="$columnSpanValue"
@@ -20,6 +23,9 @@
             :progress="$isProgress"
             :value="$valueResult"
             :simpleValue="$simpleValue"
+            :titleRaw="$labelRaw"
+            :simpleValueRaw="$simpleValueRaw"
+            :escapeUi="$escapeUi"
         />
     </x-moonshine::layout.box>
 </x-moonshine::layout.column>

--- a/src/UI/resources/views/components/pagination.blade.php
+++ b/src/UI/resources/views/components/pagination.blade.php
@@ -13,6 +13,7 @@
     'total' => 0,
     'links' => [],
     'translates' => [],
+    'escapeUi' => false,
 ])
 
 @if($simple)
@@ -26,13 +27,25 @@
                         href="{{ $prev_page_url }}"
                         @if($async) @click.prevent="asyncRequest" @endif
                         class="pagination-link pagination-link--first"
-                        title="{!! $translates['previous']  !!}"
+                        @if(! $escapeUi)
+                            title="{!! $translates['previous']  !!}"
+                        @else
+                            title="{{ $translates['previous']  }}"
+                        @endif
                     >
-                        {!! $translates['previous'] !!}
+                        @if(! $escapeUi)
+                            {!! $translates['previous'] !!}
+                        @else
+                            {{ $translates['previous'] }}
+                        @endif
                     </a>
                 @else
                     <span class="pagination-link _is-disabled">
-                        {!! $translates['previous'] !!}
+                        @if(! $escapeUi)
+                            {!! $translates['previous'] !!}
+                        @else
+                            {{ $translates['previous'] }}
+                        @endif
                     </span>
                 @endif
             </li>
@@ -44,13 +57,25 @@
                         href="{{ $next_page_url }}"
                         @if($async) @click.prevent="asyncRequest" @endif
                         class="pagination-link pagination-link--last"
-                        title="{!! $translates['next']  !!}"
+                        @if(! $escapeUi)
+                            title="{!! $translates['next']  !!}"
+                        @else
+                            title="{{ $translates['next']  }}"
+                        @endif
                     >
-                        {!! $translates['next'] !!}
+                        @if(! $escapeUi)
+                            {!! $translates['next'] !!}
+                        @else
+                            {{ $translates['next'] }}
+                        @endif
                     </a>
                 @else
                     <span class="pagination-link _is-disabled">
-                        {!! $translates['next'] !!}
+                        @if(! $escapeUi)
+                            {!! $translates['next'] !!}
+                        @else
+                            {{ $translates['next'] }}
+                        @endif
                     </span>
                 @endif
             </li>
@@ -66,7 +91,11 @@
                     <a href="{{ $prev_page_url }}"
                        @if($async) @click.prevent="asyncRequest" @endif
                        class="pagination-link pagination-link--first"
-                       title="{!! $translates['previous']  !!}"
+                       @if(! $escapeUi)
+                           title="{!! $translates['previous']  !!}"
+                       @else
+                           title="{{ $translates['previous']  }}"
+                       @endif
                     >
                         <x-moonshine::icon icon="chevron-double-left" />
                     </a>
@@ -87,7 +116,11 @@
                        @if($async) @click.prevent="asyncRequest" @endif
                        class="pagination-link @if($link['active']) _is-active @endif"
                     >
-                        {!! $link['label'] !!}
+                        @if(! $escapeUi)
+                            {!! $link['label'] !!}
+                        @else
+                            {{ $link['label'] }}
+                        @endif
                     </a>
                 </li>
                 @endif
@@ -98,7 +131,11 @@
                     <a href="{{ $next_page_url }}"
                        @if($async) @click.prevent="asyncRequest" @endif
                        class="pagination-link pagination-link--last"
-                       title="{!! $translates['next']  !!}"
+                       @if(! $escapeUi)
+                           title="{!! $translates['next']  !!}"
+                       @else
+                           title="{{ $translates['next']  }}"
+                       @endif
                     >
                         <x-moonshine::icon icon="chevron-double-right" />
                     </a>
@@ -106,17 +143,33 @@
             @endif
         </ul>
         <div class="pagination-results">
-            {!! $translates['showing']  !!}
+            @if(! $escapeUi)
+                {!! $translates['showing']  !!}
+            @else
+                {{ $translates['showing']  }}
+            @endif
             @if ($from)
                 {{ $from }}
-                {!! $translates['to']  !!}
+                @if(! $escapeUi)
+                    {!! $translates['to']  !!}
+                @else
+                    {{ $translates['to']  }}
+                @endif
                 {{ $to }}
             @else
                 {{ $per_page }}
             @endif
-            {!! $translates['of']  !!}
+            @if(! $escapeUi)
+                {!! $translates['of']  !!}
+            @else
+                {{ $translates['of']  }}
+            @endif
             {{ $total }}
-            {!! $translates['results']  !!}
+            @if(! $escapeUi)
+                {!! $translates['results']  !!}
+            @else
+                {{ $translates['results']  }}
+            @endif
         </div>
     </div>
     <!-- END: Pagination -->

--- a/src/UI/resources/views/components/popover.blade.php
+++ b/src/UI/resources/views/components/popover.blade.php
@@ -2,6 +2,8 @@
     'title' => '',
     'placement' => 'right',
     'trigger',
+    'escapeUi' => false,
+    'triggerRaw' => false,
 ])
 <span
     {{ $attributes }}
@@ -9,6 +11,17 @@
     title="{{ $title }}"
     x-data="popover({placement: '{{ $placement }}'})"
 >
-    {!! $trigger !!}
-    <div class="hidden popover-body-content">{!! $slot !!}</div>
+    @if(! $escapeUi || $triggerRaw)
+        {!! $trigger !!}
+    @else
+        {!! e((string) $trigger) !!}
+    @endif
+
+    <div class="hidden popover-body-content">
+        @if(! $escapeUi)
+            {!! $slot !!}
+        @else
+            {!! e((string) $slot) !!}
+        @endif
+    </div>
 </span>

--- a/src/UI/resources/views/components/tabs.blade.php
+++ b/src/UI/resources/views/components/tabs.blade.php
@@ -3,6 +3,7 @@
     'active' => null,
     'justifyAlign' => 'start',
     'isVertical' => false,
+    'escapeUi' => false,
 ])
 @if($tabs !== [])
     <!-- Tabs -->
@@ -20,7 +21,11 @@
                             type="button"
                     >
                         {!! $tab['icon'] !!}
-                        {!! $tab['label'] !!}
+                        @if(! $escapeUi || ($tab['labelRaw'] ?? false))
+                            {!! $tab['label'] !!}
+                        @else
+                            {{ $tab['label'] }}
+                        @endif
                     </button>
                 </li>
             @endforeach

--- a/src/UI/resources/views/fields/fieldset.blade.php
+++ b/src/UI/resources/views/fields/fieldset.blade.php
@@ -2,7 +2,12 @@
     'label' => '',
     'fields' => [],
 ])
-<x-moonshine::form.fieldset :label="$label" :attributes="$attributes">
+<x-moonshine::form.fieldset
+    :label="$label"
+    :labelRaw="$labelRaw"
+    :escapeLabel="$escapeLabel"
+    :attributes="$attributes"
+>
     <div class="space-elements">
         <x-moonshine::fields-group
             :components="$fields"

--- a/src/UI/resources/views/fields/textarea.blade.php
+++ b/src/UI/resources/views/fields/textarea.blade.php
@@ -6,4 +6,4 @@
     :attributes="$attributes->merge([
         'aria-label' => $label ?? '',
     ])"
->{!! $value ?? '' !!}</x-moonshine::form.textarea>
+>{{ $value ?? '' }}</x-moonshine::form.textarea>

--- a/src/UI/src/Components/ActionButton.php
+++ b/src/UI/src/Components/ActionButton.php
@@ -210,7 +210,9 @@ class ActionButton extends MoonShineComponent implements
      */
     public function dispatchEvent(array|string $events, array $exclude = [], bool $withoutPayload = false): static
     {
-        if (! $this->getAttributes()->has('x-data')) {
+        $attributes = $this->getAttributes();
+
+        if (! $attributes->has('x-data')) {
             $this->xDataMethod('actionButton');
         }
 
@@ -566,11 +568,15 @@ class ActionButton extends MoonShineComponent implements
      */
     protected function viewData(): array
     {
+        $escapeUi = (bool) $this->getCore()->getConfig()->get('html_escaping.ui_elements', false);
+
         return [
             'inDropdown' => $this->isInDropdown(),
             'hasComponent' => $this->hasComponent(),
             'component' => $this->hasComponent() ? $this->getComponent() : '',
             'label' => $this->getLabel(),
+            'labelRaw' => $this->isLabelRaw(),
+            'escapeUi' => $escapeUi,
             'url' => $this->getUrl(),
             'icon' => $this->getIcon(),
             'badge' => $this->hasBadge() ? $this->getBadge() : false,

--- a/src/UI/src/Components/Badge.php
+++ b/src/UI/src/Components/Badge.php
@@ -17,6 +17,8 @@ final class Badge extends MoonShineComponent
 
     protected string $view = 'moonshine::components.badge';
 
+    protected bool $valueRaw = false;
+
     public function __construct(
         public string $value = '',
         public string|Color $color = Color::PURPLE,
@@ -31,14 +33,39 @@ final class Badge extends MoonShineComponent
         }
     }
 
+    public function value(string $value): static
+    {
+        $this->value = $value;
+        $this->valueRaw = false;
+
+        return $this;
+    }
+
+    public function valueHtml(string $value): static
+    {
+        $this->value = $value;
+        $this->valueRaw = true;
+
+        return $this;
+    }
+
+    public function isValueRaw(): bool
+    {
+        return $this->valueRaw;
+    }
+
     /**
      * @return array<string, mixed>
      */
     protected function viewData(): array
     {
+        $escapeUi = (bool) $this->getCore()->getConfig()->get('html_escaping.ui_elements', false);
+
         return [
             'slot' => new ComponentSlot($this->value),
             'icon' => new ComponentSlot($this->getIcon()),
+            'valueRaw' => $this->isValueRaw(),
+            'escapeUi' => $escapeUi,
         ];
     }
 }

--- a/src/UI/src/Components/Card.php
+++ b/src/UI/src/Components/Card.php
@@ -21,6 +21,8 @@ final class Card extends MoonShineComponent
 
     protected Closure|string $actions = '';
 
+    protected bool $valuesRaw = false;
+
     /**
      * @param  (Closure(self):string)|string  $title
      * @param  (Closure(self): string[])|string[]|string  $thumbnail
@@ -86,8 +88,25 @@ final class Card extends MoonShineComponent
     public function values(Closure|array $values): self
     {
         $this->values = $values;
+        $this->valuesRaw = false;
 
         return $this;
+    }
+
+    /**
+     * @param  (Closure(self): array<string, mixed>)|array<string, mixed>  $values
+     */
+    public function valuesHtml(Closure|array $values): self
+    {
+        $this->values = $values;
+        $this->valuesRaw = true;
+
+        return $this;
+    }
+
+    public function isValuesRaw(): bool
+    {
+        return $this->valuesRaw;
     }
 
     public function overlay(): self
@@ -102,6 +121,8 @@ final class Card extends MoonShineComponent
      */
     protected function viewData(): array
     {
+        $escapeValues = (bool) $this->getCore()->getConfig()->get('html_escaping.card_values', false);
+
         return [
             'title' => value($this->title, $this),
             'url' => value($this->url, $this),
@@ -109,6 +130,8 @@ final class Card extends MoonShineComponent
             'overlay' => $this->overlay,
             'subtitle' => value($this->subtitle, $this),
             'values' => value($this->values, $this),
+            'valuesRaw' => $this->isValuesRaw(),
+            'escapeValues' => $escapeValues,
             'slot' => $this->getSlot(),
             'header' => new ComponentSlot(
                 value($this->header, $this),

--- a/src/UI/src/Components/Dropdown.php
+++ b/src/UI/src/Components/Dropdown.php
@@ -15,6 +15,12 @@ final class Dropdown extends MoonShineComponent
 {
     protected string $view = 'moonshine::components.dropdown';
 
+    protected bool $titleRaw = false;
+
+    protected bool $itemsRaw = false;
+
+    protected bool $footerRaw = false;
+
     /**
      * @var array<string, mixed>
      */
@@ -54,6 +60,18 @@ final class Dropdown extends MoonShineComponent
     public function items(Closure|array $items): self
     {
         $this->items = $items;
+        $this->itemsRaw = false;
+
+        return $this;
+    }
+
+    /**
+     * @param  (Closure(self): string[])|string[]  $items
+     */
+    public function itemsHtml(Closure|array $items): self
+    {
+        $this->items = $items;
+        $this->itemsRaw = true;
 
         return $this;
     }
@@ -99,8 +117,48 @@ final class Dropdown extends MoonShineComponent
     public function footer(Closure|string $value): self
     {
         $this->footer = $value;
+        $this->footerRaw = false;
 
         return $this;
+    }
+
+    public function footerHtml(Closure|string $value): self
+    {
+        $this->footer = $value;
+        $this->footerRaw = true;
+
+        return $this;
+    }
+
+    public function title(?string $title): self
+    {
+        $this->title = $title;
+        $this->titleRaw = false;
+
+        return $this;
+    }
+
+    public function titleHtml(?string $title): self
+    {
+        $this->title = $title;
+        $this->titleRaw = true;
+
+        return $this;
+    }
+
+    public function isTitleRaw(): bool
+    {
+        return $this->titleRaw;
+    }
+
+    public function isItemsRaw(): bool
+    {
+        return $this->itemsRaw;
+    }
+
+    public function isFooterRaw(): bool
+    {
+        return $this->footerRaw;
     }
 
 
@@ -116,10 +174,16 @@ final class Dropdown extends MoonShineComponent
      */
     protected function viewData(): array
     {
+        $escapeUi = (bool) $this->getCore()->getConfig()->get('html_escaping.ui_elements', false);
+
         return [
             'toggler' => new ComponentSlot(value($this->toggler, $this), $this->togglerAttributes),
             'slot' => new ComponentSlot(value($this->content, $this)),
             'footer' => new ComponentSlot(value($this->footer, $this)),
+            'titleRaw' => $this->isTitleRaw(),
+            'itemsRaw' => $this->isItemsRaw(),
+            'footerRaw' => $this->isFooterRaw(),
+            'escapeUi' => $escapeUi,
             'searchable' => $this->searchable,
             'searchPlaceholder' => value($this->searchPlaceholder, $this),
             'items' => value($this->items, $this),

--- a/src/UI/src/Components/Metrics/Wrapped/Metric.php
+++ b/src/UI/src/Components/Metrics/Wrapped/Metric.php
@@ -50,9 +50,13 @@ abstract class Metric extends MoonShineComponent implements HasIconContract, Has
      */
     protected function systemViewData(): array
     {
+        $escapeUi = (bool) $this->getCore()->getConfig()->get('html_escaping.ui_elements', false);
+
         return [
             ...parent::systemViewData(),
             'label' => $this->getLabel(),
+            'labelRaw' => $this->isLabelRaw(),
+            'escapeUi' => $escapeUi,
             'icon' => $this->getIcon(6, $this->iconColor),
             'columnSpanValue' => $this->getColumnSpanValue(),
             'adaptiveColumnSpanValue' => $this->getAdaptiveColumnSpanValue(),

--- a/src/UI/src/Components/Metrics/Wrapped/ValueMetric.php
+++ b/src/UI/src/Components/Metrics/Wrapped/ValueMetric.php
@@ -16,13 +16,29 @@ class ValueMetric extends Metric
 
     protected string $valueFormat = '{value}';
 
+    protected bool $simpleValueRaw = false;
+
     protected bool $progress = false;
 
     public function valueFormat(string|Closure $value): static
     {
         $this->valueFormat = value($value, $this->value);
+        $this->simpleValueRaw = false;
 
         return $this;
+    }
+
+    public function valueFormatHtml(string|Closure $value): static
+    {
+        $this->valueFormat = value($value, $this->value);
+        $this->simpleValueRaw = true;
+
+        return $this;
+    }
+
+    public function isSimpleValueRaw(): bool
+    {
+        return $this->simpleValueRaw;
     }
 
     public function getValueResult(): string|float|int
@@ -85,6 +101,7 @@ class ValueMetric extends Metric
             'isProgress' => $this->isProgress(),
             'valueResult' => $this->getValueResult(),
             'simpleValue' => $this->getSimpleValue(),
+            'simpleValueRaw' => $this->isSimpleValueRaw(),
         ];
     }
 }

--- a/src/UI/src/Components/Popover.php
+++ b/src/UI/src/Components/Popover.php
@@ -15,6 +15,8 @@ final class Popover extends MoonShineComponent
 
     protected string $view = 'moonshine::components.popover';
 
+    protected bool $triggerRaw = false;
+
     public function __construct(
         public string $title,
         public string $trigger = '',
@@ -34,6 +36,34 @@ final class Popover extends MoonShineComponent
         ]);
     }
 
+    public function title(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function trigger(string $trigger): self
+    {
+        $this->trigger = $trigger;
+        $this->triggerRaw = false;
+
+        return $this;
+    }
+
+    public function triggerHtml(string $trigger): self
+    {
+        $this->trigger = $trigger;
+        $this->triggerRaw = true;
+
+        return $this;
+    }
+
+    public function isTriggerRaw(): bool
+    {
+        return $this->triggerRaw;
+    }
+
     protected function prepareBeforeRender(): void
     {
         $this->customAttributes([
@@ -43,8 +73,12 @@ final class Popover extends MoonShineComponent
 
     protected function viewData(): array
     {
+        $escapeUi = (bool) $this->getCore()->getConfig()->get('html_escaping.ui_elements', false);
+
         return [
             'slot' => $this->getSlot(),
+            'escapeUi' => $escapeUi,
+            'triggerRaw' => $this->isTriggerRaw(),
         ];
     }
 }

--- a/src/UI/src/Components/Tabs.php
+++ b/src/UI/src/Components/Tabs.php
@@ -83,7 +83,9 @@ class Tabs extends AbstractWithComponents
      */
     public function getActive(): string|int|null
     {
-        return $this->getTabs()->firstWhere('active', true)?->getId();
+        $active = $this->getTabs()->firstWhere('active', true);
+
+        return $active instanceof Tab ? $active->getId() : null;
     }
 
     /**
@@ -109,6 +111,7 @@ class Tabs extends AbstractWithComponents
     {
         /** @var Collection<array-key, Tab> $tabs */
         $tabs = $this->getTabs();
+        $escapeUi = (bool) $this->getCore()->getConfig()->get('html_escaping.ui_elements', false);
 
         return [
             'tabs' => $tabs
@@ -118,6 +121,7 @@ class Tabs extends AbstractWithComponents
             'active' => $this->getActive(),
             'justifyAlign' => $this->getJustifyAlign(),
             'isVertical' => $this->isVertical(),
+            'escapeUi' => $escapeUi,
         ];
     }
 

--- a/src/UI/src/Components/Tabs/Tab.php
+++ b/src/UI/src/Components/Tabs/Tab.php
@@ -123,6 +123,7 @@ class Tab extends AbstractWithComponents implements HasLabelContract, HasIconCon
         return [
             'icon' => $this->getIcon(6),
             'label' => $this->getLabel(),
+            'labelRaw' => $this->isLabelRaw(),
             'labelAttributes' => $this->labelAttributes,
             'id' => $this->getId(),
             'content' => Components::make(

--- a/src/UI/src/Fields/FieldContainer.php
+++ b/src/UI/src/Fields/FieldContainer.php
@@ -29,13 +29,19 @@ final class FieldContainer extends MoonShineComponent
     ) {
         parent::__construct();
 
-        $this->attributes = $this->field
-            ->getWrapperAttributes()
-            ->merge(['required' => $this->field->getAttribute('required')]);
+        $wrapperAttributes = $this->field->getWrapperAttributes();
+
+        $wrapperAttributes = $wrapperAttributes->merge([
+            'required' => $this->field->getAttribute('required'),
+        ]);
+
+        $this->attributes = $wrapperAttributes;
     }
 
     protected function prepareBeforeRender(): void
     {
+        $escapeHint = (bool) $this->getCore()->getConfig()->get('html_escaping.hints', false);
+
         if (! $this->field->isPreviewMode() && $this->field->hasLink()) {
             $link = Link::make(
                 $this->field->getLinkValue(),
@@ -53,10 +59,16 @@ final class FieldContainer extends MoonShineComponent
         }
 
         if ($hint = $this->field->getHint()) {
+            $hintRaw = method_exists($this->field, 'isHintRaw')
+                ? (bool) \call_user_func([$this->field, 'isHintRaw'])
+                : false;
+
             $this->afterInner = new ComponentSlot(
                 $this->getCore()->getRenderer()->render('moonshine::components.form.hint', [
                     'attributes' => new MoonShineComponentAttributeBag(),
                     'slot' => $hint,
+                    'escape' => $escapeHint,
+                    'raw' => $hintRaw,
                 ])->render()
             );
         }
@@ -64,8 +76,15 @@ final class FieldContainer extends MoonShineComponent
 
     protected function viewData(): array
     {
+        $escapeLabel = (bool) $this->getCore()->getConfig()->get('html_escaping.labels', false);
+        $labelRaw = method_exists($this->field, 'isLabelRaw')
+            ? (bool) \call_user_func([$this->field, 'isLabelRaw'])
+            : false;
+
         return [
             'label' => $this->field->getLabel(),
+            'labelRaw' => $labelRaw,
+            'escapeLabel' => $escapeLabel,
             'formName' => $this->field->getFormName(),
 
             'errors' => data_get($this->field->getErrors(), $this->field->getNameDot()),

--- a/src/UI/src/Fields/Fieldset.php
+++ b/src/UI/src/Fields/Fieldset.php
@@ -146,8 +146,12 @@ class Fieldset extends Field implements HasFieldsContract, WrapperWithApplyContr
      */
     protected function viewData(): array
     {
+        $escapeLabel = (bool) $this->getCore()->getConfig()->get('html_escaping.labels', false);
+
         return [
             'fields' => $this->getPreparedFields(),
+            'labelRaw' => $this->isLabelRaw(),
+            'escapeLabel' => $escapeLabel,
         ];
     }
 }

--- a/src/UI/src/Fields/Text.php
+++ b/src/UI/src/Fields/Text.php
@@ -66,10 +66,6 @@ class Text extends Field implements HasDefaultValueContract, CanBeString, HasUpd
 
     protected function prepareRequestValue(mixed $value): mixed
     {
-        if (\is_string($value)) {
-            return $this->isUnescape() ? $value : $this->escapeValue($value);
-        }
-
         return $value;
     }
 

--- a/src/UI/src/Fields/Textarea.php
+++ b/src/UI/src/Fields/Textarea.php
@@ -30,24 +30,4 @@ class Textarea extends Field implements HasDefaultValueContract, CanBeString
             ? parent::resolvePreview()
             : $this->escapeValue((string) parent::resolvePreview());
     }
-
-    protected function prepareRequestValue(mixed $value): mixed
-    {
-        if (\is_string($value) && static::class === self::class) {
-            return $this->isUnescape() ? $value : $this->escapeValue($value);
-        }
-
-        return $value;
-    }
-
-    protected function resolveValue(): mixed
-    {
-        if (! $this->isUnescape() && static::class === self::class) {
-            return $this->escapeValue(
-                parent::resolveValue()
-            );
-        }
-
-        return parent::resolveValue();
-    }
 }

--- a/src/UI/src/Traits/Fields/WithHint.php
+++ b/src/UI/src/Traits/Fields/WithHint.php
@@ -8,9 +8,20 @@ trait WithHint
 {
     protected string $hint = '';
 
+    protected bool $hintRaw = false;
+
     public function hint(string $hint): static
     {
         $this->hint = $hint;
+        $this->hintRaw = false;
+
+        return $this;
+    }
+
+    public function hintHtml(string $hint): static
+    {
+        $this->hint = $hint;
+        $this->hintRaw = true;
 
         return $this;
     }
@@ -18,5 +29,10 @@ trait WithHint
     public function getHint(): string
     {
         return $this->hint;
+    }
+
+    public function isHintRaw(): bool
+    {
+        return $this->hintRaw;
     }
 }

--- a/src/UI/src/Traits/WithLabel.php
+++ b/src/UI/src/Traits/WithLabel.php
@@ -11,6 +11,8 @@ trait WithLabel
 {
     protected Closure|string $label = '';
 
+    protected bool $labelRaw = false;
+
     protected bool $translatable = false;
 
     protected string $translatableKey = '';
@@ -39,8 +41,22 @@ trait WithLabel
     public function setLabel(Closure|string $label): static
     {
         $this->label = $label;
+        $this->labelRaw = false;
 
         return $this;
+    }
+
+    public function labelHtml(Closure|string $label): static
+    {
+        $this->label = $label;
+        $this->labelRaw = true;
+
+        return $this;
+    }
+
+    public function isLabelRaw(): bool
+    {
+        return $this->labelRaw;
     }
 
     public function translatable(string $key = ''): static

--- a/tests/Feature/Components/CardTest.php
+++ b/tests/Feature/Components/CardTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use MoonShine\UI\Components\Card;
+
+test('card values escapes html by default', function () {
+    $card = Card::make('Test Card')
+        ->values([
+            'Name' => 'John <script>alert("xss")</script>',
+            'Email' => 'test@example.com <img src=x onerror=alert("xss")>',
+        ]);
+
+    expect($card->isValuesRaw())->toBeFalse();
+});
+
+test('card valuesHtml renders raw html', function () {
+    $card = Card::make('Test Card')
+        ->valuesHtml([
+            'Name' => 'John <strong>Doe</strong>',
+            'Email' => '<em>test@example.com</em>',
+        ]);
+
+    expect($card->isValuesRaw())->toBeTrue();
+});
+
+test('card values resets raw flag when called after valuesHtml', function () {
+    $card = Card::make('Test Card')
+        ->valuesHtml(['Name' => '<strong>Raw</strong>'])
+        ->values(['Name' => 'Safe']);
+
+    expect($card->isValuesRaw())->toBeFalse();
+});

--- a/tests/Feature/HtmlEscapingOptInTest.php
+++ b/tests/Feature/HtmlEscapingOptInTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+use MoonShine\Contracts\Core\DependencyInjection\CoreContract;
+use MoonShine\MenuManager\MenuItem;
+use MoonShine\UI\Components\ActionButton;
+use MoonShine\UI\Components\Badge;
+use MoonShine\UI\Components\Card;
+use MoonShine\UI\Components\Dropdown;
+use MoonShine\UI\Components\Layout\Menu;
+use MoonShine\UI\Components\Metrics\Wrapped\ValueMetric;
+use MoonShine\UI\Components\Popover;
+use MoonShine\UI\Fields\Text;
+
+uses()->group('components');
+
+function setEscaping(string $key, bool $value): void
+{
+    config()->set("moonshine.html_escaping.$key", $value);
+    app(CoreContract::class)->getConfig()->set("html_escaping.$key", $value);
+}
+
+beforeEach(function (): void {
+    setEscaping('hints', false);
+    setEscaping('labels', false);
+    setEscaping('card_values', false);
+    setEscaping('ui_elements', false);
+});
+
+it('escapes hints only when hints config is enabled', function (): void {
+    expect((string) Text::make('Name')->hint('<b>Hint</b>')->render())
+        ->toContain('<b>Hint</b>');
+
+    setEscaping('hints', true);
+
+    expect((string) Text::make('Name')->hint('<b>Hint</b>')->render())
+        ->toContain('&lt;b&gt;Hint&lt;/b&gt;')
+        ->and((string) Text::make('Name')->hintHtml('<b>Hint</b>')->render())
+        ->toContain('<b>Hint</b>');
+});
+
+it('escapes labels only when labels config is enabled', function (): void {
+    expect((string) Text::make('<b>Label</b>')->render())
+        ->toContain('<b>Label</b>');
+
+    setEscaping('labels', true);
+
+    expect((string) Text::make('<b>Label</b>')->render())
+        ->toContain('&lt;b&gt;label&lt;/b&gt;')
+        ->and((string) Text::make('Label')->labelHtml('<b>Label</b>')->render())
+        ->toContain('<b>Label</b>');
+});
+
+it('escapes card values only when card_values config is enabled', function (): void {
+    expect((string) Card::make()->values(['x' => '<b>Value</b>'])->render())
+        ->toContain('<b>Value</b>');
+
+    setEscaping('card_values', true);
+
+    expect((string) Card::make()->values(['x' => '<b>Value</b>'])->render())
+        ->toContain('&lt;b&gt;Value&lt;/b&gt;')
+        ->and((string) Card::make()->valuesHtml(['x' => '<b>Value</b>'])->render())
+        ->toContain('<b>Value</b>');
+});
+
+it('escapes Badge when ui_elements config is enabled', function (): void {
+    setEscaping('ui_elements', true);
+
+    expect((string) Badge::make('<b>Badge</b>', 'red')->render())
+        ->toContain('&lt;b&gt;Badge&lt;/b&gt;')
+        ->and((string) Badge::make('Badge', 'red')->valueHtml('<b>Badge</b>')->render())
+        ->toContain('<b>Badge</b>');
+});
+
+it('escapes Dropdown when ui_elements config is enabled', function (): void {
+    setEscaping('ui_elements', true);
+
+    expect((string) Dropdown::make('<b>Title</b>', footer: '<b>Footer</b>')->items(['<b>Item</b>'])->render())
+        ->toContain('&lt;b&gt;Title&lt;/b&gt;', '&lt;b&gt;Item&lt;/b&gt;', '&lt;b&gt;Footer&lt;/b&gt;')
+        ->and((string) Dropdown::make('Title', footer: 'Footer')
+            ->titleHtml('<b>Title</b>')
+            ->itemsHtml(['<b>Item</b>'])
+            ->footerHtml('<b>Footer</b>')
+            ->render())
+        ->toContain('<b>Title</b>', '<b>Item</b>', '<b>Footer</b>');
+});
+
+it('escapes ActionButton when ui_elements config is enabled', function (): void {
+    setEscaping('ui_elements', true);
+
+    expect((string) ActionButton::make('<b>Action</b>')->render())
+        ->toContain('&lt;b&gt;Action&lt;/b&gt;')
+        ->and((string) ActionButton::make('Action')->labelHtml('<b>Action</b>')->render())
+        ->toContain('<b>Action</b>');
+});
+
+it('escapes MenuItem when ui_elements config is enabled', function (): void {
+    setEscaping('ui_elements', true);
+
+    expect((string) Menu::make([
+        MenuItem::make('/', '<b>Menu</b>'),
+    ])->render())
+        ->toContain('&lt;b&gt;Menu&lt;/b&gt;')
+        ->and((string) Menu::make([
+            MenuItem::make('/', 'Menu')->labelHtml('<b>Menu</b>'),
+        ])->render())
+        ->toContain('<b>Menu</b>');
+});
+
+it('escapes ValueMetric when ui_elements config is enabled', function (): void {
+    setEscaping('ui_elements', true);
+
+    expect((string) ValueMetric::make('<b>Metric</b>')->value(10)->valueFormat('<i>{value}</i>')->render())
+        ->toContain('&lt;b&gt;Metric&lt;/b&gt;', '&lt;i&gt;10&lt;/i&gt;')
+        ->and((string) ValueMetric::make('Metric')
+            ->labelHtml('<b>Metric</b>')
+            ->value(10)
+            ->valueFormatHtml('<i>{value}</i>')
+            ->render())
+        ->toContain('<b>Metric</b>', '<i>10</i>');
+});
+
+it('Popover title is always safe in attribute context', function (): void {
+    $html = Popover::make('<script>xss</script>', 'trigger')->render();
+
+    expect((string) $html)->toContain('&lt;script&gt;xss&lt;/script&gt;');
+});
+
+it('Popover triggerHtml renders raw trigger content', function (): void {
+    setEscaping('ui_elements', true);
+
+    expect((string) Popover::make('Title', '<b>Trigger</b>')->render())
+        ->toContain('&lt;b&gt;Trigger&lt;/b&gt;')
+        ->and((string) Popover::make('Title', 'Trigger')->triggerHtml('<b>Trigger</b>')->render())
+        ->toContain('<b>Trigger</b>');
+});

--- a/tests/Unit/Fields/TextFieldTest.php
+++ b/tests/Unit/Fields/TextFieldTest.php
@@ -139,3 +139,31 @@ it('text wrap', function () {
         ->not->toContain('div class="text-clamp">', 'div class="text-ellipsis">')
     ;
 });
+
+it('prepareRequestValue does not escape html (storage invariant)', function (): void {
+    fakeRequest(parameters: ['field_name' => '<b>Test</b>']);
+
+    expect($this->field->getRequestValue())->toBe('<b>Test</b>');
+});
+
+it('hint escapes html by default', function () {
+    $field = Text::make('Name')
+        ->hint('Use <strong>title</strong> tag');
+
+    expect($field->getHint())
+        ->toBe('Use <strong>title</strong> tag');
+
+    expect($field->isHintRaw())
+        ->toBeFalse();
+});
+
+it('hintHtml renders raw html', function () {
+    $field = Text::make('Name')
+        ->hintHtml('Use <strong>title</strong> tag');
+
+    expect($field->getHint())
+        ->toBe('Use <strong>title</strong> tag');
+
+    expect($field->isHintRaw())
+        ->toBeTrue();
+});

--- a/tests/Unit/Fields/TextareaFieldTest.php
+++ b/tests/Unit/Fields/TextareaFieldTest.php
@@ -30,6 +30,12 @@ it('view', function (): void {
         ->toBe('moonshine::fields.textarea');
 });
 
+it('prepareRequestValue does not escape html (storage invariant)', function (): void {
+    fakeRequest(parameters: ['field_name' => '<b>Test</b>']);
+
+    expect($this->field->getRequestValue())->toBe('<b>Test</b>');
+});
+
 it('apply', function (): void {
     $data = ['field_name' => 'test'];
 


### PR DESCRIPTION
## Problem

MoonShine renders user-controlled content (hints, labels, card values, UI component titles/items) via `{!! !!}` without escaping, creating XSS vectors. At the same time, escaping was incorrectly placed in the storage pipeline (`prepareRequestValue`, `resolveValue`), which violated the storage invariant — data was being mutated before/after persistence.

## Solution

Escaping moved exclusively to the render layer (Blade templates), controlled by opt-in config flags (default `false` for full backward compatibility in v4.x).

## Changes

### Config (`moonshine.php`)

```php
'html_escaping' => [
    'hints'       => false,  // opt-in
    'labels'      => false,  // opt-in
    'card_values' => false,  // opt-in
    'ui_elements' => false,  // opt-in
],
```

### Storage invariant fix

- `Text::prepareRequestValue()` — removed HTML escaping; values stored as-is
- - `Textarea::prepareRequestValue()` / `resolveValue()` — removed entirely; no more storage-level mutation
- - `textarea.blade.php` — `{!! $value !!}` → `{{ $value }}` (escaping at render layer)
### Opt-in API (new methods, no breaking changes)

All existing methods (`hint()`, `setLabel()`, `values()`, etc.) behaviour is unchanged by default. New `*Html()` variants explicitly mark content as trusted raw HTML:

| Trait / Class | Safe method | Raw HTML method |
|---|---|---|
| `WithHint` | `hint()` | `hintHtml()` |
| `WithLabel` | `setLabel()` / `make()` | `labelHtml()` |
| `Card` | `values()` | `valuesHtml()` |
| `Badge` | `make($value)` | `valueHtml()` |
| `Dropdown` | `make($title)` / `items()` | `titleHtml()` / `itemsHtml()` / `footerHtml()` |
| `ActionButton` | `make($label)` | `labelHtml()` |
| `Popover` | `trigger()` | `triggerHtml()` |
| `ValueMetric` | `make($label)` / `valueFormat()` | `labelHtml()` / `valueFormatHtml()` |
| `MenuItem` | `make($label)` | `labelHtml()` |
| `Tabs\Tab` | `make($label)` | `labelHtml()` |

### Blade template logic

```blade
@if(! $escapeX || $rawFlag)
    {!! $value !!}   {{-- default: raw (v4 compat) --}}
@else
    {{ $value }}     {{-- opt-in: escaped --}}
@endif
```

> **Note on `Popover::title`** — title is always rendered inside an HTML attribute (`title="{{ $title }}"`), so Blade `{{ }}` auto-escaping already protects it regardless of config.

## Upgrade path

**v4.x (default — no changes needed):** everything works as before.

**Opt-in escaping** — add to `config/moonshine.php`:

```php
'html_escaping' => [
    'hints'       => true,
    'labels'      => true,
    'card_values' => true,
    'ui_elements' => true,
],
```

Then use `hintHtml()` / `labelHtml()` / `valuesHtml()` / `*Html()` where intentional HTML rendering is needed.

**v5.x plan:** flip all defaults to `true` (breaking change, announced in advance).

## Tests

- `HtmlEscapingOptInTest` — 9 tests covering all 4 config zones + Popover
- `CardTest` — 3 unit tests for `isValuesRaw()` flag
- `TextFieldTest` — storage invariant + hint/hintHtml flags
- `TextareaFieldTest` — storage invariant
- 41 related tests — green. 10 pre-existing failures (SQL dialect, file uploads) — unchanged.

## Checklist

- [x] Code changes made
- [x] Tests added
- [x] Code style fixed
- [x] Tests passed

PRs #1990, #1991, #1992 superseded by this PR.