### PR TITLE
Fix authorization for relation read endpoints

### DIFF
--- a/src/Laravel/src/Http/Controllers/BelongsToManyPivotController.php
+++ b/src/Laravel/src/Http/Controllers/BelongsToManyPivotController.php
@@ -37,7 +37,7 @@ final class BelongsToManyPivotController extends MoonShineController
         $parent = $request->getResource()?->getItemOrInstance();
 
         /** @var null|BelongsToMany $field */
-        $field = $request->getPageField();
+        $field = $request->getPageField(BelongsToMany::class);
 
         if ($field === null) {
             throw ModelRelationFieldException::notFound();
@@ -193,7 +193,7 @@ final class BelongsToManyPivotController extends MoonShineController
         $parent = $request->getResource()?->getItemOrInstance();
 
         /** @var null|BelongsToMany $field */
-        $field = $request->getPageField();
+        $field = $request->getPageField(BelongsToMany::class);
 
         if ($field === null) {
             throw ModelRelationFieldException::notFound();
@@ -226,7 +226,7 @@ final class BelongsToManyPivotController extends MoonShineController
         $parent = $request->getResource()?->getItemOrInstance();
 
         /** @var null|BelongsToMany $field */
-        $field = $request->getPageField();
+        $field = $request->getPageField(BelongsToMany::class);
 
         if ($field === null) {
             throw ModelRelationFieldException::notFound();
@@ -259,7 +259,7 @@ final class BelongsToManyPivotController extends MoonShineController
         $parent = $request->getResource()?->getItemOrInstance();
 
         /** @var null|BelongsToMany $field */
-        $field = $request->getPageField();
+        $field = $request->getPageField(BelongsToMany::class);
 
         if ($field === null) {
             throw ModelRelationFieldException::notFound();
@@ -297,7 +297,7 @@ final class BelongsToManyPivotController extends MoonShineController
         $parentItem = $parentResource->getItemOrInstance();
 
         /** @var null|BelongsToMany $field */
-        $field = $request->getPageField();
+        $field = $request->getPageField(BelongsToMany::class);
 
         if ($field === null) {
             throw ModelRelationFieldException::notFound();

--- a/src/Laravel/src/Http/Controllers/HasManyController.php
+++ b/src/Laravel/src/Http/Controllers/HasManyController.php
@@ -35,7 +35,7 @@ final class HasManyController extends MoonShineController
         $parent = $request->getResource()?->getItemOrInstance();
 
         /** @var null|HasMany|MorphMany $field */
-        $field = $request->getPageField();
+        $field = $request->getPageField(HasMany::class);
 
         if ($field === null) {
             throw ModelRelationFieldException::notFound();
@@ -171,7 +171,7 @@ final class HasManyController extends MoonShineController
         /**
          * @var ?HasMany $field
          */
-        $field = $request->getPageField();
+        $field = $request->getPageField(HasMany::class);
 
         if ($field === null) {
             throw ModelRelationFieldException::notFound();

--- a/src/Laravel/src/Http/Requests/Relations/AsyncSearchRequest.php
+++ b/src/Laravel/src/Http/Requests/Relations/AsyncSearchRequest.php
@@ -4,45 +4,9 @@ declare(strict_types=1);
 
 namespace MoonShine\Laravel\Http\Requests\Relations;
 
-use MoonShine\Core\Exceptions\ResourceException;
-use MoonShine\Support\Enums\Ability;
-use MoonShine\Support\Enums\Action;
-use MoonShine\Support\Enums\PageType;
-use Throwable;
-
+/**
+ * @deprecated Will be removed in 5.0. Use RelationModelFieldRequest instead.
+ */
 class AsyncSearchRequest extends RelationModelFieldRequest
 {
-    /**
-     * @throws Throwable
-     */
-    public function authorize(): bool
-    {
-        $resource = $this->getResource();
-
-        if (\is_null($resource)) {
-            throw ResourceException::notDeclared();
-        }
-
-        $ability = match ($this->getPage()->getPageType()) {
-            PageType::INDEX => Ability::VIEW_ANY,
-            PageType::DETAIL => Ability::VIEW,
-            PageType::FORM => $this->route('resourceItem') === null
-                ? Ability::CREATE
-                : Ability::UPDATE,
-            default => Ability::VIEW_ANY,
-        };
-
-        $action = match ($ability) {
-            Ability::VIEW => Action::VIEW,
-            Ability::CREATE => Action::CREATE,
-            Ability::UPDATE => Action::UPDATE,
-            default => null,
-        };
-
-        if ($action !== null && ! $resource->hasAction($action)) {
-            return false;
-        }
-
-        return $resource->can($ability);
-    }
 }

--- a/src/Laravel/src/Http/Requests/Relations/RelationModelFieldRequest.php
+++ b/src/Laravel/src/Http/Requests/Relations/RelationModelFieldRequest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
 use MoonShine\Contracts\Core\CrudPageContract;
 use MoonShine\Contracts\Core\CrudResourceContract;
+use MoonShine\Contracts\UI\FieldContract;
 use MoonShine\Contracts\UI\HasFieldsContract;
 use MoonShine\Core\Exceptions\ResourceException;
 use MoonShine\Laravel\Collections\Fields;
@@ -69,11 +70,12 @@ class RelationModelFieldRequest extends FormRequest
     }
 
     /**
+     * @param class-string<ModelRelationField>|null $fieldClass
      * @throws Throwable
      */
-    public function getPageField(): ?ModelRelationField
+    public function getPageField(?string $fieldClass = null): ?ModelRelationField
     {
-        return memoize(function () {
+        return memoize(function () use ($fieldClass) {
             /**
              * @var Fields $fields
              * @phpstan-ignore-next-line
@@ -99,6 +101,7 @@ class RelationModelFieldRequest extends FormRequest
 
             return $fields
                 ->onlyFields()
+                ->filter(static fn (FieldContract $field): bool => $fieldClass === null || $field instanceof $fieldClass)
                 ->findByRelation($this->getRelationName());
         });
     }

--- a/src/Laravel/src/Http/Requests/Relations/RelationModelFieldRequest.php
+++ b/src/Laravel/src/Http/Requests/Relations/RelationModelFieldRequest.php
@@ -9,12 +9,15 @@ use Illuminate\Foundation\Http\FormRequest;
 use MoonShine\Contracts\Core\CrudPageContract;
 use MoonShine\Contracts\Core\CrudResourceContract;
 use MoonShine\Contracts\UI\HasFieldsContract;
+use MoonShine\Core\Exceptions\ResourceException;
 use MoonShine\Laravel\Collections\Fields;
 use MoonShine\Laravel\DependencyInjection\MoonShine;
 use MoonShine\Laravel\Fields\Relationships\ModelRelationField;
 use MoonShine\Laravel\Resources\ModelResource;
 use MoonShine\Laravel\Traits\Request\HasPageRequest;
 use MoonShine\Laravel\Traits\Request\HasResourceRequest;
+use MoonShine\Support\Enums\Ability;
+use MoonShine\Support\Enums\Action;
 use MoonShine\Support\Enums\PageType;
 use MoonShine\UI\Exceptions\FieldException;
 use Throwable;
@@ -25,6 +28,40 @@ class RelationModelFieldRequest extends FormRequest
     use HasResourceRequest;
     /** @use HasPageRequest<CrudPageContract<ModelResource, MoonShine, Fields>> */
     use HasPageRequest;
+
+    /**
+     * @throws Throwable
+     */
+    public function authorize(): bool
+    {
+        $resource = $this->getResource();
+
+        if (\is_null($resource)) {
+            throw ResourceException::notDeclared();
+        }
+
+        $ability = match ($this->getPage()->getPageType()) {
+            PageType::INDEX => Ability::VIEW_ANY,
+            PageType::DETAIL => Ability::VIEW,
+            PageType::FORM => $this->route('resourceItem') === null
+                ? Ability::CREATE
+                : Ability::UPDATE,
+            default => Ability::VIEW_ANY,
+        };
+
+        $action = match ($ability) {
+            Ability::VIEW => Action::VIEW,
+            Ability::CREATE => Action::CREATE,
+            Ability::UPDATE => Action::UPDATE,
+            default => null,
+        };
+
+        if ($action !== null && ! $resource->hasAction($action)) {
+            return false;
+        }
+
+        return $resource->can($ability);
+    }
 
     public function getRelationName(): string
     {

--- a/tests/Feature/Controllers/HasManyControllerTest.php
+++ b/tests/Feature/Controllers/HasManyControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use MoonShine\Contracts\Core\DependencyInjection\CoreContract;
 use MoonShine\Laravel\Fields\Relationships\BelongsToMany;
 use MoonShine\Laravel\Fields\Relationships\HasMany;
+use MoonShine\Laravel\Fields\Relationships\RelationRepeater;
 use MoonShine\Laravel\Models\MoonshineUser;
 use MoonShine\Support\Enums\PageType;
 use MoonShine\Tests\Fixtures\Models\Category;
@@ -124,6 +125,26 @@ it('get form component', function () {
         ->assertOk()
         ->assertSee('form')
     ;
+});
+
+it('uses has many field when a relation repeater has the same relation', function (): void {
+    $item = createItem(countComments: 1);
+
+    $resource = TestResourceBuilder::new(Item::class)
+        ->setTestFields([
+            RelationRepeater::make('Comments', 'comments', resource: TestCommentResource::class),
+            HasMany::make('Comments List', 'comments', resource: TestCommentResource::class)
+                ->creatable(),
+        ]);
+
+    asAdmin()->get($this->moonshineCore->getRouter()->to('has-many.form', [
+        'pageUri' => PageType::FORM->value,
+        'resourceUri' => $resource->getUriKey(),
+        'resourceItem' => $item->getKey(),
+        '_relation' => 'comments',
+    ]))
+        ->assertOk()
+        ->assertSee('form');
 });
 
 it('forbids relation data when update policy denies access to the parent resource', function (): void {

--- a/tests/Feature/Controllers/HasManyControllerTest.php
+++ b/tests/Feature/Controllers/HasManyControllerTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 use MoonShine\Contracts\Core\DependencyInjection\CoreContract;
 use MoonShine\Laravel\Fields\Relationships\BelongsToMany;
 use MoonShine\Laravel\Fields\Relationships\HasMany;
+use MoonShine\Laravel\Models\MoonshineUser;
 use MoonShine\Support\Enums\PageType;
 use MoonShine\Tests\Fixtures\Models\Category;
 use MoonShine\Tests\Fixtures\Models\Item;
 use MoonShine\Tests\Fixtures\Resources\TestCategoryResource;
+use MoonShine\Tests\Fixtures\Resources\TestCommentResource;
 use MoonShine\Tests\Fixtures\Resources\TestItemResource;
 use MoonShine\Tests\Fixtures\Resources\TestResource;
+use MoonShine\Tests\Fixtures\Resources\TestResourceBuilder;
 use MoonShine\UI\Fields\ID;
 use MoonShine\UI\Fields\Text;
 
@@ -121,6 +124,29 @@ it('get form component', function () {
         ->assertOk()
         ->assertSee('form')
     ;
+});
+
+it('forbids relation data when update policy denies access to the parent resource', function (): void {
+    $item = createItem(countComments: 1);
+
+    $resource = TestResourceBuilder::new(Item::class)
+        ->setTestFields([
+            ID::make(),
+            HasMany::make('Comments', resource: TestCommentResource::class),
+        ])
+        ->setTestPolicy(true);
+
+    MoonshineUser::query()->whereKey(1)->update([
+        'name' => 'Policies test',
+    ]);
+
+    asAdmin()->get($this->moonshineCore->getRouter()->to('has-many.list', [
+        'pageUri' => PageType::FORM->value,
+        'resourceUri' => $resource->getUriKey(),
+        'resourceItem' => $item->getKey(),
+        '_relation' => 'comments',
+    ]))
+        ->assertForbidden();
 });
 
 it('uses related resource context for nested relation fields in form component', function (): void {


### PR DESCRIPTION
## Summary

- enforce parent resource authorization for relation requests based on the active page context
- reuse the shared authorization logic for async search requests
- deprecate the now-empty `AsyncSearchRequest` compatibility alias ahead of 5.0
- resolve duplicate relation names by selecting the field type handled by each relation endpoint
- add regression coverage for denied parent access and duplicate relation fields

## Tests

- `composer test:all`
- 757 passed (2,124 assertions), 4 skipped, 1 todo
- Rector, PHP CS Fixer, and all PHPStan package checks passed
