### PR TITLE
Fix unsafe Alpine value interpolation in Blade templates

### DIFF
--- a/src/Laravel/src/Fields/Relationships/MorphTo.php
+++ b/src/Laravel/src/Fields/Relationships/MorphTo.php
@@ -186,7 +186,7 @@ class MorphTo extends BelongsTo
         return [
             ...parent::viewData(),
             'types' => $this->getTypes()->toArray(),
-            'typeValue' => addslashes($this->getTypeValue()),
+            'typeValue' => $this->getTypeValue(),
             'column' => $this->getColumn(),
             'morphType' => $this->getMorphType(),
             'morphTypeName' => Str::of($this->getNameAttribute())->replace($this->getColumn(), $this->getMorphType()),

--- a/src/Support/src/Traits/WithComponentAttributes.php
+++ b/src/Support/src/Traits/WithComponentAttributes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MoonShine\Support\Traits;
 
 use Closure;
+use Illuminate\Support\Js;
 use Illuminate\Support\Str;
 use MoonShine\Contracts\UI\ComponentAttributesBagContract;
 use MoonShine\Contracts\UI\FieldContract;
@@ -143,7 +144,7 @@ trait WithComponentAttributes
     {
         if (\is_array($value)) {
             try {
-                $value = str_replace('"', "'", json_encode($value, JSON_THROW_ON_ERROR));
+                $value = Js::from($value)->toHtml();
             } catch (Throwable) {
                 $value = null;
             }
@@ -170,7 +171,9 @@ trait WithComponentAttributes
         $data = [];
 
         foreach ($parameters as $parameter) {
-            $data[] = Str::of($parameter ?? '')->isJson() ? $parameter : "`$parameter`";
+            $data[] = Str::of($parameter ?? '')->isJson()
+                ? $parameter
+                : Js::from($parameter ?? '')->toHtml();
         }
 
         $data = implode(",", $data);

--- a/src/UI/resources/views/components/cards.blade.php
+++ b/src/UI/resources/views/components/cards.blade.php
@@ -15,8 +15,8 @@
 ])
 <div class="js-cards-builder-container">
     <div x-data="cardsBuilder(
-    {{ (int) $async }},
-    '{{ $asyncUrl }}'
+    @js((int) $async),
+    @js($asyncUrl)
 )"
          @defineEventWhen($async, 'cards_updated', $name, 'asyncRequest')
         {{ $attributes }}

--- a/src/UI/resources/views/components/carousel.blade.php
+++ b/src/UI/resources/views/components/carousel.blade.php
@@ -16,7 +16,7 @@
         <a @click.prevent="previous" href="javascript:void(0);" class="carousel-navigation-next" x-show="activeSlide !== 0">
             <x-moonshine::icon icon="chevron-left" />
         </a>
-        <a @click.prevent="next" href="javascript:void(0);" class="carousel-navigation-prev" x-show="activeSlide !== {{ count($items) - 1 }}">
+        <a @click.prevent="next" href="javascript:void(0);" class="carousel-navigation-prev" x-show="activeSlide !== @js(count($items) - 1)">
             <x-moonshine::icon icon="chevron-right" />
         </a>
     </div>

--- a/src/UI/resources/views/components/collapse.blade.php
+++ b/src/UI/resources/views/components/collapse.blade.php
@@ -10,9 +10,9 @@
     {{ $attributes->class(['accordion']) }}
     x-data="
         @if($persist)
-            collapse($persist({{ $open ? 'true' : 'false' }}).as($id('collapse')))
+            collapse($persist(@js($open)).as($id('collapse')))
         @else
-            collapse({{ $open ? 'true' : 'false' }})
+            collapse(@js($open))
         @endif
     "
 >
@@ -51,4 +51,3 @@
         </div>
     </div>
 </div>
-

--- a/src/UI/resources/views/components/form/file-item.blade.php
+++ b/src/UI/resources/views/components/form/file-item.blade.php
@@ -45,7 +45,7 @@
 
     @if($imageable)
         <img src="{{ $file }}"
-             @click.stop="$dispatch('img-popup', {open: true, src: '{{ $file }}' })"
+             @click.stop="$dispatch('img-popup', {open: true, src: @js($file)})"
              alt="{{ $filename ?? '' }}"
         />
     @endif

--- a/src/UI/resources/views/components/form/input-extensions/copy.blade.php
+++ b/src/UI/resources/views/components/form/input-extensions/copy.blade.php
@@ -2,10 +2,10 @@
     'value',
     'translates' => [],
 ])
-<button @click.prevent="copy('{{ $value }}')"
+<button @click.prevent="copy(@js($value))"
         {{ $attributes->class(['expansion']) }}
         type="button"
-        x-data="tooltip('{{ $translates['copied'] }}', {placement: 'top', trigger: 'click', delay: [0, 800]})"
+        x-data="tooltip(@js($translates['copied']), {placement: 'top', trigger: 'click', delay: [0, 800]})"
 >
     <x-moonshine::icon
         icon="clipboard"

--- a/src/UI/resources/views/components/form/label.blade.php
+++ b/src/UI/resources/views/components/form/label.blade.php
@@ -1,7 +1,13 @@
 @props([
-    'required' => false
+    'required' => false,
+    'forName' => null,
 ])
-<label {{ $attributes->merge(['class' => 'form-label']) }}>
+<label
+    @if($forName !== null)
+        :for="$id('field-' + @js($forName))"
+    @endif
+    {{ $attributes->merge(['class' => 'form-label']) }}
+>
     {{ $slot ?? ''  }}
 
     @if($required)

--- a/src/UI/resources/views/components/form/select.blade.php
+++ b/src/UI/resources/views/components/form/select.blade.php
@@ -10,13 +10,14 @@
 ])
 
 <select
+        @if(!$native && !$attributes->has('x-data'))
+            x-data="select(@js((string) $asyncRoute), @js($settings), @js($plugins))"
+        @endif
         {{ $attributes->merge([
             'class' => $native ? 'form-select' : null,
             'data-search-enabled' => $searchable,
             'data-remove-item-button' => $attributes->get('multiple', false) || $nullable
-        ])->when(!$native, fn($a) => $a->merge([
-            'x-data' => "select('$asyncRoute', ". json_encode($settings) .", ". json_encode($plugins) .")",
-        ]))->when($nullable && !$native && $attributes->get('placeholder') === null, fn($a) => $a->merge(['placeholder' => '-'])) }}
+        ])->when($nullable && !$native && $attributes->get('placeholder') === null, fn($a) => $a->merge(['placeholder' => '-'])) }}
 >
     @if($options ?? false)
         {!! $options !!}

--- a/src/UI/resources/views/components/form/slide-range.blade.php
+++ b/src/UI/resources/views/components/form/slide-range.blade.php
@@ -11,7 +11,7 @@
     'toField' => $toName
 ])
 <div {{ $attributes->class(['form-group-range'])->only('class') }}>
-    <div x-data="range({{ '`'.($fromValue ?? $min).'`,`'.($toValue ?? $max).'`' }})"
+    <div x-data="range(@js($fromValue ?? $min), @js($toValue ?? $max))"
          x-init="mintrigger(); maxtrigger()"
          data-min="{{ $attributes->get('min', $min) }}"
          data-max="{{ $attributes->get('max', $max) }}"

--- a/src/UI/resources/views/components/form/wrapper.blade.php
+++ b/src/UI/resources/views/components/form/wrapper.blade.php
@@ -8,7 +8,7 @@
     'after',
 ])
 <div {{ $attributes->merge(['class' => 'form-group moonshine-field'])->except('required') }}
-     x-id="['input-wrapper', 'field-{{ $formName }}']"
+     x-id="['input-wrapper', 'field-' + @js($formName)]"
      :id="$id('input-wrapper')"
      data-validation-wrapper
 >
@@ -17,7 +17,7 @@
     @if($label)
         <x-moonshine::form.label
             :required="$attributes->get('required', false)"
-            ::for="$id('field-{{ $formName }}')"
+            :for-name="$formName"
         >
             {{ $beforeLabel && $insideLabel ? $slot : '' }}
             {!! $label !!}

--- a/src/UI/resources/views/components/fragment.blade.php
+++ b/src/UI/resources/views/components/fragment.blade.php
@@ -16,7 +16,7 @@
 @if($interval)
     <script>
         setInterval(() => {
-            window.dispatchEvent(new CustomEvent('fragment_updated:{{ $name }}'))
-        }, {{ $interval }})
+            window.dispatchEvent(new CustomEvent("fragment_updated:" + @js($name)))
+        }, @js($interval))
     </script>
 @endif

--- a/src/UI/resources/views/components/layout/burger.blade.php
+++ b/src/UI/resources/views/components/layout/burger.blade.php
@@ -8,15 +8,15 @@
 
 <button
     type="button"
-    {{ $attributes->merge([
-        'class'          => 'btn-burger btn-fit',
-        '@click.prevent' => '$store.menu.' . $toggleMethod . '()',
-    ]) }}
+    {{ $attributes->merge(['class' => 'btn-burger btn-fit']) }}
+    @if(!$attributes->has('@click.prevent'))
+        @click.prevent="$store.menu[@js($toggleMethod)]()"
+    @endif
 >
-    <svg x-show="!$store.menu.{{ $toggleState }}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+    <svg x-show="!$store.menu[@js($toggleState)]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
     </svg>
-    <svg x-cloak x-show="$store.menu.{{ $toggleState }}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+    <svg x-cloak x-show="$store.menu[@js($toggleState)]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
     </svg>
 </button>

--- a/src/UI/resources/views/components/menu/group.blade.php
+++ b/src/UI/resources/views/components/menu/group.blade.php
@@ -13,7 +13,7 @@
         @click.outside="dropdown = false"
         data-dropdown-placement="bottom-start"
     @else
-        x-data="{ dropdown: {{ $isActive ? 'true' : 'false' }} }"
+        x-data="{ dropdown: @js($isActive) }"
     @endif
     :class="dropdown && 'menu-item--opened'"
     x-ref="dropdownMenu"

--- a/src/UI/resources/views/components/modal.blade.php
+++ b/src/UI/resources/views/components/modal.blade.php
@@ -13,9 +13,9 @@
     'outerHtml' => null
 ])
 <div x-data="modal(
-    `{{ $open }}`,
-    `{{ $async ? str_replace('&amp;', '&', $asyncUrl) : ''}}`,
-    `{{ $autoClose }}`
+    @js((string) $open),
+    @js($async ? str_replace('&amp;', '&', $asyncUrl) : ''),
+    @js((string) $autoClose)
 )"
     {{ $attributes }}
 >

--- a/src/UI/resources/views/components/off-canvas.blade.php
+++ b/src/UI/resources/views/components/off-canvas.blade.php
@@ -12,9 +12,9 @@
     'togglerButton' => false,
 ])
 <div x-data="offCanvas(
-    `{{ $open }}`,
-    `{{ $async ? str_replace('&amp;', '&', $asyncUrl) : ''}}`,
-    `{{ $autoClose }}`
+    @js((string) $open),
+    @js($async ? str_replace('&amp;', '&', $asyncUrl) : ''),
+    @js((string) $autoClose)
 )"
     {{ $attributes }}
 >

--- a/src/UI/resources/views/components/popover.blade.php
+++ b/src/UI/resources/views/components/popover.blade.php
@@ -7,7 +7,7 @@
     {{ $attributes }}
     class="popover-trigger"
     title="{{ $title }}"
-    x-data="popover({placement: '{{ $placement }}'})"
+    x-data="popover({placement: @js($placement)})"
 >
     {!! $trigger !!}
     <div x-ignore class="hidden popover-body-content">{!! $slot !!}</div>

--- a/src/UI/resources/views/components/snippet.blade.php
+++ b/src/UI/resources/views/components/snippet.blade.php
@@ -13,7 +13,7 @@
     <button @click.prevent="copy()"
             class="snippet-copy"
             type="button"
-            x-data="tooltip('{{ $translates['copied'] ?? '' }}', {placement: 'top', trigger: 'click', delay: [0, 800]})"
+            x-data="tooltip(@js($translates['copied'] ?? ''), {placement: 'top', trigger: 'click', delay: [0, 800]})"
     >
         <x-moonshine::icon icon="document-duplicate" size="4" />
     </button>

--- a/src/UI/resources/views/components/table/builder.blade.php
+++ b/src/UI/resources/views/components/table/builder.blade.php
@@ -30,11 +30,11 @@
     <div
         class="js-table-builder-wrapper"
         x-data="tableBuilder(
-            {{ (int) $creatable }},
-            {{ (int) $reorderable }},
-            {{ (int) $reindex }},
-            {{ (int) $async }},
-            '{{ $asyncUrl }}'
+            @js((int) $creatable),
+            @js((int) $reorderable),
+            @js((int) $reindex),
+            @js((int) $async),
+            @js($asyncUrl)
         )"
         @defineEvent('table_empty_row_added', $name, 'add(true)')
         @defineEvent('table_reindex', $name, 'resolveReindex')

--- a/src/UI/resources/views/components/tabs.blade.php
+++ b/src/UI/resources/views/components/tabs.blade.php
@@ -8,8 +8,8 @@
     <!-- Tabs -->
     <div {{ $attributes->class(['tabs']) }}
         x-data="tabs(
-            '{{ $active ?? array_key_first($tabs) }}',
-            {{ $isVertical ? 'true' : 'false' }}
+            @js((string) ($active ?? array_key_first($tabs))),
+            @js($isVertical)
         )"
     >
         <!-- Tabs Buttons -->

--- a/src/UI/resources/views/components/thumbnails.blade.php
+++ b/src/UI/resources/views/components/thumbnails.blade.php
@@ -13,10 +13,10 @@
                  alt="{{ $value['name'] ?? $alt }}"
                  @click.stop="$dispatch('img-popup', {
                     open: true,
-                    src: '{{ $value['full_path']  }}',
-                    wide: {{ isset($value['extra']['wide']) && $value['extra']['wide'] ? 'true' : 'false'  }},
-                    auto: {{ isset($value['extra']['auto']) && $value['extra']['auto'] ? 'true' : 'false'  }},
-                    styles: '{{ $value['extra']['content_styles'] ?? ''  }}'
+                    src: @js($value['full_path']),
+                    wide: @js(isset($value['extra']['wide']) && $value['extra']['wide']),
+                    auto: @js(isset($value['extra']['auto']) && $value['extra']['auto']),
+                    styles: @js($value['extra']['content_styles'] ?? ''),
                  })"
             >
         </div>
@@ -33,10 +33,10 @@
                     alt="{{ $value['name'] ?? $alt }}"
                     @click.stop="$dispatch('img-popup', {
                         open: true,
-                        src: '{{ $value['full_path']  }}',
-                        wide: {{ isset($value['extra']['wide']) && $value['extra']['wide'] ? 'true' : 'false'  }},
-                        auto: {{ isset($value['extra']['auto']) && $value['extra']['auto'] ? 'true' : 'false'  }},
-                        styles: '{{ $value['extra']['content_styles'] ?? ''  }}'
+                        src: @js($value['full_path']),
+                        wide: @js(isset($value['extra']['wide']) && $value['extra']['wide']),
+                        auto: @js(isset($value['extra']['auto']) && $value['extra']['auto']),
+                        styles: @js($value['extra']['content_styles'] ?? ''),
                     })"
                 />
             </div>

--- a/src/UI/resources/views/components/toast.blade.php
+++ b/src/UI/resources/views/components/toast.blade.php
@@ -7,11 +7,10 @@
 
 @if($showOnCreate)
 <div x-data
-     x-init="$nextTick(() => { $dispatch('toast', {type: '{{ $type }}', text: '{{ $content }}', duration: {{ $duration ?? 'null' }}}) })"
+     x-init="$nextTick(() => { $dispatch('toast', {type: @js($type), text: @js($content), duration: @js($duration)}) })"
 ></div>
 @else
-    <div x-data="{ show(){$dispatch('toast', {type: '{{ $type }}', text: '{{ $content }}', duration: {{ $duration ?? 'null' }}})} }">
+    <div x-data="{ show(){$dispatch('toast', {type: @js($type), text: @js($content), duration: @js($duration)})} }">
         {{ $slot ?? '' }}
     </div>
 @endif
-

--- a/src/UI/resources/views/components/tooltip.blade.php
+++ b/src/UI/resources/views/components/tooltip.blade.php
@@ -3,7 +3,7 @@
     'placement' => 'right',
 ])
 <span {{ $attributes->class(['inline-block']) }}
-     x-data="tooltip(`{{ $content }}`, {placement: '{{ $placement }}'})"
+     x-data="tooltip(@js($content), {placement: @js($placement)})"
 >
     {{ $slot ?? '' }}
 </span>

--- a/src/UI/resources/views/fields/range.blade.php
+++ b/src/UI/resources/views/fields/range.blade.php
@@ -9,9 +9,11 @@
 ])
 <div
     x-data="{
-         {{ $fromColumn }}: '{{ $fromValue ?? '' }}',
-         {{ $toColumn }}: '{{ $toValue ?? '' }}'
-     }"
+        [@js($fromColumn)]: @js($fromValue ?? ''),
+        [@js($toColumn)]: @js($toValue ?? ''),
+    }"
+    data-range-from-column="{{ $fromColumn }}"
+    data-range-to-column="{{ $toColumn }}"
     {{ $attributes
         ->only('class')
         ->merge(['class' => 'form-group form-group-inline']) }}
@@ -20,15 +22,15 @@
 >
     <x-moonshine::form.input
         :attributes="$fromAttributes"
-        x-bind:max="{{ $toColumn }}"
-        x-model="{{ $fromColumn }}"
+        x-bind:max="$data[$root.dataset.rangeToColumn]"
+        x-model="$data[$root.dataset.rangeFromColumn]"
         value="{{ $fromValue ?? '' }}"
     />
 
     <x-moonshine::form.input
         :attributes="$toAttributes"
-        x-bind:min="{{ $fromColumn }}"
-        x-model="{{ $toColumn }}"
+        x-bind:min="$data[$root.dataset.rangeFromColumn]"
+        x-model="$data[$root.dataset.rangeToColumn]"
         value="{{ $toValue ?? '' }}"
     />
 </div>

--- a/src/UI/resources/views/fields/relationships/belongs-to-many.blade.php
+++ b/src/UI/resources/views/fields/relationships/belongs-to-many.blade.php
@@ -33,7 +33,7 @@
         <x-moonshine::layout.divider />
 
         @fragment($relationName)
-            <div x-data="fragment('{{ $fragmentUrl }}')"
+            <div x-data="fragment(@js($fragmentUrl))"
                  @defineEvent('fragment_updated', $relationName, 'fragmentUpdate')
             >
         @endif
@@ -62,11 +62,11 @@
                 </div>
             @else
                 @if($isAsyncSearch)
-                    <div x-data="belongsToMany">
+                    <div x-data="belongsToMany" data-async-search-url="{{ $asyncSearchUrl }}">
                         <div class="dropdown">
                             <x-moonshine::form.input
                                 x-model="query"
-                                @input.debounce="search('{{ $asyncSearchUrl }}')"
+                                @input.debounce="search($root.dataset.asyncSearchUrl)"
                                 :placeholder="$translates['search']"
                             />
                             <div class="dropdown-body mt-1" :class="{ 'pointer-events-auto visible opacity-100': query.length && match.length }">
@@ -76,7 +76,7 @@
                                             <li class="dropdown-item">
                                                 <a href="javascript:void(0);"
                                                    class="dropdown-menu-link flex gap-x-2 items-center"
-                                                   @click.prevent="select(item, {{ $isDeduplicate ? 1 : 0}})"
+                                                   @click.prevent="select(item, @js((int) $isDeduplicate))"
                                                 >
                                                     <template x-if="item?.properties?.image">
                                                         <div

--- a/src/UI/resources/views/fields/relationships/belongs-to.blade.php
+++ b/src/UI/resources/views/fields/relationships/belongs-to.blade.php
@@ -20,7 +20,7 @@
 
 @fragment($relationName)
 <div
-    x-data="fragment('{{ $fragmentUrl }}')"
+    x-data="fragment(@js($fragmentUrl))"
     @defineEvent('fragment_updated', $relationName, 'fragmentUpdate')
 >
 @endif

--- a/src/UI/resources/views/fields/relationships/morph-to.blade.php
+++ b/src/UI/resources/views/fields/relationships/morph-to.blade.php
@@ -14,7 +14,7 @@
     'settings' => [],
     'plugins' => [],
 ])
-<div x-data="{morphType: '{{ $typeValue }}'}"
+<div x-data="{morphType: @js($typeValue)}"
      class="flex items-center gap-x-2"
 >
     <div class="sm:w-1/4 w-full">

--- a/tests/Feature/ComponentsEqualsTest.php
+++ b/tests/Feature/ComponentsEqualsTest.php
@@ -145,6 +145,14 @@ describe('Layouts', function () {
 
     it('burger', function () {
         compare(Burger::make());
+
+        $html = (string) Burger::make()
+            ->customAttributes(['@click.prevent' => 'customToggle()'])
+            ->render();
+
+        expect($html)
+            ->toContain('@click.prevent="customToggle()"')
+            ->not->toContain('@click.prevent="$store.menu');
     });
 
     it('column', function () {
@@ -484,6 +492,44 @@ describe('Basic', function () {
         );
     });
 
+    it('escapes values embedded in Alpine expressions', function () {
+        $payload = "x'});alert(document.domain);//</script>";
+        $toast = Blade::render('<x-moonshine::toast :content="$content" />', ['content' => $payload]);
+        $modal = Blade::render(
+            '<x-moonshine::modal :async="true" :async-url="$url" />',
+            ['url' => $payload],
+        );
+        $offCanvas = Blade::render(
+            '<x-moonshine::off-canvas :async="true" :async-url="$url" />',
+            ['url' => $payload],
+        );
+        $wrapper = Blade::render(
+            '<x-moonshine::form.wrapper label="Label" :form-name="$name" />',
+            ['name' => $payload],
+        );
+        $html = [
+            $toast,
+            $modal,
+            $offCanvas,
+            $wrapper,
+            (string) Div::make()->xData(['value' => $payload])->render(),
+            (string) Div::make()->xDataMethod('tooltip', $payload)->render(),
+        ];
+
+        expect($toast)->toContain('x-init="$nextTick')
+            ->and($modal)->toContain('x-data="modal(')
+            ->and($offCanvas)->toContain('x-data="offCanvas(')
+            ->and($wrapper)->not->toContain('@js(');
+
+        expect($html)
+            ->each(
+                fn ($value) => $value
+                    ->not->toContain($payload)
+                    ->toContain('\\u0027')
+                    ->not->toContain('</script>')
+            );
+    });
+
     it('progress-bar', function () {
         compare(
             ProgressBar::make(80, 'sm', 'red')->radial(),
@@ -515,6 +561,16 @@ describe('Basic', function () {
             ['items' => ['Tab 1' => 'Content 1']],
         );
     })->skip('unique ids different');
+
+    it('keeps numeric tab identifiers as strings in Alpine state', function () {
+        $tabs = Tabs::make([
+            Tab::make('Tab', [FlexibleRender::make('Content')])->setId('2002'),
+        ]);
+        $html = (string) value($tabs->render(), $tabs);
+
+        expect($tabs->toArray()['active'])->toBeNull()
+            ->and($html)->toContain("            '2002',");
+    });
 
     it('thumbnails', function () {
         compare(
@@ -606,8 +662,12 @@ describe('Form', function () {
 
     it('select', function () {
         $blade = renderBlade('moonshine::form.select', ['options' => 'option 1 option 2'], attributes: ['class' => 'test-class'], slot: 'Content');
+        $custom = renderBlade('moonshine::form.select', attributes: ['x-data' => 'customSelect']);
 
-        expect($blade)->toContain('<select', 'test-class', 'option 1', 'option 2');
+        expect($blade)->toContain('<select', 'test-class', 'option 1', 'option 2')
+            ->and($custom)
+            ->toContain('x-data="customSelect"')
+            ->not->toContain('x-data="select(');
     });
 
     it('slide-range', function () {

--- a/tests/Feature/Fields/RangeFieldTest.php
+++ b/tests/Feature/Fields/RangeFieldTest.php
@@ -47,6 +47,8 @@ it('show field on pages', function () {
         ->assertSee('range')
         ->assertSee('start_point')
         ->assertSee('end_point')
+        ->assertSee('data-range-from-column="range_from_', false)
+        ->assertSee('x-model="$data[$root.dataset.rangeFromColumn]"', false)
     ;
 });
 

--- a/tests/Feature/Fields/Relationships/MorphToTest.php
+++ b/tests/Feature/Fields/Relationships/MorphToTest.php
@@ -58,6 +58,7 @@ it('show field on pages', function () {
         ->assertOk()
         ->assertSee('Imageable')
         ->assertSee($this->image->imageable->name)
+        ->assertSee("x-data=\"{morphType: 'MoonShine\\\\Tests\\\\Fixtures\\\\Models\\\\Item'}\"", false)
     ;
 });
 


### PR DESCRIPTION
## Summary\n\n- replace direct Blade interpolation in Alpine expressions with context-safe JavaScript serialization\n- preserve existing component overrides, runtime value types, and dynamic Range state keys\n- fix numeric tab IDs and the initial MorphTo async search without changing public component data\n\n## Testing\n\n- 
  [44;1m INFO [49;22m Test file "..." not found.: 200 passed, 3 skipped (576 assertions)\n- Playwright smoke test across 26 admin routes\n- verified Profile tabs, Range/DateRange bindings, and MorphTo search with the initially selected type