### PR TITLE
Fix enum labels in async relationship search

### DIFF
--- a/src/Laravel/src/Traits/Fields/WithAsyncSearch.php
+++ b/src/Laravel/src/Traits/Fields/WithAsyncSearch.php
@@ -14,6 +14,7 @@ use MoonShine\Contracts\UI\FieldContract;
 use MoonShine\Laravel\Http\Requests\Relations\RelationModelFieldRequest;
 use MoonShine\Support\DTOs\Select\Option;
 use MoonShine\Support\DTOs\Select\OptionProperty;
+use MoonShine\Support\EnumToString;
 
 trait WithAsyncSearch
 {
@@ -160,10 +161,12 @@ trait WithAsyncSearch
 
         $searchColumn ??= '';
 
+        $label = \is_null($this->getAsyncSearchValueCallback())
+            ? data_get($model, $searchColumn, '')
+            : \call_user_func($this->getAsyncSearchValueCallback(), $model, $this);
+
         return new Option(
-            label: \is_null($this->getAsyncSearchValueCallback())
-                ? (string) data_get($model, $searchColumn, '')
-                : (string) \call_user_func($this->getAsyncSearchValueCallback(), $model, $this),
+            label: (string) (new EnumToString($label))->convert(),
             value: (string)$model->getKey(),
             properties: new OptionProperty($this->getImageUrl($model)),
         );

--- a/tests/Feature/Fields/Relationships/EnumLabelsTest.php
+++ b/tests/Feature/Fields/Relationships/EnumLabelsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use MoonShine\Laravel\Fields\Relationships\BelongsTo;
+use MoonShine\Tests\Fixtures\Enums\TestEnumBreadcrumbLabel;
+use MoonShine\Tests\Fixtures\Enums\TestEnumColor;
+use MoonShine\Tests\Fixtures\Resources\TestCommentResource;
+use MoonShine\Tests\Fixtures\Resources\TestItemResource;
+
+uses()->group('model-relation-fields');
+
+it('renders enum labels in relationship options', function (string $enumClass, string $raw, string $label) {
+    $item = createItem(countComments: 1);
+    $item->update(['name' => $raw]);
+    $item->mergeCasts(['name' => $enumClass]);
+    $comment = $item->comments->first()->setRelation('item', $item);
+
+    $field = BelongsTo::make('Item', 'item', resource: TestItemResource::class)
+        ->nowOn(page: app(TestCommentResource::class)->getFormPage(), resource: app(TestCommentResource::class))
+        ->valuesQuery(fn ($query) => $query->whereKey($item->getKey())->withCasts(['name' => $enumClass]))
+        ->fillData($comment);
+
+    expect($field->getValues()->getValues()->first()->getLabel())->toBe($label)
+        ->and((string) $field->render())->toContain($label);
+})->with([
+    'backed enum' => [TestEnumColor::class, 'R', 'R'],
+    'custom label' => [TestEnumBreadcrumbLabel::class, 'blue', 'Blue label'],
+]);
+
+it('renders enum labels in async relationship search', function (bool $formatted, string $enumClass, string $raw, string $label) {
+    $item = createItem(countComments: 0);
+    $item->update(['name' => $raw]);
+    $item->mergeCasts(['name' => $enumClass]);
+
+    $field = BelongsTo::make('Item', 'item', resource: TestItemResource::class)->asyncSearch(
+        'name',
+        formatted: $formatted ? fn ($model) => $model->name : null,
+    );
+
+    expect($field->getAsyncSearchOption($item)->getLabel())->toBe($label);
+})->with(['column' => false, 'callback' => true])->with([
+    'backed enum' => [TestEnumColor::class, 'R', 'R'],
+    'custom label' => [TestEnumBreadcrumbLabel::class, 'blue', 'Blue label'],
+]);
+
+it('renders enum labels in relationship previews', function (string $enumClass, string $raw, string $label) {
+    $item = createItem(countComments: 1);
+    $item->update(['name' => $raw]);
+    $item->mergeCasts(['name' => $enumClass]);
+    $comment = $item->comments->first()->setRelation('item', $item);
+
+    $field = BelongsTo::make('Item', 'item', resource: TestItemResource::class)
+        ->nowOn(page: app(TestCommentResource::class)->getIndexPage(), resource: app(TestCommentResource::class))
+        ->fillData($comment);
+
+    expect((string) $field->preview())->toContain($label);
+})->with([
+    'backed enum' => [TestEnumColor::class, 'R', 'R'],
+    'custom label' => [TestEnumBreadcrumbLabel::class, 'blue', 'Blue label'],
+]);

--- a/tests/Fixtures/Enums/TestEnumBreadcrumbLabel.php
+++ b/tests/Fixtures/Enums/TestEnumBreadcrumbLabel.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\Tests\Fixtures\Enums;
+
+enum TestEnumBreadcrumbLabel: string
+{
+    case Blue = 'blue';
+
+    public function toString(): string
+    {
+        return 'Blue label';
+    }
+}

--- a/tests/Unit/Pages/PageBreadcrumbsTest.php
+++ b/tests/Unit/Pages/PageBreadcrumbsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use MoonShine\Tests\Fixtures\Enums\TestEnumBreadcrumbLabel;
+use MoonShine\Tests\Fixtures\Enums\TestEnumColor;
+use MoonShine\Tests\Fixtures\Models\Item;
+use MoonShine\Tests\Fixtures\Resources\TestItemResource;
+use MoonShine\UI\Components\Breadcrumbs;
+
+uses()->group('pages');
+
+it('renders the resource column in page breadcrumbs', function (
+    string $pageMethod,
+    string|int|null $value,
+    ?string $enumClass,
+    string $expected,
+) {
+    $item = new Item();
+
+    if ($enumClass !== null) {
+        $item->mergeCasts(['name' => $enumClass]);
+    }
+
+    $item->setRawAttributes(['id' => 1, 'name' => $value]);
+
+    $resource = app(TestItemResource::class)->setItem($item)->setItemID(1);
+    $page = $resource->{$pageMethod}();
+    $breadcrumbs = $page->getBreadcrumbs();
+
+    $html = (string) Breadcrumbs::make($breadcrumbs)->render();
+
+    expect(preg_replace('/\s+/', ' ', trim(strip_tags($html))))->toBe(trim('Items ' . $expected));
+})->with([
+    'form page' => 'getFormPage',
+    'detail page' => 'getDetailPage',
+])->with([
+    'backed enum' => ['R', TestEnumColor::class, 'R'],
+    'enum with toString' => ['blue', TestEnumBreadcrumbLabel::class, 'Blue label'],
+    'string' => ['Article title', null, 'Article title'],
+    'zero' => [0, null, '0'],
+    'null' => [null, null, ''],
+]);


### PR DESCRIPTION
## What was changed

Convert enum labels through the existing `EnumToString` helper before building async relationship search options. This supports both enum-cast model columns and formatting callbacks, including custom enum `toString()` labels, while preserving ordinary string conversion.

## Why?

On `4.x`, async relationship search directly casts its display value to a string and throws when that value is an enum. Four regression cases reproduced this failure before the fix.

Breadcrumbs, regular relationship options and relationship previews already handle these enums on `4.x`. Their behavior is covered by additional regression tests and their implementation is unchanged. This is a focused backport; it does not include the PHPStan or API changes from `5.x`.

## Validation

- Full suite on PHP 8.4.21 / Laravel 13.30.1 / MySQL: 784 tests passed, 2,194 assertions; one existing todo and four skipped tests.
- All 18 new regression scenarios pass, including default/custom enum labels, column/callback async search and form/detail breadcrumb rendering.
- Laravel package PHPStan passes at the existing level 5.
- PHP CS Fixer and `git diff --check` pass.

## Checklist

- [x] Regression tests added and failures demonstrated before the fix
- [x] Existing tests left unchanged
