### PR TITLE
test: stabilize cross-driver assertions and phpstan flow

### DIFF
--- a/src/ColorManager/src/ColorMutator.php
+++ b/src/ColorManager/src/ColorMutator.php
@@ -306,7 +306,7 @@ final class ColorMutator
             ? ((float) rtrim($parts[1], '%')) / 100
             : (float) $parts[1];
 
-        $h = (float) ($parts[2] ?? 0);
+        $h = (float) $parts[2];
 
         $a = cos(deg2rad($h)) * $c;
         $b = sin(deg2rad($h)) * $c;

--- a/src/Crud/src/Pages/PageComponents/DefaultForm.php
+++ b/src/Crud/src/Pages/PageComponents/DefaultForm.php
@@ -9,7 +9,6 @@ use MoonShine\Contracts\Core\DependencyInjection\FieldsContract;
 use MoonShine\Contracts\Core\TypeCasts\DataWrapperContract;
 use MoonShine\Contracts\UI\FormBuilderContract;
 use MoonShine\Core\Traits\WithCore;
-use MoonShine\Crud\Collections\Fields;
 use MoonShine\Crud\Contracts\Page\FormPageContract;
 use MoonShine\Crud\Contracts\PageComponents\DefaultFormContract;
 use MoonShine\Support\AlpineJs;
@@ -34,21 +33,17 @@ final class DefaultForm implements DefaultFormContract
         bool $isAsync = true,
     ): FormBuilderContract {
         $resource = $page->getResource();
+        $formFields = \is_null($item)
+            ? $fields
+            : $fields->push(
+                Hidden::make('_method')->setValue('PUT'),
+            );
 
         return FormBuilder::make($action)
             ->cast($resource->getCaster())
             ->fill($item)
             ->fields([
-                /** @phpstan-ignore argument.templateType */
-                ...$fields
-                    ->when(
-                        ! \is_null($item),
-                        static fn (Fields $fields): Fields
-                            => $fields->push(
-                                Hidden::make('_method')->setValue('PUT'),
-                            ),
-                    )
-                    ->toArray(),
+                ...$formFields->toArray(),
             ])
             ->when(
                 ! $page->hasErrorsAbove(),

--- a/src/Laravel/src/Layouts/BaseLayout.php
+++ b/src/Laravel/src/Layouts/BaseLayout.php
@@ -189,7 +189,7 @@ abstract class BaseLayout extends AbstractLayout
         return [];
     }
 
-    protected function getTopBarComponent(): Topbar
+    protected function getTopBarComponent(): TopBar
     {
         return TopBar::make([
             Fragment::make([

--- a/src/Laravel/src/Resources/ModelResource.php
+++ b/src/Laravel/src/Resources/ModelResource.php
@@ -262,7 +262,7 @@ abstract class ModelResource extends CrudResource implements WithQueryBuilderCon
                 $item = $this->afterSave($item, $fields);
             }
         } catch (QueryException $queryException) {
-            throw new ResourceException($queryException->getMessage(), previous: $queryException);
+            throw new ResourceException($queryException->getMessage(), (int) $queryException->getCode(), previous: $queryException);
         }
 
         $this->setItem($item->getOriginal());

--- a/src/Support/src/Traits/WithComponentAttributes.php
+++ b/src/Support/src/Traits/WithComponentAttributes.php
@@ -244,10 +244,11 @@ trait WithComponentAttributes
         $type = $if ? 'if' : 'show';
 
         if ($if && $this instanceof FieldContract) {
+            /** @phpstan-ignore method.nonObject */
+            $field = $this->beforeRender(fn (): string => '<template x-if="' . $variable($this) . '">');
+
             /** @phpstan-ignore return.type,method.nonObject */
-            return $this
-                ->beforeRender(fn (): string => '<template x-if="' . $variable($this) . '">')
-                ->afterRender(fn (): string => '</template>');
+            return $field->afterRender(fn (): string => '</template>');
         }
 
         if ($this instanceof FieldContract && $wrapper) {

--- a/src/UI/src/Components/CardsBuilder.php
+++ b/src/UI/src/Components/CardsBuilder.php
@@ -257,12 +257,11 @@ final class CardsBuilder extends IterableComponent implements
      */
     protected function getMapper(mixed $data, FieldsContract $fields, int $index): array
     {
-        /** @var array<string, string> $values */
-        /** @phpstan-ignore-next-line */
-        $values = $fields
-            ->values()
-            ->mapWithKeys(static fn (FieldContract $value): array => [$value->getLabel() => (string) $value->preview()])
-            ->toArray();
+        $values = [];
+
+        foreach ($fields->values() as $value) {
+            $values[$value->getLabel()] = (string) $value->preview();
+        }
 
         return [
             'title' => $this->getMapperValue('title', $data, $index),

--- a/src/UI/src/Components/Table/TableBuilder.php
+++ b/src/UI/src/Components/Table/TableBuilder.php
@@ -290,14 +290,13 @@ final class TableBuilder extends IterableComponent implements
             $casted = $this->castData($data);
             $cells = TableCells::make();
 
-            /** @phpstan-ignore argument.templateType */
             $fields = $this
                 ->getFilledFields($casted->toArray(), $casted, $index, $tableFields)
-                ->onlyVisible()
-                ->when(
-                    $this->isReindex() && ! $this->isPreparedReindex(),
-                    static fn (FieldsContract $f): FieldsContract => $f->prepareReindexNames(),
-                );
+                ->onlyVisible();
+
+            if ($this->isReindex() && ! $this->isPreparedReindex()) {
+                $fields = $fields->prepareReindexNames();
+            }
 
             $key = $casted->getKey();
 

--- a/tests/Feature/AppliesRegisterTest.php
+++ b/tests/Feature/AppliesRegisterTest.php
@@ -92,8 +92,10 @@ it('add new filter apply', function (): void {
 
     $data = $field->apply($defaultApply, (new Item())->newQuery());
 
-    expect($data->toRawSql())
-        ->toContain("`some_column` = '!'");
+    expect($data->toSql())
+        ->toContain('some_column')
+        ->and($data->getBindings())
+        ->toContain('!');
 });
 
 class CustomTextFilterApply implements ApplyContract

--- a/tests/Feature/Fields/DateRangeFieldTest.php
+++ b/tests/Feature/Fields/DateRangeFieldTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 use MoonShine\ImportExport\ExportHandler;
 use MoonShine\ImportExport\ImportHandler;
 use MoonShine\Laravel\Applies\Filters\DateRangeModelApply;
@@ -71,10 +72,10 @@ it('apply as base', function () {
 
     $this->item->refresh();
 
-    expect($this->item->start_date)
-        ->toBe($from->format('Y-m-d'))
-        ->and($this->item->end_date)
-        ->toBe($to->format('Y-m-d'));
+    expect(Carbon::parse((string) $this->item->start_date)->toDateString())
+        ->toBe($from->toDateString())
+        ->and(Carbon::parse((string) $this->item->end_date)->toDateString())
+        ->toBe($to->toDateString());
 });
 
 it('before apply', function () {
@@ -144,10 +145,10 @@ it('apply as base with default', function () {
 
     $this->item->refresh();
 
-    expect($this->item->start_date)
-        ->toBe($from->format('Y-m-d'))
-        ->and($this->item->end_date)
-        ->toBe($to->format('Y-m-d'));
+    expect(Carbon::parse((string) $this->item->start_date)->toDateString())
+        ->toBe($from->toDateString())
+        ->and(Carbon::parse((string) $this->item->end_date)->toDateString())
+        ->toBe($to->toDateString());
 });
 
 it('apply as base with null', function () {

--- a/tests/Feature/Fields/JsonFieldTest.php
+++ b/tests/Feature/Fields/JsonFieldTest.php
@@ -67,12 +67,12 @@ it('apply as base with file', function () {
 
     $this->item->refresh();
 
-    expect($this->item->data->toArray())->toBe(
-        [
-            ['file' => $file->hashName(), 'title' => 'Title 1', 'value' => 'Value 1',],
-            ['file' => $file->hashName(), 'title' => 'Title 2', 'value' => 'Value 2',],
-        ]
-    );
+    $savedData = $this->item->data->toArray();
+
+    expect($savedData)
+        ->toHaveCount(2)
+        ->and($savedData[0])->toMatchArray(['title' => 'Title 1', 'value' => 'Value 1', 'file' => $file->hashName()])
+        ->and($savedData[1])->toMatchArray(['title' => 'Title 2', 'value' => 'Value 2', 'file' => $file->hashName()]);
 });
 
 it('apply as base with file stay hidden', function () {
@@ -107,12 +107,12 @@ it('apply as base with file stay hidden', function () {
 
     $this->item->refresh();
 
-    expect($this->item->data->toArray())->toBe(
-        [
-            ['file' => null, 'title' => 'Title 1', 'value' => 'Value 1'],
-            ['file' => $file->hashName(), 'title' => 'Title 2', 'value' => 'Value 2'],
-        ]
-    );
+    $savedData = $this->item->data->toArray();
+
+    expect($savedData)
+        ->toHaveCount(2)
+        ->and($savedData[0])->toMatchArray(['title' => 'Title 1', 'value' => 'Value 1', 'file' => null])
+        ->and($savedData[1])->toMatchArray(['title' => 'Title 2', 'value' => 'Value 2', 'file' => $file->hashName()]);
 });
 
 it('apply as base', function () {
@@ -269,8 +269,10 @@ it('apply as filter', function (): void {
             $query
         );
 
-    expect($query->toRawSql())
-        ->toContain('json_contains');
+    $sql = strtolower($query->toRawSql());
+
+    expect(str_contains($sql, 'json_contains') || str_contains($sql, 'json_each'))
+        ->toBeTrue();
 });
 
 function jsonExport(Item $item): ?string

--- a/tests/Feature/Fields/Relationships/BelongsToManyFieldTest.php
+++ b/tests/Feature/Fields/Relationships/BelongsToManyFieldTest.php
@@ -249,8 +249,12 @@ it('apply as filter', function (): void {
             $query
         );
 
-    expect($query->toRawSql())
-        ->toContain('`category_item`.`category_id` in (3)');
+    $sql = strtolower($query->toRawSql());
+
+    expect($sql)
+        ->toContain('category_item')
+        ->toContain('category_id')
+        ->toContain('in (3)');
 });
 
 function belongsToManyExport(Item $item, BelongsToMany $field): ?string
@@ -266,6 +270,8 @@ function belongsToManyExport(Item $item, BelongsToMany $field): ?string
     );
 
     $export = ExportHandler::make('');
+
+    Storage::disk('public')->delete('test-resource.csv');
 
     asAdmin()->get(
         $resource->getRoute('handler', query: ['handlerUri' => $export->getUriKey()])

--- a/tests/Feature/Fields/SelectFieldTest.php
+++ b/tests/Feature/Fields/SelectFieldTest.php
@@ -152,7 +152,7 @@ it('apply as base with empty', function () {
         $data
     )->assertRedirect();
 
-})->fails('set `moonshine_user_id` = []');
+})->fails('moonshine_user_id');
 
 function selectExport(Item $item, Select $field, int $value, string $label): ?string
 {


### PR DESCRIPTION
## Summary
- make multiple feature assertions driver-agnostic (SQLite/MySQL quoting and JSON SQL differences)
- stabilize date expectations in DateRange tests by asserting date precision only
- resolve phpstan issues in `Crud`, `UI`, and `Support` paths triggered by `composer test:all`
- fix strict exception code typing in `ModelResource` and case mismatch in `BaseLayout`

## Verification
- `composer test:all`