### PR TITLE
Fix CRUD JSON policy authorization

### DIFF
--- a/src/Laravel/src/Http/Controllers/CrudController.php
+++ b/src/Laravel/src/Http/Controllers/CrudController.php
@@ -7,7 +7,6 @@ namespace MoonShine\Laravel\Http\Controllers;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests;
-use Illuminate\Http\Request;
 use MoonShine\Contracts\Core\DependencyInjection\CrudRequestContract;
 use MoonShine\Contracts\UI\FieldContract;
 use MoonShine\Crud\Contracts\Notifications\MoonShineNotificationContract;
@@ -17,6 +16,8 @@ use MoonShine\Laravel\Http\Requests\Resources\DeleteFormRequest;
 use MoonShine\Laravel\Http\Requests\Resources\MassDeleteFormRequest;
 use MoonShine\Laravel\Http\Requests\Resources\StoreFormRequest;
 use MoonShine\Laravel\Http\Requests\Resources\UpdateFormRequest;
+use MoonShine\Laravel\Http\Requests\Resources\ViewAnyFormRequest;
+use MoonShine\Laravel\Http\Requests\Resources\ViewFormRequest;
 use MoonShine\Support\Enums\ToastType;
 use MoonShine\UI\Enums\HtmlMode;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,7 +34,7 @@ final class CrudController extends MoonShineController
             ->only(['store', 'update']);
     }
 
-    public function index(Request $request, CrudRequestContract $crudRequest): Jsonable
+    public function index(ViewAnyFormRequest $request, CrudRequestContract $crudRequest): Jsonable
     {
         abort_if(! $request->wantsJson(), 403);
 
@@ -56,7 +57,7 @@ final class CrudController extends MoonShineController
         );
     }
 
-    public function show(Request $request, CrudRequestContract $crudRequest): Jsonable
+    public function show(ViewFormRequest $request, CrudRequestContract $crudRequest): Jsonable
     {
         abort_if(! $request->wantsJson(), 403);
 

--- a/tests/Feature/Resources/ResourceWithPoliciesTest.php
+++ b/tests/Feature/Resources/ResourceWithPoliciesTest.php
@@ -71,8 +71,26 @@ it('policies index forbidden', function () {
     )->assertForbidden();
 });
 
+it('policy denied index is forbidden by crud json endpoint', function () {
+    MoonshineUser::query()->where('id', 1)->update([
+        'name' => 'Policies test',
+    ]);
+
+    asAdmin()
+        ->withHeader('Accept', 'application/json')
+        ->get($this->resource->getRoute('crud.index'))
+        ->assertForbidden();
+});
+
 it('policies in detail', function () {
     asAdmin()->get(
         $this->resource->getDetailPageUrl($this->item->id)
     )->assertForbidden();
+});
+
+it('policy denied detail is forbidden by crud json endpoint', function () {
+    asAdmin()
+        ->withHeader('Accept', 'application/json')
+        ->get($this->resource->getRoute('crud.show', $this->item->id))
+        ->assertForbidden();
 });


### PR DESCRIPTION
## Summary
- enforce existing VIEW_ANY authorization on CRUD JSON index endpoint
- enforce existing VIEW authorization on CRUD JSON show endpoint
- add regression tests for policy-denied JSON CRUD endpoints

Fixes #2021

## Tests
- composer test tests/Feature/Resources/ResourceWithPoliciesTest.php
- composer test tests/Feature/Controllers/CrudControllerTest.php