### PR TITLE
Fix Select field names settings

### DIFF
--- a/src/UI/src/Traits/Fields/ConfigurableSelect.php
+++ b/src/UI/src/Traits/Fields/ConfigurableSelect.php
@@ -82,7 +82,9 @@ trait ConfigurableSelect
 
     public function fieldsNames(FieldsNames $names): static
     {
-        return $this->settings(array_filter($names->toArray()));
+        $this->settings = array_merge($this->settings, array_filter($names->toArray()));
+
+        return $this;
     }
 
     public function selectCreatable(

--- a/tests/Unit/Fields/SelectFieldTest.php
+++ b/tests/Unit/Fields/SelectFieldTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Model;
+use MoonShine\Support\DTOs\Select\FieldsNames;
 use MoonShine\Support\DTOs\Select\Option;
 use MoonShine\Support\DTOs\Select\OptionGroup;
 use MoonShine\Support\DTOs\Select\OptionImage;
@@ -96,6 +97,16 @@ describe('basic methods', function () {
             ->and($this->fieldMultiple->searchable())
             ->isSearchable()
             ->toBeTrue();
+    });
+
+    it('field names', function (): void {
+        expect($this->field->fieldsNames(
+            FieldsNames::make()->value('id')->label('name')
+        )->toArray()['settings'])->toBe([
+            'valueField' => 'id',
+            'labelField' => 'name',
+            'searchField' => ['name'],
+        ]);
     });
 
     it('options', function (): void {


### PR DESCRIPTION
Fixes #2047.

## Summary

- preserve `FieldsNames` values when configuring Select fields
- avoid passing field-name mappings through the unrelated `Settings` whitelist
- add a regression test for custom value, label, and search field names

## Testing

- `vendor/bin/pest tests/Unit/Fields/SelectFieldTest.php` (22 passed, 47 assertions)
- `composer test:types:packages`