### PR TITLE
feat: Add withFormData method to ActionButton for submitting form data with async requests

### DIFF
--- a/src/Contracts/src/UI/ActionButtonContract.php
+++ b/src/Contracts/src/UI/ActionButtonContract.php
@@ -82,6 +82,8 @@ interface ActionButtonContract extends
 
     public function withSelectorsParams(array $selectors): static;
 
+    public function withFormData(?string $selector = null): static;
+
     public function dispatchEvent(array|string $events): static;
 
     public function async(

--- a/src/Laravel/src/Layouts/BaseLayout.php
+++ b/src/Laravel/src/Layouts/BaseLayout.php
@@ -129,7 +129,7 @@ abstract class BaseLayout extends AbstractLayout
         return [];
     }
 
-    protected function getTopBarComponent(): Topbar
+    protected function getTopBarComponent(): TopBar
     {
         return TopBar::make([
             Div::make([

--- a/src/Support/src/AlpineJs.php
+++ b/src/Support/src/AlpineJs.php
@@ -91,6 +91,13 @@ final readonly class AlpineJs
         ]);
     }
 
+    public static function asyncFormDataAttributes(?string $selector = null): array
+    {
+        return [
+            'data-async-form-data' => $selector ?? '',
+        ];
+    }
+
     public static function asyncWithQueryParamsAttributes(): array
     {
         return [

--- a/src/UI/resources/js/Components/ActionButton.js
+++ b/src/UI/resources/js/Components/ActionButton.js
@@ -10,6 +10,7 @@ export default () => ({
   method: 'GET',
   withParams: '',
   withQueryParams: false,
+  withFormData: false,
   loading: false,
   btnText: '',
 

--- a/src/UI/resources/js/Components/ActionButton.js
+++ b/src/UI/resources/js/Components/ActionButton.js
@@ -1,4 +1,5 @@
 import selectorsParams from '../Support/SelectorsParams.js'
+import formDataParams from '../Support/FormDataParams.js'
 import {ComponentRequestData} from '../DTOs/ComponentRequestData.js'
 import {dispatchEvents as de} from '../Support/DispatchEvents.js'
 import request from '../Request/Core.js'
@@ -18,6 +19,7 @@ export default () => ({
     this.method = this.$el?.dataset?.asyncMethod
 
     this.withParams = this.$el?.dataset?.asyncWithParams
+    this.withFormData = this.$el?.dataset?.asyncFormData
     this.withQueryParams = this.$el?.dataset?.asyncWithQueryParams ?? false
 
     this.loading = false
@@ -56,7 +58,12 @@ export default () => ({
         ? {}
         : Object.fromEntries(prepareQueryParams(new URLSearchParams(url.search), exclude))
 
-    extra['_data'] = Object.assign({}, preparedURLParams, selectorsParams(this.withParams))
+    extra['_data'] = Object.assign(
+      {},
+      preparedURLParams,
+      selectorsParams(this.withParams),
+      this.withFormData !== undefined ? formDataParams(this.withFormData, this.$el) : {},
+    )
 
     de(componentEvent, '', this, extra)
   },
@@ -72,11 +79,15 @@ export default () => ({
       this.loading = true
     }
 
-    if (this.withParams !== undefined && this.withParams) {
+    if ((this.withParams !== undefined && this.withParams) || this.withFormData !== undefined) {
       this.method = this.method.toLowerCase() === 'get' ? 'post' : this.method
     }
 
     let body = selectorsParams(this.withParams)
+
+    if (this.withFormData !== undefined) {
+      Object.assign(body, formDataParams(this.withFormData, this.$el))
+    }
 
     if (this.withQueryParams) {
       const queryParams = new URLSearchParams(window.location.search)

--- a/src/UI/resources/js/Support/FormDataParams.js
+++ b/src/UI/resources/js/Support/FormDataParams.js
@@ -1,0 +1,29 @@
+export default function formDataParams(selector, el) {
+  let form = null
+
+  if (selector !== undefined && selector !== null && selector !== '') {
+    form = document.querySelector(selector)
+  } else if (el) {
+    form = el.closest('form')
+  }
+
+  if (!form) {
+    return {}
+  }
+
+  const formData = new FormData(form)
+  const data = {}
+
+  formData.forEach(function (value, key) {
+    if (key in data) {
+      if (!Array.isArray(data[key])) {
+        data[key] = [data[key]]
+      }
+      data[key].push(value)
+    } else {
+      data[key] = value
+    }
+  })
+
+  return data
+}

--- a/src/UI/resources/js/Support/FormDataParams.js
+++ b/src/UI/resources/js/Support/FormDataParams.js
@@ -1,3 +1,5 @@
+import {formToJSON} from 'axios'
+
 export default function formDataParams(selector, el) {
   let form = null
 
@@ -11,19 +13,5 @@ export default function formDataParams(selector, el) {
     return {}
   }
 
-  const formData = new FormData(form)
-  const data = {}
-
-  formData.forEach(function (value, key) {
-    if (key in data) {
-      if (!Array.isArray(data[key])) {
-        data[key] = [data[key]]
-      }
-      data[key].push(value)
-    } else {
-      data[key] = value
-    }
-  })
-
-  return data
+  return formToJSON(new FormData(form))
 }

--- a/src/UI/src/Components/ActionButton.php
+++ b/src/UI/src/Components/ActionButton.php
@@ -345,6 +345,13 @@ class ActionButton extends MoonShineComponent implements
         );
     }
 
+    public function withFormData(?string $selector = null): static
+    {
+        return $this->customAttributes(
+            AlpineJs::asyncFormDataAttributes($selector),
+        );
+    }
+
     public function withQueryParams(): static
     {
         return $this->customAttributes(


### PR DESCRIPTION
## Problem

The existing `withSelectorsParams` method collects values from individual DOM elements using `querySelector` and reads their `.value` property. This approach doesn't work well when a form contains complex fields — for example, JSON fields, arrays (`name="tags[]"`), or multiple inputs with the same name.

<img width="1145" height="233" alt="Снимок" src="https://github.com/user-attachments/assets/7191464c-1874-4392-a6bd-aed0e781ffbc" />

## Solution

Added a new `withFormData(?string $selector = null)` method that uses the native `FormData` API to collect all form data at once.

- If a CSS selector is passed (e.g. `'#myForm'`), the form is found via `document.querySelector`
- If no argument is passed, the closest `<form>` ancestor is found via `el.closest('form')`

### Usage

```php
// With an explicit form selector
ActionButton::make('Submit')
    ->method('postAndSave')
    ->withFormData('#myForm');

// Without argument — uses closest form
ActionButton::make('Submit')
    ->method('postAndSave')
    ->withFormData();
