### PR TITLE
Fix saved query state filters

### DIFF
--- a/src/Crud/src/Concerns/Resource/HasFilters.php
+++ b/src/Crud/src/Concerns/Resource/HasFilters.php
@@ -104,11 +104,17 @@ trait HasFilters
     {
         $default = $this->getQueryParam('filter', []);
 
+        if ($this->isSaveQueryState() && $this->hasQueryParam('filter') && ! $this->hasQueryParam('reset')) {
+            return $default;
+        }
+
         if ($this->isSaveQueryState() && ! $this->hasQueryParam('reset')) {
+            $cached = $this->getCore()->getCache()->get($this->getQueryCacheKey(), []);
+
             return data_get(
-                $this->getCore()->getCache()->get($this->getQueryCacheKey(), []),
-                'filter',
-                $default,
+                $cached,
+                $this->getQueryParamName('filter'),
+                data_get($cached, 'filter', $default),
             );
         }
 

--- a/src/Crud/src/Traits/Resource/ResourceQuery.php
+++ b/src/Crud/src/Traits/Resource/ResourceQuery.php
@@ -409,7 +409,12 @@ trait ResourceQuery
 
     protected function getQueryCacheKey(): string
     {
-        return "moonshine_query_{$this->getUriKey()}";
+        return "moonshine_query_{$this->getUriKey()}{$this->getQueryCacheKeySuffix()}";
+    }
+
+    protected function getQueryCacheKeySuffix(): string
+    {
+        return '';
     }
 
     protected function withCache(): static

--- a/src/Laravel/src/Resources/ModelResource.php
+++ b/src/Laravel/src/Resources/ModelResource.php
@@ -143,6 +143,13 @@ abstract class ModelResource extends CrudResource implements WithQueryBuilderCon
         return Gate::forUser($user)->allows($ability->value, $item);
     }
 
+    protected function getQueryCacheKeySuffix(): string
+    {
+        $identifier = MoonShineAuth::getGuard()->id() ?? 'guest';
+
+        return '_user_' . str_replace(['\\', '/', ':'], '_', (string) $identifier);
+    }
+
     /**
      * @param  array<int|string>  $ids
      */

--- a/tests/Feature/Pages/IndexPageTest.php
+++ b/tests/Feature/Pages/IndexPageTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 uses()->group('pages-feature');
 
+use MoonShine\Laravel\Models\MoonshineUser;
 use MoonShine\Laravel\Pages\Crud\IndexPage;
 use MoonShine\Tests\Fixtures\Factories\CategoryFactory;
 use MoonShine\Tests\Fixtures\Models\Category;
@@ -55,3 +56,82 @@ it('query tags', function () {
         ->assertSee($item->name)
     ;
 });
+
+it('prefers current filter params over cached query state', function () {
+    $resource = app(SaveQueryStateTestItemResource::class);
+
+    fakeRequest('/', parameters: [
+        'p_filter' => [
+            'name' => 'Fresh filter',
+        ],
+    ]);
+
+    $resource->setQueryParams(
+        $this->moonshineCore->getRequest()->getOnly($resource->getQueryParamsKeys())
+    );
+
+    $this->moonshineCore->getCache()->set(
+        $resource->publicQueryCacheKey(),
+        [
+            'p_filter' => [
+                'name' => 'Cached filter',
+            ],
+        ],
+    );
+
+    expect($resource->getFilterParams())
+        ->toBe([
+            'name' => 'Fresh filter',
+        ]);
+});
+
+it('fills filter params from cached prefixed query state', function () {
+    $resource = app(SaveQueryStateTestItemResource::class);
+
+    fakeRequest('/');
+
+    $resource->setQueryParams(
+        $this->moonshineCore->getRequest()->getOnly($resource->getQueryParamsKeys())
+    );
+
+    $this->moonshineCore->getCache()->set(
+        $resource->publicQueryCacheKey(),
+        [
+            'p_filter' => [
+                'name' => 'Cached filter',
+            ],
+        ],
+    );
+
+    expect($resource->getFilterParams())
+        ->toBe([
+            'name' => 'Cached filter',
+        ]);
+});
+
+it('scopes saved query state by moonshine user', function () {
+    $resource = app(SaveQueryStateTestItemResource::class);
+
+    fakeRequest('/');
+
+    $adminKey = $resource->publicQueryCacheKey();
+
+    $user = MoonshineUser::factory()->create();
+
+    $this->actingAs($user, 'moonshine')->get('/');
+
+    expect($resource->publicQueryCacheKey())
+        ->not->toBe($adminKey);
+});
+
+final class SaveQueryStateTestItemResource extends TestItemResource
+{
+    protected bool $saveQueryState = true;
+
+    protected string $queryParamPrefix = 'p_';
+
+    public function publicQueryCacheKey(): string
+    {
+        return $this->getQueryCacheKey();
+    }
+}


### PR DESCRIPTION
## What was changed

  Fixed saved query state behavior for resource filters:

  - Current request filter params now take priority over cached filter params.
  - Cached filter params are restored correctly for resources that use a query param prefix.
  - Laravel model resources now scope saved query state cache keys by the current MoonShine user.
  - Added tests for fresh filter priority, prefixed cached filters, and user-scoped query state.

  ## Why?

  Saved query state could behave unpredictably when filters were cached:

  - Submitting a new filter could still use an older cached filter value.
  - After redirecting back to an index page, the list could use cached filters while the filters form appeared empty.
  - Saved query state was shared by resource URI only, so different MoonShine users could reuse the same cached state.

  These changes make saved filter state predictable and user-specific.

  ## Checklist

  - Issue #
  - Tested
      - [x] Tested manually
      - [x] Tests added
  - [ ] Documentation

## RUS What was changed

  Исправлено поведение сохраненного query state для фильтров ресурсов:

  - Текущие параметры фильтра из request теперь имеют приоритет над закэшированными.
  - Закэшированные фильтры корректно восстанавливаются для ресурсов с query param prefix.
  - Laravel model resources теперь добавляют текущего MoonShine-пользователя в cache key сохраненного query state.
  - Добавлены тесты на приоритет свежего фильтра, prefixed cached filters и user-scoped query state.

  ## Why?

  Сохраненное состояние фильтров могло работать непредсказуемо:

  - При отправке нового фильтра мог использоваться старый фильтр из cache.
  - После редиректа обратно на index список мог фильтроваться по cache, но форма фильтров оставалась пустой.
  - Query state сохранялся только по URI ресурса, поэтому разные MoonShine-пользователи могли использовать одно и то же закэшированное состояние.

  Эти изменения делают сохраненное состояние фильтров предсказуемым и привязанным к пользователю.

  ## Checklist

  - Issue #
  - Tested
      - [x] Tested manually
      - [x] Tests added
  - [ ] Documentation