### PR TITLE
Add conditional escaping for text values on apply

### DIFF
--- a/src/UI/src/Fields/Password.php
+++ b/src/UI/src/Fields/Password.php
@@ -38,6 +38,11 @@ class Password extends Text
         return true;
     }
 
+    public function isUnescapeOnApply(): bool
+    {
+        return true;
+    }
+
     public function raw(Closure|bool|null $condition = null): static
     {
         $result = value($condition, $this) ?? true;

--- a/src/UI/src/Fields/Text.php
+++ b/src/UI/src/Fields/Text.php
@@ -67,7 +67,7 @@ class Text extends Field implements HasDefaultValueContract, CanBeString, HasUpd
     protected function prepareRequestValue(mixed $value): mixed
     {
         if (\is_string($value)) {
-            return $this->isUnescape() ? $value : $this->escapeValue($value);
+            return $this->isUnescapeOnApply() ? $value : $this->escapeValue($value);
         }
 
         return $value;

--- a/src/UI/src/Fields/Textarea.php
+++ b/src/UI/src/Fields/Textarea.php
@@ -34,7 +34,7 @@ class Textarea extends Field implements HasDefaultValueContract, CanBeString
     protected function prepareRequestValue(mixed $value): mixed
     {
         if (\is_string($value) && static::class === self::class) {
-            return $this->isUnescape() ? $value : $this->escapeValue($value);
+            return $this->isUnescapeOnApply() ? $value : $this->escapeValue($value);
         }
 
         return $value;

--- a/src/UI/src/Traits/Fields/WithEscapedValue.php
+++ b/src/UI/src/Traits/Fields/WithEscapedValue.php
@@ -4,9 +4,16 @@ declare(strict_types=1);
 
 namespace MoonShine\UI\Traits\Fields;
 
+use Closure;
+
 trait WithEscapedValue
 {
     protected bool $unescape = false;
+
+    /**
+     * @var (Closure(static): bool)|null
+     */
+    protected ?Closure $escapeOnApply = null;
 
     public function escape(): static
     {
@@ -25,6 +32,25 @@ trait WithEscapedValue
     public function isUnescape(): bool
     {
         return $this->unescape;
+    }
+
+    /**
+     * @param (Closure(static $ctx): bool)|null $condition = null
+     */
+    public function escapeOnApply(?Closure $condition = null): static
+    {
+        $this->escapeOnApply = $condition;
+
+        return $this;
+    }
+
+    public function isUnescapeOnApply(): bool
+    {
+        if ($this->escapeOnApply === null) {
+            return false;
+        }
+
+        return ! \call_user_func($this->escapeOnApply, $this);
     }
 
     protected function escapeValue(?string $value = null, bool $doubleEncode = true): string

--- a/tests/Unit/Fields/TextFieldTest.php
+++ b/tests/Unit/Fields/TextFieldTest.php
@@ -9,6 +9,7 @@ use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
 use MoonShine\UI\Fields\Field;
 use MoonShine\UI\Fields\FormElement;
 use MoonShine\UI\Fields\Text;
+use MoonShine\UI\Fields\Textarea;
 use MoonShine\UI\InputExtensions\InputExtension;
 use MoonShine\UI\InputExtensions\InputEye;
 
@@ -69,6 +70,36 @@ it('apply', function (): void {
         ->toBe($data['field_name'])
     ;
 });
+
+it('conditionally escapes on apply without affecting preview', function (string $fieldClass, ?bool $condition, string $expected): void {
+    $value = '<script>alert(1)</script> &';
+    $field = $fieldClass::make('Field name');
+
+    if (! \is_null($condition)) {
+        $field->escapeOnApply(fn (): bool => $condition);
+    }
+
+    fakeRequest(parameters: ['field_name' => $value]);
+
+    expect($field->apply(
+        TestResourceBuilder::new()->fieldApply($field),
+        new class () extends Model {
+            protected $fillable = ['field_name'];
+        }
+    ))
+        ->field_name
+        ->toBe($expected)
+        ->and((string) $field->fill($value)->previewMode()->render())
+        ->not->toContain($value)
+        ->toContain('&lt;script&gt;');
+})->with([
+    [Text::class, null, '&lt;script&gt;alert(1)&lt;/script&gt; &amp;'],
+    [Text::class, true, '&lt;script&gt;alert(1)&lt;/script&gt; &amp;'],
+    [Text::class, false, '<script>alert(1)</script> &'],
+    [Textarea::class, null, '&lt;script&gt;alert(1)&lt;/script&gt; &amp;'],
+    [Textarea::class, true, '&lt;script&gt;alert(1)&lt;/script&gt; &amp;'],
+    [Textarea::class, false, '<script>alert(1)</script> &'],
+]);
 
 it('visual states', function () {
     $field = Text::make('Field name')->fill('<p>Hello world</p>');


### PR DESCRIPTION
Fixes #2044.

## Summary

- add an `escapeOnApply()` callback to control HTML escaping for `Text` and `Textarea` request values
- keep the existing save-time escaping by default while allowing applications to store the submitted value unchanged
- keep preview escaping independent from save-time escaping
- preserve raw password handling through a dedicated apply-side override
- add regression coverage for `Text` and `Textarea` with no callback and callbacks returning `true` or `false`

## Testing

- `vendor/bin/pest tests/Unit/Fields/TextFieldTest.php tests/Unit/Fields/TextareaFieldTest.php tests/Unit/Fields/PasswordFieldTest.php` (39 passed, 91 assertions)
- `composer test:types:packages`
- PHP CS Fixer on all changed files