### PR TITLE
test: make AppliesRegister SQL assertion portable

### DIFF
--- a/tests/Feature/AppliesRegisterTest.php
+++ b/tests/Feature/AppliesRegisterTest.php
@@ -92,8 +92,10 @@ it('add new filter apply', function (): void {
 
     $data = $field->apply($defaultApply, (new Item())->newQuery());
 
-    expect($data->toRawSql())
-        ->toContain("`some_column` = '!'");
+    expect($data->toSql())
+        ->toContain('some_column')
+        ->and($data->getBindings())
+        ->toContain('!');
 });
 
 class CustomTextFilterApply implements ApplyContract


### PR DESCRIPTION

<img width="975" height="668" alt="image" src="https://github.com/user-attachments/assets/b51dc359-b28c-40d7-8f73-da8057d7dd7a" />

## Summary
- replace SQL-string assertion in `AppliesRegisterTest` with driver-agnostic checks
- assert `toSql()` contains `some_column` and `getBindings()` contains the submitted value
- avoid brittle quoting differences between SQLite/MySQL/PostgreSQL in CI

## Verification
- `./vendor/bin/pest tests/Feature/AppliesRegisterTest.php`