### PR TITLE
fix: stop HTML-encoding Text and Textarea values into storage

### DIFF
--- a/src/UI/src/Fields/Text.php
+++ b/src/UI/src/Fields/Text.php
@@ -64,15 +64,6 @@ class Text extends Field implements HasDefaultValueContract, CanBeString, HasUpd
             ]);
     }
 
-    protected function prepareRequestValue(mixed $value): mixed
-    {
-        if (\is_string($value)) {
-            return $this->isUnescape() ? $value : $this->escapeValue($value);
-        }
-
-        return $value;
-    }
-
     protected function resolvePreview(): Renderable|string
     {
         return $this->isUnescape()

--- a/src/UI/src/Fields/Textarea.php
+++ b/src/UI/src/Fields/Textarea.php
@@ -31,15 +31,6 @@ class Textarea extends Field implements HasDefaultValueContract, CanBeString
             : $this->escapeValue((string) parent::resolvePreview());
     }
 
-    protected function prepareRequestValue(mixed $value): mixed
-    {
-        if (\is_string($value) && static::class === self::class) {
-            return $this->isUnescape() ? $value : $this->escapeValue($value);
-        }
-
-        return $value;
-    }
-
     protected function resolveValue(): mixed
     {
         if (! $this->isUnescape() && static::class === self::class) {

--- a/tests/Feature/Fields/EscapeRenderingTest.php
+++ b/tests/Feature/Fields/EscapeRenderingTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use MoonShine\Tests\Fixtures\Models\Item;
+use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
+use MoonShine\UI\Fields\ID;
+use MoonShine\UI\Fields\Text;
+use MoonShine\UI\Fields\Textarea;
+
+uses()->group('fields');
+uses()->group('escape');
+
+const XSS_TAG = '<script>alert(1)</script>';
+const XSS_ATTR = '" onfocus="alert(1)" autofocus x="';
+
+beforeEach(function (): void {
+    $fields = [
+        ID::make(),
+        Text::make('Name title', 'name'),
+        Textarea::make('Content', 'content'),
+    ];
+
+    $this->resource = TestResourceBuilder::new(Item::class)
+        ->setTestIndexFields($fields)
+        ->setTestDetailFields($fields)
+        ->setTestFormFields($fields)
+        ->setTestExportFields([ID::make()])
+        ->setTestImportFields([ID::make()]);
+
+    // Values as stored once escaping is off the save path: exactly what was
+    // typed, no entities.
+    $this->item = createItem(1, 0);
+    $this->item->forceFill([
+        'name' => XSS_TAG . XSS_ATTR,
+        'content' => XSS_TAG,
+    ])->save();
+});
+
+it('never emits a raw script tag from a stored value', function (string $urlMethod): void {
+    $url = $urlMethod === 'getIndexPageUrl'
+        ? $this->resource->getIndexPageUrl()
+        : $this->resource->{$urlMethod}($this->item->getKey());
+
+    $html = asAdmin()->get($url)->assertOk()->getContent();
+
+    expect($html)
+        ->not->toContain(XSS_TAG)
+        ->not->toContain(XSS_ATTR)
+        ->toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+})->with([
+    ['getIndexPageUrl'],
+    ['getDetailPageUrl'],
+    ['getFormPageUrl'],
+]);
+
+it('stores what the form posted, byte for byte', function (): void {
+    $typed = 'musique d\'ambiance & "quotes"';
+
+    asAdmin()->put(
+        $this->resource->getRoute('crud.update', $this->item->getKey()),
+        ['name' => $typed, 'content' => $typed]
+    );
+
+    $this->item->refresh();
+
+    expect($this->item->name)->toBe($typed)
+        ->and($this->item->content)->toBe($typed);
+});

--- a/tests/Feature/Fields/EscapeSinkSweepTest.php
+++ b/tests/Feature/Fields/EscapeSinkSweepTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use MoonShine\Tests\Fixtures\Models\Item;
+use MoonShine\Tests\Fixtures\Resources\TestItemResource;
+
+uses()->group('fields');
+uses()->group('escape');
+
+const SWEEP_TAG = '<script>alert(1)</script>';
+const SWEEP_ATTR = '" onfocus="alert(1)" autofocus x="';
+
+beforeEach(function (): void {
+    $this->resource = app(TestItemResource::class);
+
+    $this->item = createItem(1, 1);
+    $this->item->forceFill([
+        'name' => SWEEP_TAG . SWEEP_ATTR,
+        'content' => SWEEP_TAG,
+    ])->save();
+});
+
+/**
+ * Assert a response body carries no executable payload.
+ *
+ * JSON bodies escape the solidus, so `</script>` arrives as `<\/script>`;
+ * checking only the literal would pass on a body that does leak.
+ */
+function assertNoRawPayload(string $body): void
+{
+    expect($body)
+        ->not->toContain(SWEEP_TAG)
+        ->not->toContain(str_replace('/', '\/', SWEEP_TAG))
+        ->not->toContain(SWEEP_ATTR)
+        ->not->toContain(str_replace('"', '\"', SWEEP_ATTR));
+}
+
+it('does not leak through an async component reload', function (): void {
+    $html = asAdmin()->get($this->moonshineCore->getRouter()->to('component', [
+        '_component_name' => 'index-table-test-item-resource',
+        'resourceUri' => $this->resource->getUriKey(),
+        'pageUri' => 'index-page',
+    ]))->assertOk()->getContent();
+
+    expect($html)->toContain('&lt;script&gt;');
+
+    assertNoRawPayload($html);
+});
+
+it('does not leak through a fragment load', function (): void {
+    $html = asAdmin()->get(
+        $this->resource->getIndexPageUrl(['_fragment-load' => 'index-table-test-item-resource'])
+    )->assertOk()->getContent();
+
+    assertNoRawPayload($html);
+});
+
+/**
+ * The SDUI structure response is a JSON API for third-party front-ends, not an
+ * HTML sink. It carries the stored value verbatim -- which is the point of the
+ * fix, since entity-encoded data was what #2044 reported. Escaping is the
+ * consumer's responsibility at its own render step.
+ *
+ * This is a behaviour change: before the fix these payloads were incidentally
+ * pre-escaped because the escaping happened on the save path.
+ */
+it('carries the stored value verbatim through the SDUI json structure', function (string $urlMethod): void {
+    $url = $urlMethod === 'getIndexPageUrl'
+        ? $this->resource->getIndexPageUrl()
+        : $this->resource->{$urlMethod}($this->item->getKey());
+
+    $json = asAdmin()->getJson($url, ['X-MS-Structure' => true])->assertOk()->getContent();
+
+    expect($json)->toContain(str_replace('/', '\/', SWEEP_TAG));
+})->with([
+    ['getIndexPageUrl'],
+    ['getDetailPageUrl'],
+    ['getFormPageUrl'],
+]);
+
+it('serves the stored value verbatim to a non-blade consumer', function (): void {
+    // The whole point of the fix: an API/export reading the column gets what
+    // the user typed, with no entities to decode.
+    expect(Item::query()->find($this->item->getKey())->name)
+        ->toBe(SWEEP_TAG . SWEEP_ATTR);
+});

--- a/tests/Unit/Fields/EscapeValueTest.php
+++ b/tests/Unit/Fields/EscapeValueTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Eloquent\Model;
+use MoonShine\Laravel\Fields\Slug;
+use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
+use MoonShine\UI\Fields\Email;
+use MoonShine\UI\Fields\Field;
+use MoonShine\UI\Fields\Phone;
+use MoonShine\UI\Fields\Text;
+use MoonShine\UI\Fields\Textarea;
+use MoonShine\UI\Fields\Url;
+
+uses()->group('fields');
+uses()->group('escape');
+
+function applyToModel(Field $field, string $value): Model
+{
+    fakeRequest(parameters: ['field_name' => $value]);
+
+    return $field->apply(
+        TestResourceBuilder::new()->fieldApply($field),
+        new class () extends Model {
+            protected $fillable = [
+                'field_name',
+            ];
+        }
+    );
+}
+
+it('stores the typed value verbatim', function (string $class): void {
+    $value = 'musique d\'ambiance & "quotes" <b>';
+
+    expect(applyToModel($class::make('Field name'), $value))
+        ->field_name
+        ->toBe($value);
+})->with([
+    [Text::class],
+    [Textarea::class],
+    [Email::class],
+    [Url::class],
+    [Phone::class],
+    [Slug::class],
+]);
+
+it('does not compound encoding across repeated saves', function (string $class): void {
+    $value = 'a & b';
+
+    $first = applyToModel($class::make('Field name'), $value)->field_name;
+    $second = applyToModel($class::make('Field name'), $first)->field_name;
+
+    expect($second)->toBe($first);
+})->with([
+    [Text::class],
+    [Textarea::class],
+]);
+
+it('keeps a url query string intact', function (): void {
+    expect(applyToModel(Url::make('Field name'), 'https://example.com/?a=1&b=2'))
+        ->field_name
+        ->toBe('https://example.com/?a=1&b=2');
+});
+
+it('escapes the text input value attribute on render', function (): void {
+    $payload = '" onfocus="alert(1)" autofocus x="';
+
+    expect((string) Text::make('Field name')->fill($payload)->render())
+        ->toContain('&quot; onfocus=&quot;alert(1)&quot; autofocus x=&quot;')
+        ->not->toContain('" onfocus="alert(1)"');
+});
+
+it('escapes the textarea value on render', function (): void {
+    expect((string) Textarea::make('Field name')->fill('<script>alert(1)</script>')->render())
+        ->toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+        ->not->toContain('<script>');
+});
+
+it('escapes both the href and the label of a url preview', function (): void {
+    expect((string) Url::make('Field name')->fill('https://example.com/?a=1&b=2"><script>alert(1)</script>')->previewMode()->render())
+        ->toContain('href="https://example.com/?a=1&amp;b=2&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"')
+        ->not->toContain('<script>');
+});
+
+it('escapes the preview value', function (string $class): void {
+    expect((string) $class::make('Field name')->fill('<script>alert(1)</script>')->previewMode()->render())
+        ->not->toContain('<script>');
+})->with([
+    [Text::class],
+    [Textarea::class],
+]);
+
+it('renders the raw value when unescaped', function (string $class): void {
+    expect((string) $class::make('Field name')->unescape()->fill('<b>bold</b>')->previewMode()->render())
+        ->toContain('<b>bold</b>');
+})->with([
+    [Text::class],
+    [Textarea::class],
+]);


### PR DESCRIPTION
## What was changed

Removed the `prepareRequestValue()` overrides from `Text` and `Textarea`. Both called
`htmlspecialchars()` on the **save** path, so the database stored HTML entities instead of what the
user typed.

```diff
-    protected function prepareRequestValue(mixed $value): mixed
-    {
-        if (\is_string($value)) {
-            return $this->isUnescape() ? $value : $this->escapeValue($value);
-        }
-
-        return $value;
-    }
```

That is the entire source change — 18 lines deleted, nothing added. Both classes fall back to
`FormElement::prepareRequestValue()`, which returns the value unchanged. No new API, and the
render-side escaping is untouched.

## Why?

`escapeValue()` passes `doubleEncode: true`, so each save re-encoded the previous encoding. Saving
`musique d'ambiance & "quotes"` through the admin form:

| | value in the DB column |
|---|---|
| typed | `musique d'ambiance & "quotes"` |
| after 1st save | `musique d&#039;ambiance &amp; &quot;quotes&quot;` |
| after 2nd save | `musique d&amp;#039;ambiance &amp;amp; &amp;quot;quotes&amp;quot;` |

It grew by one layer per save, without limit. `Email`, `Url`, `Phone` and `Slug` extend `Text` and
inherited it — for `Url` it corrupted query strings, storing `?a=1&b=2` as `?a=1&amp;b=2`.

This is the same root cause as #1894, fixed in #1895 for `Password` only by overriding
`isUnescape()`. That override is redundant after this change but harmless, so this PR leaves it alone.

### Why deleting it is safe rather than a hole

The save-time escape was redundant for HTML rendering. Every HTML sink already escapes on output:

| Field | Sink | Escaped by |
|---|---|---|
| `Text` (+ `Email`, `Url`, `Phone`, `Slug`) | `<input value="…">` | `ComponentAttributeBag::merge()`, which escapes by default |
| `Textarea` | `{!! $value !!}` in `moonshine::fields.textarea` | `Textarea::resolveValue()` |
| index / detail preview | `{!! $slot !!}` in `components/table/td.blade.php` | `resolvePreview()` |
| `Url` preview | `<a href="…">label</a>` | attribute escaping + `Url::resolvePreview()` |

Rather than rely on reading the code, the added tests store an XSS payload raw and render it through
the real HTTP layer — index, detail and form pages, the async component reload, and fragment loads.
To confirm those tests are load-bearing rather than passing vacuously, I neutralised
`resolvePreview()` / `resolveValue()` and re-ran them: they fail on every page. The output escaping
is doing the work; the save-time escape was duplicating it.

## Behaviour change: the SDUI structure response

**This is the one deliberate, user-visible change beyond the fix, and it deserves your call.**

The SDUI JSON (`X-MS-Structure`) now carries the stored value verbatim. Three places emit it: the
index `data` rows, breadcrumb titles, and the form field `value`.

| | DB column | SDUI JSON |
|---|---|---|
| before | `&lt;script&gt;alert(1)&lt;/script&gt;` | `&lt;script&gt;alert(1)&lt;/script&gt;` |
| after | `<script>alert(1)</script>` | `<script>alert(1)</script>` |

I believe this is correct — it is the same thing the issue reports, since a JSON API answering
`musique d&#039;ambiance` is the bug. Escaping data inside a JSON transport is the same category of
mistake as escaping it into the database, and escaping belongs at the consumer's render step.

But it is a real change for anyone consuming SDUI who was relying on the incidental pre-escaping,
and it is undocumented today. If you would rather it not land in a `4.x` patch, I am happy to retarget
this at the next major, or to gate it.

MoonShine's own front-end is unaffected: it consumes HTML fragments, which the tests show stay escaped.

## Existing data

Rows already written stay encoded. They render as entities in the panel — that is true both before and
after this PR, since the render path is unchanged, so this is not a regression. Decoding them is
application-specific, so I have not added a command; a one-off per affected column looks like:

```php
Item::query()->eachById(function (Item $item): void {
    $value = $item->name;

    while ($value !== ($decoded = html_entity_decode($value, ENT_QUOTES, 'UTF-8'))) {
        $value = $decoded;
    }

    $item->updateQuietly(['name' => $value]);
});
```

Worth flagging to users that this also decodes entities somebody typed deliberately.

## Checklist

- Issue #2044
- Tested
    - [x] Tested manually
    - [x] Tests added
        - `tests/Unit/Fields/EscapeValueTest.php` — values round-trip to storage verbatim across
          `Text`, `Textarea`, `Email`, `Url`, `Phone` and `Slug`; repeated saves do not compound;
          input attribute, textarea body, previews and `Url` href/label still escape `<script>` and
          attribute-breakout payloads.
        - `tests/Feature/Fields/EscapeRenderingTest.php` — index, detail and form pages rendered
          through HTTP with a payload stored raw.
        - `tests/Feature/Fields/EscapeSinkSweepTest.php` — async component reload, fragment load and
          the SDUI structure response.
        - Every storage test fails on `4.x` before the change and passes after. Full suite locally:
          768 passing, with 4 failures that also fail on unmodified `4.x` (`PublishCommand`,
          `DateRangeFieldTest` ×2, `SelectFieldTest`) because I ran against SQLite rather than MySQL.
- [ ] Documentation — `unescape()` is documented as "disables the escaping of HTML tags in the field
  value", which is what it does after this change; before it also silently disabled a storage-time
  mutation. Happy to open a docs PR for the SDUI note if you want this merged as-is.
