### PR TITLE
Restrict inline field updates to preview-enabled fields

### DIFF
--- a/src/Laravel/src/Http/Controllers/UpdateFieldController.php
+++ b/src/Laravel/src/Http/Controllers/UpdateFieldController.php
@@ -14,6 +14,7 @@ use MoonShine\Laravel\Collections\Fields;
 use MoonShine\Laravel\Exceptions\ModelRelationFieldException;
 use MoonShine\Laravel\Http\Requests\Relations\RelationModelColumnUpdateRequest;
 use MoonShine\Laravel\Http\Requests\Resources\UpdateColumnFormRequest;
+use MoonShine\UI\Contracts\HasUpdateOnPreviewContract;
 use Throwable;
 
 class UpdateFieldController extends MoonShineController
@@ -55,6 +56,11 @@ class UpdateFieldController extends MoonShineController
 
     private function save(CrudResource $resource, FieldContract $field)
     {
+        abort_unless(
+            $field instanceof HasUpdateOnPreviewContract && $field->isUpdateOnPreview(),
+            403
+        );
+
         try {
             $resource->save(
                 $resource->getCaster()->cast(

--- a/tests/Feature/Controllers/UpdateFieldControllerTest.php
+++ b/tests/Feature/Controllers/UpdateFieldControllerTest.php
@@ -16,7 +16,9 @@ beforeEach(function () {
     $this->user = MoonshineUser::query()->find(1);
 });
 
-it('update through column', function () {
+it('does not update through column without update on preview', function () {
+    $name = $this->user->name;
+
     asAdmin()->put(
         $this->moonshineCore->getRouter()->to('update-field.through-column', [
             'resourceItem' => $this->user->getKey(),
@@ -24,12 +26,12 @@ it('update through column', function () {
             'field' => 'name',
             'value' => 'New name',
         ])
-    )->assertStatus(204);
+    )->assertForbidden();
 
     $this->user->refresh();
 
     expect($this->user->name)
-        ->toBe('New name')
+        ->toBe($name)
     ;
 });
 


### PR DESCRIPTION
## What was changed

Added a shared guard for column and relation field updates so only fields with updateOnPreview enabled can be saved through the inline update endpoint.

Updated the controller test to verify that a regular index field returns 403 and remains unchanged.

## Why?

The inline update endpoint should follow the field configuration used to enable preview editing.

## Checklist

- Tested
    - [x] Tests added
    - [x] PHPStan
- Documentation not needed