### PR TITLE
Fixed handle failed validation for JSON requests in MoonShineFormRequest

### DIFF
--- a/src/Laravel/src/Http/Requests/MoonShineFormRequest.php
+++ b/src/Laravel/src/Http/Requests/MoonShineFormRequest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace MoonShine\Laravel\Http\Requests;
 
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\ValidationException;
 use MoonShine\Contracts\Core\PageContract;
 use MoonShine\Core\Exceptions\ResourceException;
 use MoonShine\Crud\Contracts\Page\FormPageContract;
@@ -34,6 +37,22 @@ class MoonShineFormRequest extends FormRequest
         }
 
         $this->request = request()->getPayload();
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        if ($this->expectsJson()) {
+            $exception = new ValidationException($validator);
+
+            throw new HttpResponseException(
+                response()->json([
+                    'message' => $exception->getMessage(),
+                    'errors' => $exception->errors(),
+                ], $exception->status)
+            );
+        }
+
+        parent::failedValidation($validator);
     }
 
     public function messages(): array


### PR DESCRIPTION
## What was changed
Updated MoonShineFormRequest to return a JSON validation response directly when the request expects JSON.
For failed validation on async MoonShine forms, it now returns a 422 response with the standard Laravel validation payload.


## Why?
Async MoonShine forms rely on JSON validation errors to display field errors on the frontend.
This became necessary after Laravel v13.8.0, where the default application skeleton started rendering JSON exceptions for API routes explicitly via shouldRenderJsonWhen(). If an application keeps that callback limited to api/*, MoonShine async form requests may still send Accept: application/json, but failed validation can be rendered as an HTML page instead of JSON.
Handling JSON validation failures inside MoonShineFormRequest makes MoonShine forms independent from the host application's exception rendering configuration and ensures validation errors are consistently displayed on the frontend.

## Checklist

- Tested
    - [ ] Tested manually
    - [ ] Tests added

