### PR TITLE
fix(ui): complete phase3 html escaping for components

### DIFF
--- a/src/MenuManager/src/MenuItem.php
+++ b/src/MenuManager/src/MenuItem.php
@@ -6,6 +6,7 @@ namespace MoonShine\MenuManager;
 
 use Attribute;
 use Closure;
+use Illuminate\Support\HtmlString;
 use Leeto\FastAttributes\Attributes;
 use MoonShine\Contracts\MenuManager\MenuFillerContract;
 use MoonShine\Contracts\UI\ActionButtonContract;
@@ -250,7 +251,7 @@ class MenuItem extends MenuElement implements WithBadgeContract
             'url' => $this->getUrl(),
         ];
 
-        $viewData['button'] = (string) $this->actionButton
+        $viewData['button'] = new HtmlString((string) $this->actionButton
             ->badge($this->hasBadge() ? $this->getBadge() : null)
             ->setUrl($this->getUrl())
             ->customView('moonshine::components.menu.item-link', [
@@ -259,7 +260,7 @@ class MenuItem extends MenuElement implements WithBadgeContract
                 'onlyIcon' => $this->isOnlyIcon(),
                 'icon' => $this->getIcon(),
                 'top' => $this->isTopMode(),
-            ]);
+            ]));
 
         return $viewData;
     }

--- a/src/UI/resources/views/components/badge.blade.php
+++ b/src/UI/resources/views/components/badge.blade.php
@@ -1,5 +1,15 @@
 @props([
     'color' => null,
     'icon' => null,
+    'value' => '',
+    'valueRaw' => false,
 ])
-<span {{ $attributes->merge(['class' => 'badge'.($color ? ' badge-'.$color : '')])->class(['inline-flex items-center gap-1 max-w-full' => $icon?->isNotEmpty()]) }}>{{ $icon ?? '' }}{{ $slot }}</span>
+<span {{ $attributes->merge(['class' => 'badge'.($color ? ' badge-'.$color : '')])->class(['inline-flex items-center gap-1 max-w-full' => $icon?->isNotEmpty()]) }}>
+    {{ $icon ?? '' }}
+
+    @if($valueRaw)
+        {!! $value !!}
+    @else
+        {{ $value }}
+    @endif
+</span>

--- a/src/UI/resources/views/components/dropdown.blade.php
+++ b/src/UI/resources/views/components/dropdown.blade.php
@@ -3,9 +3,12 @@
     'placement' => 'bottom-start',
     'toggler',
     'title',
+    'titleRaw' => false,
+    'itemsRaw' => false,
     'searchable' => false,
     'searchPlaceholder' => '',
     'footer' => null,
+    'footerRaw' => false,
     'strategy' => 'fixed',
 ])
 <div x-data="dropdown"
@@ -21,7 +24,13 @@
 
     <div {{ $attributes->merge(['class' => 'dropdown-body']) }}>
         @if($title ?? false)
-            <div class="dropdown-heading">{{ $title }}</div>
+            <div class="dropdown-heading">
+                @if($titleRaw)
+                    {!! $title !!}
+                @else
+                    {{ $title }}
+                @endif
+            </div>
         @endif
 
         <div class="dropdown-content">
@@ -44,7 +53,11 @@
                             class="dropdown-menu-item"
                             @if($searchable) x-ref="dropdown_{{$key}}" @endif
                         >
-                            {!! $item !!}
+                            @if($itemsRaw)
+                                {!! $item !!}
+                            @else
+                                {{ $item }}
+                            @endif
                         </li>
                     @endforeach
                 </ul>
@@ -53,7 +66,11 @@
 
         @if($footer ?? false)
             <div class="dropdown-footer">
-                {{ $footer ?? '' }}
+                @if($footerRaw)
+                    {!! $footer ?? '' !!}
+                @else
+                    {{ $footer ?? '' }}
+                @endif
             </div>
         @endif
     </div>

--- a/src/UI/resources/views/components/menu/item.blade.php
+++ b/src/UI/resources/views/components/menu/item.blade.php
@@ -10,5 +10,5 @@
 <li
     {{ $attributes->class(['menu-item', '_is-active' => $isActive]) }}
 >
-    {!! $button !!}
+    {{ $button }}
 </li>

--- a/src/UI/resources/views/components/metrics/value.blade.php
+++ b/src/UI/resources/views/components/metrics/value.blade.php
@@ -1,9 +1,11 @@
 @props([
     'title' => '',
+    'titleRaw' => false,
     'icon' => '',
     'progress' => false,
     'value' => 0,
     'simpleValue' => '',
+    'valueRaw' => false,
 ])
 <div {{ $attributes->merge(['class' => 'report-card']) }}>
     @if($icon)
@@ -23,7 +25,19 @@
     @endif
 
     <div class="report-card-body">
-        <div class="report-card-value">{!! $simpleValue !== '' ? $simpleValue : $value !!}</div>
-        <h5 class="report-card-title">{!! $title !!}</h5>
+        <div class="report-card-value">
+            @if($valueRaw)
+                {!! $simpleValue !== '' ? $simpleValue : $value !!}
+            @else
+                {{ $simpleValue !== '' ? $simpleValue : $value }}
+            @endif
+        </div>
+        <h5 class="report-card-title">
+            @if($titleRaw)
+                {!! $title !!}
+            @else
+                {{ $title }}
+            @endif
+        </h5>
     </div>
 </div>

--- a/src/UI/resources/views/components/metrics/wrapped/value.blade.php
+++ b/src/UI/resources/views/components/metrics/wrapped/value.blade.php
@@ -1,11 +1,13 @@
 @props([
     'label' => '',
+    'labelRaw' => false,
     'icon' => '',
     'columnSpanValue' => 12,
     'adaptiveColumnSpanValue' => 12,
     'isProgress' => false,
     'valueResult' => 0,
     'simpleValue' => 0,
+    'valueRaw' => false,
 ])
 <x-moonshine::layout.column
     :colSpan="$columnSpanValue"
@@ -16,10 +18,12 @@
         <x-moonshine::metrics.value
             :attributes="$attributes"
             :title="$label"
+            :titleRaw="$labelRaw"
             :icon="$icon"
             :progress="$isProgress"
             :value="$valueResult"
             :simpleValue="$simpleValue"
+            :valueRaw="$valueRaw"
         />
     </x-moonshine::layout.box>
 </x-moonshine::layout.column>

--- a/src/UI/resources/views/components/pagination.blade.php
+++ b/src/UI/resources/views/components/pagination.blade.php
@@ -15,6 +15,15 @@
     'translates' => [],
 ])
 
+@php
+    $previousTranslate = html_entity_decode((string) ($translates['previous'] ?? ''));
+    $nextTranslate = html_entity_decode((string) ($translates['next'] ?? ''));
+    $showingTranslate = html_entity_decode((string) ($translates['showing'] ?? ''));
+    $toTranslate = html_entity_decode((string) ($translates['to'] ?? ''));
+    $ofTranslate = html_entity_decode((string) ($translates['of'] ?? ''));
+    $resultsTranslate = html_entity_decode((string) ($translates['results'] ?? ''));
+@endphp
+
 @if($simple)
     <!-- Pagination -->
     <div class="pagination">
@@ -26,13 +35,13 @@
                         href="{{ $prev_page_url }}"
                         @if($async) @click.prevent="asyncRequest" @endif
                         class="pagination-link pagination-link--first"
-                        title="{!! $translates['previous']  !!}"
+                        title="{{ $previousTranslate }}"
                     >
-                        {!! $translates['previous'] !!}
+                        {{ $previousTranslate }}
                     </a>
                 @else
                     <span class="pagination-link _is-disabled">
-                        {!! $translates['previous'] !!}
+                        {{ $previousTranslate }}
                     </span>
                 @endif
             </li>
@@ -44,13 +53,13 @@
                         href="{{ $next_page_url }}"
                         @if($async) @click.prevent="asyncRequest" @endif
                         class="pagination-link pagination-link--last"
-                        title="{!! $translates['next']  !!}"
+                        title="{{ $nextTranslate }}"
                     >
-                        {!! $translates['next'] !!}
+                        {{ $nextTranslate }}
                     </a>
                 @else
                     <span class="pagination-link _is-disabled">
-                        {!! $translates['next'] !!}
+                        {{ $nextTranslate }}
                     </span>
                 @endif
             </li>
@@ -66,7 +75,7 @@
                     <a href="{{ $prev_page_url }}"
                        @if($async) @click.prevent="asyncRequest" @endif
                        class="pagination-link pagination-link--first"
-                       title="{!! $translates['previous']  !!}"
+                       title="{{ $previousTranslate }}"
                     >
                         <x-moonshine::icon icon="chevron-double-left" />
                     </a>
@@ -87,7 +96,7 @@
                        @if($async) @click.prevent="asyncRequest" @endif
                        class="pagination-link @if($link['active']) _is-active @endif"
                     >
-                        {!! $link['label'] !!}
+                        {{ html_entity_decode((string) ($link['label'] ?? '')) }}
                     </a>
                 </li>
                 @endif
@@ -98,7 +107,7 @@
                     <a href="{{ $next_page_url }}"
                        @if($async) @click.prevent="asyncRequest" @endif
                        class="pagination-link pagination-link--last"
-                       title="{!! $translates['next']  !!}"
+                       title="{{ $nextTranslate }}"
                     >
                         <x-moonshine::icon icon="chevron-double-right" />
                     </a>
@@ -106,17 +115,17 @@
             @endif
         </ul>
         <div class="pagination-results">
-            {!! $translates['showing']  !!}
+            {{ $showingTranslate }}
             @if ($from)
                 {{ $from }}
-                {!! $translates['to']  !!}
+                {{ $toTranslate }}
                 {{ $to }}
             @else
                 {{ $per_page }}
             @endif
-            {!! $translates['of']  !!}
+            {{ $ofTranslate }}
             {{ $total }}
-            {!! $translates['results']  !!}
+            {{ $resultsTranslate }}
         </div>
     </div>
     <!-- END: Pagination -->

--- a/src/UI/resources/views/components/popover.blade.php
+++ b/src/UI/resources/views/components/popover.blade.php
@@ -2,6 +2,7 @@
     'title' => '',
     'placement' => 'right',
     'trigger',
+    'triggerRaw' => false,
 ])
 <span
     {{ $attributes }}
@@ -9,6 +10,10 @@
     title="{{ $title }}"
     x-data="popover({placement: '{{ $placement }}'})"
 >
-    {!! $trigger !!}
+    @if($triggerRaw)
+        {!! $trigger !!}
+    @else
+        {{ $trigger }}
+    @endif
     <div class="hidden popover-body-content">{!! $slot !!}</div>
 </span>

--- a/src/UI/resources/views/components/tabs.blade.php
+++ b/src/UI/resources/views/components/tabs.blade.php
@@ -20,7 +20,11 @@
                             type="button"
                     >
                         {!! $tab['icon'] !!}
-                        {!! $tab['label'] !!}
+                        @if($tab['labelRaw'] ?? false)
+                            {!! $tab['label'] !!}
+                        @else
+                            {{ $tab['label'] }}
+                        @endif
                     </button>
                 </li>
             @endforeach

--- a/src/UI/src/Components/Badge.php
+++ b/src/UI/src/Components/Badge.php
@@ -17,6 +17,8 @@ final class Badge extends MoonShineComponent
 
     protected string $view = 'moonshine::components.badge';
 
+    protected bool $valueRaw = false;
+
     public function __construct(
         public string $value = '',
         public string|Color $color = Color::PURPLE,
@@ -31,13 +33,35 @@ final class Badge extends MoonShineComponent
         }
     }
 
+    public function value(string $value): self
+    {
+        $this->value = $value;
+        $this->valueRaw = false;
+
+        return $this;
+    }
+
+    public function valueHtml(string $value): self
+    {
+        $this->value = $value;
+        $this->valueRaw = true;
+
+        return $this;
+    }
+
+    public function isValueRaw(): bool
+    {
+        return $this->valueRaw;
+    }
+
     /**
      * @return array<string, mixed>
      */
     protected function viewData(): array
     {
         return [
-            'slot' => new ComponentSlot($this->value),
+            'value' => $this->value,
+            'valueRaw' => $this->isValueRaw(),
             'icon' => new ComponentSlot($this->getIcon()),
         ];
     }

--- a/src/UI/src/Components/Dropdown.php
+++ b/src/UI/src/Components/Dropdown.php
@@ -15,6 +15,12 @@ final class Dropdown extends MoonShineComponent
 {
     protected string $view = 'moonshine::components.dropdown';
 
+    protected bool $titleRaw = false;
+
+    protected bool $itemsRaw = false;
+
+    protected bool $footerRaw = false;
+
     /**
      * @var array<string, mixed>
      */
@@ -54,6 +60,15 @@ final class Dropdown extends MoonShineComponent
     public function items(Closure|array $items): self
     {
         $this->items = $items;
+        $this->itemsRaw = false;
+
+        return $this;
+    }
+
+    public function itemsHtml(Closure|array $items): self
+    {
+        $this->items = $items;
+        $this->itemsRaw = true;
 
         return $this;
     }
@@ -99,8 +114,48 @@ final class Dropdown extends MoonShineComponent
     public function footer(Closure|string $value): self
     {
         $this->footer = $value;
+        $this->footerRaw = false;
 
         return $this;
+    }
+
+    public function footerHtml(Closure|string $value): self
+    {
+        $this->footer = $value;
+        $this->footerRaw = true;
+
+        return $this;
+    }
+
+    public function title(?string $title): self
+    {
+        $this->title = $title;
+        $this->titleRaw = false;
+
+        return $this;
+    }
+
+    public function titleHtml(?string $title): self
+    {
+        $this->title = $title;
+        $this->titleRaw = true;
+
+        return $this;
+    }
+
+    public function isTitleRaw(): bool
+    {
+        return $this->titleRaw;
+    }
+
+    public function isItemsRaw(): bool
+    {
+        return $this->itemsRaw;
+    }
+
+    public function isFooterRaw(): bool
+    {
+        return $this->footerRaw;
     }
 
 
@@ -119,7 +174,10 @@ final class Dropdown extends MoonShineComponent
         return [
             'toggler' => new ComponentSlot(value($this->toggler, $this), $this->togglerAttributes),
             'slot' => new ComponentSlot(value($this->content, $this)),
-            'footer' => new ComponentSlot(value($this->footer, $this)),
+            'footer' => value($this->footer, $this),
+            'titleRaw' => $this->isTitleRaw(),
+            'itemsRaw' => $this->isItemsRaw(),
+            'footerRaw' => $this->isFooterRaw(),
             'searchable' => $this->searchable,
             'searchPlaceholder' => value($this->searchPlaceholder, $this),
             'items' => value($this->items, $this),

--- a/src/UI/src/Components/Metrics/Wrapped/Metric.php
+++ b/src/UI/src/Components/Metrics/Wrapped/Metric.php
@@ -19,16 +19,39 @@ use MoonShine\UI\Traits\WithLabel;
 abstract class Metric extends MoonShineComponent implements HasIconContract, HasLabelContract
 {
     use WithColumnSpan;
-    use WithLabel;
+    use WithLabel {
+        setLabel as private setTraitLabel;
+    }
     use WithIcon;
 
     protected Color $iconColor = Color::PRIMARY;
+
+    protected bool $labelRaw = false;
 
     final public function __construct(Closure|string $label)
     {
         parent::__construct();
 
         $this->setLabel($label);
+    }
+
+    public function setLabel(Closure|string $label): static
+    {
+        $this->labelRaw = false;
+
+        return $this->setTraitLabel($label);
+    }
+
+    public function labelHtml(Closure|string $label): static
+    {
+        $this->labelRaw = true;
+
+        return $this->setTraitLabel($label);
+    }
+
+    public function isLabelRaw(): bool
+    {
+        return $this->labelRaw;
     }
 
     public function iconColor(Color $color): static
@@ -53,6 +76,7 @@ abstract class Metric extends MoonShineComponent implements HasIconContract, Has
         return [
             ...parent::systemViewData(),
             'label' => $this->getLabel(),
+            'labelRaw' => $this->isLabelRaw(),
             'icon' => $this->getIcon(6, $this->iconColor),
             'columnSpanValue' => $this->getColumnSpanValue(),
             'adaptiveColumnSpanValue' => $this->getAdaptiveColumnSpanValue(),

--- a/src/UI/src/Components/Metrics/Wrapped/ValueMetric.php
+++ b/src/UI/src/Components/Metrics/Wrapped/ValueMetric.php
@@ -18,9 +18,20 @@ class ValueMetric extends Metric
 
     protected bool $progress = false;
 
+    protected bool $valueRaw = false;
+
     public function valueFormat(string|Closure $value): static
     {
         $this->valueFormat = value($value, $this->value);
+        $this->valueRaw = false;
+
+        return $this;
+    }
+
+    public function valueFormatHtml(string|Closure $value): static
+    {
+        $this->valueFormat = value($value, $this->value);
+        $this->valueRaw = true;
 
         return $this;
     }
@@ -60,8 +71,22 @@ class ValueMetric extends Metric
     public function value(int|string|float|Closure $value): static
     {
         $this->value = value($value);
+        $this->valueRaw = false;
 
         return $this;
+    }
+
+    public function valueHtml(int|string|float|Closure $value): static
+    {
+        $this->value = value($value);
+        $this->valueRaw = true;
+
+        return $this;
+    }
+
+    public function isValueRaw(): bool
+    {
+        return $this->valueRaw;
     }
 
     public function progress(int|float|Closure $target): static
@@ -85,6 +110,7 @@ class ValueMetric extends Metric
             'isProgress' => $this->isProgress(),
             'valueResult' => $this->getValueResult(),
             'simpleValue' => $this->getSimpleValue(),
+            'valueRaw' => $this->isValueRaw(),
         ];
     }
 }

--- a/src/UI/src/Components/Popover.php
+++ b/src/UI/src/Components/Popover.php
@@ -15,6 +15,8 @@ final class Popover extends MoonShineComponent
 
     protected string $view = 'moonshine::components.popover';
 
+    protected bool $triggerRaw = false;
+
     public function __construct(
         public string $title,
         public string $trigger = '',
@@ -25,6 +27,27 @@ final class Popover extends MoonShineComponent
         if ($this->trigger === '') {
             $this->trigger = $title;
         }
+    }
+
+    public function trigger(string $trigger): self
+    {
+        $this->trigger = $trigger;
+        $this->triggerRaw = false;
+
+        return $this;
+    }
+
+    public function triggerHtml(string $trigger): self
+    {
+        $this->trigger = $trigger;
+        $this->triggerRaw = true;
+
+        return $this;
+    }
+
+    public function isTriggerRaw(): bool
+    {
+        return $this->triggerRaw;
     }
 
     public function showOnClick(): self
@@ -44,6 +67,7 @@ final class Popover extends MoonShineComponent
     protected function viewData(): array
     {
         return [
+            'triggerRaw' => $this->isTriggerRaw(),
             'slot' => $this->getSlot(),
         ];
     }

--- a/src/UI/src/Components/Tabs/Tab.php
+++ b/src/UI/src/Components/Tabs/Tab.php
@@ -24,12 +24,16 @@ use Throwable;
  */
 class Tab extends AbstractWithComponents implements HasLabelContract, HasIconContract
 {
-    use WithLabel;
+    use WithLabel {
+        setLabel as private setTraitLabel;
+    }
     use WithIcon;
 
     public bool $active = false;
 
     public ?string $id = null;
+
+    protected bool $labelRaw = false;
 
     private ComponentAttributesBagContract $labelAttributes;
 
@@ -53,6 +57,25 @@ class Tab extends AbstractWithComponents implements HasLabelContract, HasIconCon
         $this->labelAttributes = new MoonShineComponentAttributeBag();
 
         parent::__construct($components);
+    }
+
+    public function setLabel(Closure|string $label): static
+    {
+        $this->labelRaw = false;
+
+        return $this->setTraitLabel($label);
+    }
+
+    public function labelHtml(Closure|string $label): static
+    {
+        $this->labelRaw = true;
+
+        return $this->setTraitLabel($label);
+    }
+
+    public function isLabelRaw(): bool
+    {
+        return $this->labelRaw;
     }
 
     /**
@@ -123,6 +146,7 @@ class Tab extends AbstractWithComponents implements HasLabelContract, HasIconCon
         return [
             'icon' => $this->getIcon(6),
             'label' => $this->getLabel(),
+            'labelRaw' => $this->isLabelRaw(),
             'labelAttributes' => $this->labelAttributes,
             'id' => $this->getId(),
             'content' => Components::make(

--- a/tests/Feature/Components/SecurityEscapingPhase3Test.php
+++ b/tests/Feature/Components/SecurityEscapingPhase3Test.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+use MoonShine\MenuManager\MenuItem;
+use MoonShine\UI\Components\Badge;
+use MoonShine\UI\Components\Dropdown;
+use MoonShine\UI\Components\Metrics\Wrapped\ValueMetric;
+use MoonShine\UI\Components\Popover;
+use MoonShine\UI\Components\Tabs\Tab;
+
+test('phase3 raw flags are false by default and true via html methods', function () {
+    $tab = Tab::make('Label')
+        ->labelHtml('<strong>Label</strong>');
+
+    $badge = Badge::make('Value')
+        ->valueHtml('<strong>Value</strong>');
+
+    $dropdown = Dropdown::make()
+        ->titleHtml('<strong>Title</strong>')
+        ->itemsHtml(['<em>item</em>'])
+        ->footerHtml('<small>Footer</small>');
+
+    $popover = Popover::make('Title')
+        ->triggerHtml('<strong>Trigger</strong>');
+
+    $metric = ValueMetric::make('Title')
+        ->labelHtml('<strong>Title</strong>')
+        ->valueFormatHtml('<strong>{value}</strong>');
+
+    expect(Tab::make('Label')->isLabelRaw())->toBeFalse()
+        ->and($tab->isLabelRaw())->toBeTrue()
+        ->and(Badge::make('Value')->isValueRaw())->toBeFalse()
+        ->and($badge->isValueRaw())->toBeTrue()
+        ->and(Dropdown::make()->isTitleRaw())->toBeFalse()
+        ->and(Dropdown::make()->isItemsRaw())->toBeFalse()
+        ->and(Dropdown::make()->isFooterRaw())->toBeFalse()
+        ->and($dropdown->isTitleRaw())->toBeTrue()
+        ->and($dropdown->isItemsRaw())->toBeTrue()
+        ->and($dropdown->isFooterRaw())->toBeTrue()
+        ->and(Popover::make('Title')->isTriggerRaw())->toBeFalse()
+        ->and($popover->isTriggerRaw())->toBeTrue()
+        ->and(ValueMetric::make('Title')->isLabelRaw())->toBeFalse()
+        ->and($metric->isLabelRaw())->toBeTrue()
+        ->and(ValueMetric::make('Title')->isValueRaw())->toBeFalse()
+        ->and($metric->isValueRaw())->toBeTrue();
+});
+
+test('pagination escapes translates and labels', function () {
+    $translates = [
+        'previous' => '<script>alert(1)</script>',
+        'next' => 'Next &raquo;',
+        'showing' => 'Showing',
+        'to' => 'to',
+        'of' => 'of',
+        'results' => 'results',
+    ];
+
+    $html = Blade::render(
+        '<x-moonshine::pagination :simple="true" :prev_page_url="\'/prev\'" :next_page_url="\'/next\'" :translates="$translates" />',
+        ['translates' => $translates]
+    );
+
+    expect($html)
+        ->toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+        ->not->toContain('<script>alert(1)</script>')
+        ->toContain('Next »');
+
+    $htmlWithLinks = Blade::render(
+        '<x-moonshine::pagination :has_pages="true" :current_page="2" :last_page="3" :prev_page_url="\'/prev\'" :next_page_url="\'/next\'" :links="$links" :translates="$translates" />',
+        [
+            'links' => [
+                ['url' => '/1', 'label' => '<img src=x onerror=alert(1)>', 'active' => false],
+            ],
+            'translates' => $translates,
+        ]
+    );
+
+    expect($htmlWithLinks)
+        ->toContain('&lt;img src=x onerror=alert(1)&gt;')
+        ->not->toContain('<img src=x onerror=alert(1)>');
+});
+
+test('menu item button remains renderable and label is escaped', function () {
+    $html = (string) value(MenuItem::make('/users', '<script>alert(1)</script>')->render());
+
+    expect($html)
+        ->toContain('menu-link')
+        ->toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+        ->not->toContain('<script>alert(1)</script>');
+});


### PR DESCRIPTION
## What was changed
Completed remaining **Phase 3** HTML escaping fixes for UI components.

### Implemented
- Tabs:
  - Added `labelRaw` flow in component API (`label()` safe by default, [labelHtml()](cci:1://file:///home/alex/Projects/moonshine/src/UI/src/Components/Metrics/Wrapped/Metric.php:44:4-49:5) raw opt-in)
  - Updated blade rendering to conditional escaped/raw output
- Dropdown:
  - Added raw flags and `*Html()` methods for `title`, `items`, `footer`
  - Updated blade rendering accordingly
- Badge:
  - Added `valueRaw` flow with [value()](cci:1://file:///home/alex/Projects/moonshine/src/UI/src/Components/Metrics/Wrapped/ValueMetric.php:70:4-76:5) / [valueHtml()](cci:1://file:///home/alex/Projects/moonshine/src/UI/src/Components/Metrics/Wrapped/ValueMetric.php:78:4-84:5)
  - Updated blade to conditional escaped/raw output
- Popover:
  - Added `triggerRaw` handling in blade (`trigger` escaped by default)
- Menu Item:
  - Replaced raw blade output for button with safe output
  - Passed `button` as `HtmlString` from component side
- Pagination:
  - Escaped `translates` and pagination link labels by default
  - Kept entity-safe visual output via `html_entity_decode(...)` before escaped rendering
- Metrics:
  - Added `labelRaw` support in [Metric](cci:2://file:///home/alex/Projects/moonshine/src/UI/src/Components/Metrics/Wrapped/Metric.php:18:0-84:1)
  - Added `valueRaw` support in [ValueMetric](cci:2://file:///home/alex/Projects/moonshine/src/UI/src/Components/Metrics/Wrapped/ValueMetric.php:8:0-115:1) ([valueHtml](cci:1://file:///home/alex/Projects/moonshine/src/UI/src/Components/Metrics/Wrapped/ValueMetric.php:78:4-84:5), [valueFormatHtml](cci:1://file:///home/alex/Projects/moonshine/src/UI/src/Components/Metrics/Wrapped/ValueMetric.php:30:4-36:5))
  - Updated `metrics/value` and wrapped view templates to use conditional escaped/raw output

## Why?
To close remaining Phase 3 XSS/HTML-injection exposure points from the escaping audit while preserving explicit raw HTML opt-in APIs for intentional markup rendering.

## Tests
Added regression tests:
- [tests/Feature/Components/SecurityEscapingPhase3Test.php](cci:7://file:///home/alex/Projects/moonshine/tests/Feature/Components/SecurityEscapingPhase3Test.php:0:0-0:0)

Covers:
- raw flags default/opt-in behavior for phase3 components
- pagination escaping for `translates` and link labels
- menu item rendering remains functional and label is escaped

## Checklist
- Issue #n/a
- Tested
  - [x] Tested manually
  - [x] Tests added
- [ ] Documentation