### PR TITLE
test: make field assertions portable across SQL drivers

### DIFF
--- a/tests/Feature/Fields/JsonFieldTest.php
+++ b/tests/Feature/Fields/JsonFieldTest.php
@@ -67,12 +67,12 @@ it('apply as base with file', function () {
 
     $this->item->refresh();
 
-    expect($this->item->data->toArray())->toBe(
-        [
-            ['file' => $file->hashName(), 'title' => 'Title 1', 'value' => 'Value 1',],
-            ['file' => $file->hashName(), 'title' => 'Title 2', 'value' => 'Value 2',],
-        ]
-    );
+    $savedData = $this->item->data->toArray();
+
+    expect($savedData)
+        ->toHaveCount(2)
+        ->and($savedData[0])->toMatchArray(['title' => 'Title 1', 'value' => 'Value 1', 'file' => $file->hashName()])
+        ->and($savedData[1])->toMatchArray(['title' => 'Title 2', 'value' => 'Value 2', 'file' => $file->hashName()]);
 });
 
 it('apply as base with file stay hidden', function () {
@@ -107,12 +107,12 @@ it('apply as base with file stay hidden', function () {
 
     $this->item->refresh();
 
-    expect($this->item->data->toArray())->toBe(
-        [
-            ['file' => null, 'title' => 'Title 1', 'value' => 'Value 1'],
-            ['file' => $file->hashName(), 'title' => 'Title 2', 'value' => 'Value 2'],
-        ]
-    );
+    $savedData = $this->item->data->toArray();
+
+    expect($savedData)
+        ->toHaveCount(2)
+        ->and($savedData[0])->toMatchArray(['title' => 'Title 1', 'value' => 'Value 1', 'file' => null])
+        ->and($savedData[1])->toMatchArray(['title' => 'Title 2', 'value' => 'Value 2', 'file' => $file->hashName()]);
 });
 
 it('apply as base', function () {
@@ -269,8 +269,10 @@ it('apply as filter', function (): void {
             $query
         );
 
-    expect($query->toRawSql())
-        ->toContain('json_contains');
+    $sql = strtolower($query->toRawSql());
+
+    expect(str_contains($sql, 'json_contains') || str_contains($sql, 'json_each'))
+        ->toBeTrue();
 });
 
 function jsonExport(Item $item): ?string

--- a/tests/Feature/Fields/Relationships/BelongsToManyFieldTest.php
+++ b/tests/Feature/Fields/Relationships/BelongsToManyFieldTest.php
@@ -249,8 +249,12 @@ it('apply as filter', function (): void {
             $query
         );
 
-    expect($query->toRawSql())
-        ->toContain('`category_item`.`category_id` in (3)');
+    $sql = strtolower($query->toRawSql());
+
+    expect($sql)
+        ->toContain('category_item')
+        ->toContain('category_id')
+        ->toContain('in (3)');
 });
 
 function belongsToManyExport(Item $item, BelongsToMany $field): ?string
@@ -266,6 +270,8 @@ function belongsToManyExport(Item $item, BelongsToMany $field): ?string
     );
 
     $export = ExportHandler::make('');
+
+    Storage::disk('public')->delete('test-resource.csv');
 
     asAdmin()->get(
         $resource->getRoute('handler', query: ['handlerUri' => $export->getUriKey()])

--- a/tests/Feature/Fields/SelectFieldTest.php
+++ b/tests/Feature/Fields/SelectFieldTest.php
@@ -152,7 +152,7 @@ it('apply as base with empty', function () {
         $data
     )->assertRedirect();
 
-})->fails('set `moonshine_user_id` = []');
+})->fails('moonshine_user_id');
 
 function selectExport(Item $item, Select $field, int $value, string $label): ?string
 {


### PR DESCRIPTION
## Summary
- make JSON field filter SQL assertion portable (`json_contains` vs `json_each`)
- make belongs-to-many filter SQL assertion quote-agnostic
- make SelectField expected-failure assertion message driver-agnostic

## Verification
- `./vendor/bin/pest tests/Feature/Fields/JsonFieldTest.php tests/Feature/Fields/Relationships/BelongsToManyFieldTest.php tests/Feature/Fields/SelectFieldTest.php`